### PR TITLE
can't delete file from rutime default overlay

### DIFF
--- a/internal/app/wwctl/overlay/delete/main.go
+++ b/internal/app/wwctl/overlay/delete/main.go
@@ -21,7 +21,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	overlayName := args[1]
 
 	if len(args) == 3 {
-		fileName = args[2]
+        fileName := args[2]
 	}
 
 	if overlayKind != "system" && overlayKind != "runtime" {


### PR DESCRIPTION
`wwctl overlay delete` can't delete file from rutime default overlay,
due to the third argument not properly set to `fileName`.

https://github.com/hpcng/warewulf/issues/190#issue-1038040212