### PR TITLE
download rendered overlays via http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix issue that initrd fails at downloading runtime overlay with permission denied error,
   when warewulf secure option in warewulf.conf is enabled. #806
 - Allow iPXE to continue booting without runtime overlay. #806
+- Block unprivileged requests for arbitrary overlays in secure mode.
+- new subcommand `wwctl genconf` is available with following subcommands:
+  * `completions` which will create the files used for bash-completion. Also
+     fish an zsh completions can be generated
+  * `defaults` which will generate a valid `defaults.conf`
+  * `man` which will generate the man pages in the specified directory
+  * `reference` which will generate a reference documentation for the wwctl commands
+  * `warwulfconf print` which will print the used `warewulf.conf`. If there is no valid
+     `warewulf.conf` a valid configuration is provided, prefilled with default values
+     and an IP configuration derived from the network configuration of the host
+- All paths can now be configured in `warewulf.conf`, check the paths section of of 
+   `wwctl --emptyconf genconfig warewulfconf print` for the available paths.
+- Added experimental dnsmasq support.
+- Check for formal correct IP and MAC addresses for command line options and
+  when reading in the configurations
+- Added the possibility to retrieve files and templates from the overlay directory
+  `wwroot` which has the following syntax http://$IP:$PORT/overlays/overlay.ww?node=$nodename and 
+  plain files with http://$IP:$PORT/overlays/foo.iso
 
 ## v4.5.8, 2024-10-01
 

--- a/internal/pkg/oci/defaults.go
+++ b/internal/pkg/oci/defaults.go
@@ -12,3 +12,5 @@ const (
 	blobPrefix   = "blobs"
 	rootfsPrefix = "rootfs"
 )
+
+func Parsdasad

--- a/internal/pkg/oci/defaults.go
+++ b/internal/pkg/oci/defaults.go
@@ -12,5 +12,3 @@ const (
 	blobPrefix   = "blobs"
 	rootfsPrefix = "rootfs"
 )
-
-func Parsdasad

--- a/internal/pkg/warewulfd/overlay.go
+++ b/internal/pkg/warewulfd/overlay.go
@@ -1,0 +1,109 @@
+package warewulfd
+
+import (
+	"net/http"
+	"os"
+	"path"
+	"strconv"
+
+	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
+	"github.com/warewulf/warewulf/internal/pkg/node"
+	"github.com/warewulf/warewulf/internal/pkg/overlay"
+	"github.com/warewulf/warewulf/internal/pkg/util"
+	"github.com/warewulf/warewulf/internal/pkg/wwlog"
+)
+
+func OverlaySend(w http.ResponseWriter, req *http.Request) {
+	conf := warewulfconf.Get()
+	overlaySourceDir := overlay.OverlaySourceDir("wwroot")
+	if !util.IsDir(overlaySourceDir) {
+		wwlog.Error("Overlay source dir wwroot doesn't exist")
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	rinfo, err := parseReqRender(req)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		wwlog.ErrorExc(err, "got error: %w")
+		return
+	}
+
+	wwlog.Info("recv: render req node: %s, overlay: %s", rinfo.node, rinfo.overlay)
+	if conf.Warewulf.Secure() {
+		if rinfo.remoteport >= 1024 {
+			wwlog.Denied("Non-privileged port: %s", req.RemoteAddr)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+	}
+	overlayFile := path.Join(overlaySourceDir, rinfo.overlay)
+	if !path.IsAbs(overlayFile) {
+		wwlog.Denied("Path %s isn't absolute", overlayFile)
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	nodeName := rinfo.node
+	if nodeName != "" {
+		nodeDB, err := node.New()
+		if err != nil {
+			wwlog.ErrorExc(err, "error when opening node database")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		node, err := nodeDB.GetNode(nodeName)
+		if err != nil {
+			wwlog.Warn("Unknown node %s from: %s", nodeName, req.RemoteAddr)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if !util.IsFile(overlayFile) {
+			overlayFile += ".ww"
+			wwlog.Debug("trying to use .ww for file: %s", overlayFile)
+		}
+		if !util.IsFile(overlayFile) {
+			wwlog.Denied("file doesn't exists: %s", overlayFile)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		tstruct, err := overlay.InitStruct(node)
+		if err != nil {
+			wwlog.ErrorExc(err, "error when initializing template data")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		tstruct.BuildSource = overlayFile
+		buffer, _, _, err := overlay.RenderTemplateFile(overlayFile, tstruct)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			wwlog.ErrorExc(err, "")
+			return
+		}
+		w.Header().Set("Content-Type", "text")
+		w.Header().Set("Content-Length", strconv.Itoa(buffer.Len()))
+		_, err = buffer.WriteTo(w)
+		if err != nil {
+			wwlog.ErrorExc(err, "")
+		}
+		wwlog.Info("%15s: %s", node.Id(), overlayFile)
+	} else {
+		if !util.IsFile(overlayFile) {
+			wwlog.Denied("file doesn't exists: %s", overlayFile)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		fileBytes, err := os.ReadFile(overlayFile)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			wwlog.ErrorExc(err, "")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, err = w.Write(fileBytes)
+		if err != nil {
+			wwlog.ErrorExc(err, "")
+		}
+		wwlog.Info("send overlay for node %s: %s", nodeName, overlayFile)
+
+	}
+}

--- a/internal/pkg/warewulfd/overlay_test.go
+++ b/internal/pkg/warewulfd/overlay_test.go
@@ -1,0 +1,71 @@
+package warewulfd
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
+	"github.com/warewulf/warewulf/internal/pkg/testenv"
+	"github.com/warewulf/warewulf/internal/pkg/wwlog"
+)
+
+var overlaySendTests = []struct {
+	description string
+	url         string
+	body        string
+	status      int
+	ip          string
+}{
+	{"testfile should exist", "/test.template", "test", 200, "10.10.10.10:9873"},
+	{"testfile shouldn't exist", "/fake.template", "", 404, "10.10.10.10:9873"},
+	{"testfile.ww should exist and be rendered", "/test.template.ww?node=n1", "n1", 200, "10.10.10.10:9873"},
+	{"testfile.ww should exist node not found", "/test.template.ww?node=n2", "", 404, "10.10.10.10:9873"},
+	{"testfile.ww should exist even it isn't rendered", "/test.template?node=n1", "test", 200, "10.10.10.10:9873"},
+	{"testfile.ww should not exist", "/test2.template.ww?node=n1", "", 404, "10.10.10.10:9873"},
+	{"testfile.ww should exist in subdir and be rendered", "/dir1/test2.template.ww?node=n1", "n1", 200, "10.10.10.10:9873"},
+}
+
+func Test_OverlaySend(t *testing.T) {
+	env := testenv.New(t)
+
+	env.WriteFile(t, "etc/warewulf/nodes.conf", `nodeprofiles:
+  default: {}
+nodes:
+  n1: {}
+`)
+	conf := warewulfconf.Get()
+	assert.NoError(t, os.MkdirAll(path.Join(conf.Paths.WWOverlaydir, "wwroot/dir1"), 0700))
+	assert.NoError(t, os.WriteFile(path.Join(conf.Paths.WWOverlaydir, "/wwroot", "test.template"), []byte("test"), 0600))
+	assert.NoError(t, os.WriteFile(path.Join(conf.Paths.WWOverlaydir, "/wwroot", "test.template.ww"), []byte("{{.Id}}"), 0600))
+	assert.NoError(t, os.WriteFile(path.Join(conf.Paths.WWOverlaydir, "/wwroot/dir1", "test2.template.ww"), []byte("{{.Id}}"), 0600))
+
+	dbErr := LoadNodeDB()
+	assert.NoError(t, dbErr)
+
+	secureFalse := false
+	conf.Warewulf.SecureP = &secureFalse
+	wwlog.SetLogLevel(wwlog.DEBUG)
+	for _, tt := range overlaySendTests {
+		t.Run(tt.description, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			req.RemoteAddr = tt.ip
+			w := httptest.NewRecorder()
+			OverlaySend(w, req)
+			res := w.Result()
+			defer res.Body.Close()
+
+			data, readErr := io.ReadAll(res.Body)
+			assert.NoError(t, readErr)
+			if tt.body != "" {
+				assert.Equal(t, tt.body, string(data))
+			}
+			assert.Equal(t, tt.status, res.StatusCode)
+		})
+	}
+}

--- a/internal/pkg/warewulfd/parser.go
+++ b/internal/pkg/warewulfd/parser.go
@@ -104,7 +104,6 @@ func parseReq(req *http.Request) (parserInfo, error) {
 			return ret, errors.New("no hwaddr encoded in GET")
 		}
 	}
-	
 
 	return ret, nil
 }

--- a/internal/pkg/warewulfd/provision.go
+++ b/internal/pkg/warewulfd/provision.go
@@ -276,7 +276,7 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 				wwlog.ErrorExc(err, "")
 			}
 
-			wwlog.Info("send %s -> %s", stage_file, remoteNode.Id())
+			wwlog.Info("send %s -> %s '%v' '%v'", stage_file, remoteNode.Id(), remoteNode.Tags, tmpl_data.Tags)
 
 		} else {
 			if rinfo.compress == "gz" {

--- a/internal/pkg/warewulfd/provision_test.go
+++ b/internal/pkg/warewulfd/provision_test.go
@@ -24,7 +24,7 @@ var provisionSendTests = []struct {
 }{
 	{"system overlay", "/overlay-system/00:00:00:ff:ff:ff", "system overlay", 200, "10.10.10.10:9873"},
 	{"runtime overlay", "/overlay-runtime/00:00:00:ff:ff:ff", "runtime overlay", 200, "10.10.10.10:9873"},
-	{"fake overlay", "/overlay-system/00:00:00:ff:ff:ff?overlay=fake", "", 404, "10.10.10.10:9873:9873"},
+	{"fake overlay", "/overlay-system/00:00:00:ff:ff:ff?overlay=fake", "", 400, "10.10.10.10:9873:9873"},
 	{"specific overlay", "/overlay-system/00:00:00:ff:ff:ff?overlay=o1", "specific overlay", 200, "10.10.10.10:9873"},
 	{"find shim", "/efiboot/shim.efi", "", 200, "10.10.10.10:9873"},
 	{"find shim", "/efiboot/shim.efi", "", 404, "10.10.10.11:9873"},

--- a/internal/pkg/warewulfd/warewulfd.go
+++ b/internal/pkg/warewulfd/warewulfd.go
@@ -74,6 +74,7 @@ func RunServer() error {
 	wwHandler.HandleFunc("/container/", ProvisionSend)
 	wwHandler.HandleFunc("/overlay-system/", ProvisionSend)
 	wwHandler.HandleFunc("/overlay-runtime/", ProvisionSend)
+	wwHandler.HandleFunc("/overlay/", OverlaySend)
 	wwHandler.HandleFunc("/status", StatusSend)
 
 	conf := warewulfconf.Get()

--- a/overlays/wwwroot/ignition.json.ww
+++ b/overlays/wwwroot/ignition.json.ww
@@ -1,0 +1,1 @@
+{{ IgnitionJson }}


### PR DESCRIPTION
Adds a simple http server on the warewulf port which is rooted at
the $OVERLAYIDR/wwroot/. Files with the .ww suffix are rendered as 
templates where the node can be set via the 
`http://${wwinit_ip}:${wwinit_port}/overlay/test?node=$NODE` 
url.
