### PR TITLE
render template files several times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added experimental dnsmasq support.
 - Check for formal correct IP and MAC addresses for command line options and
   when reading in the configurations
-
+- render template several (up to 8 times) if template refrences like '{{ foo }}' are
+  found in a rendered template. This make it possible to use e.g. the ip address of
+  the warewulf master in the kernel command line.
 ## [4.4.0] 2023-01-18
 
 ### Added


### PR DESCRIPTION
This makes it possible to use something like {{ .IPAddress }} in variables,
so that e.g. the kernel commandline parameter can contain a reference to 
the ip address of the warewulf master host

