### PR TITLE
Init rootfs fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Return an error during `wwctl container import` if archive filename includes a colon. #1371
 - Correctly extract smbios asset key during Grub boot. #1291
+- Refactor of `wwinit/init` to more properly address rootfs options. #1098
 
 ## v4.5.7, 2024-09-11
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -38,3 +38,4 @@
 * Tobias Poschwatta <poschwatta@zib.de>
 * Josh Burks <jeburks2@asu.edu>
 * Elmar Pruesse <pruessee@njhealth.org> @epruesse
+* Adam Michel <elfurbe@furbism.com> [@elfurbe](https://github.com/elfurbe)

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -47,7 +47,7 @@ if [ "${WWROOT}" != "${ROOTFSTYPE}" ]; then
         echo "Unrecognized rootfs type requested: ${WWROOT}"
         echo "Rebooting in 1 minute..."
         sleep 60
-        /sbin/reboot
+        /sbin/reboot -f
     fi
 else
     echo "Invoking /warewulf/wwinit..."
@@ -57,4 +57,4 @@ fi
 echo
 echo "There was a problem with the initial provisioning process, rebooting in 1 minute..."
 sleep 60
-echo b > /proc/sysrq-trigger || /sbin/reboot
+echo b > /proc/sysrq-trigger || /sbin/reboot -f

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -43,7 +43,7 @@ if [ -n "${WWROOT}" ] && [ "${WWROOT}" != "${ROOTFSTYPE}" ]; then
     elif [ "${WWROOT}" == "initramfs" ]; then
         echo ">>> Deprecated option \"initramfs\" chosen."
         echo ">>> The 'initramfs' can be either a ramfs or a tmpfs natively, depending on kernel configuration."
-        echo ">>> If you wish to use whatever this kernel chooses by default, remove this 'root' setting from your nodes/profiles."
+        echo ">>> If you wish to use whatever this kernel chooses by default, remove the 'root' setting from your nodes/profiles."
         echo "Invoking /warewulf/wwinit..."
         exec /warewulf/wwinit
     else

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -41,6 +41,9 @@ if [ "${WWROOT}" != "${ROOTFSTYPE}" ]; then
         echo "Switching to new rootfs and invoking /warewulf/wwinit..."
         exec /sbin/switch_root /newroot /warewulf/wwinit
     elif [ "${WWROOT}" == "initramfs" ]; then
+        echo ">>> Deprecated option \"initramfs\" chosen."
+        echo ">>> The 'initramfs' can be either a ramfs or a tmpfs natively, depending on kernel configuration."
+        echo ">>> If you wish to use whatever this kernel chooses by default, remove this 'root' setting from your nodes/profiles."
         echo "Invoking /warewulf/wwinit..."
         exec /warewulf/wwinit
     else

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -6,7 +6,7 @@
 # Edit at your own risk! DANGER DANGER.
 
 
-if test -f "/warewulf/config"; then
+if [ -f "/warewulf/config" ]; then
     . /warewulf/config
 else
     echo "ERROR: Warewulf configuration file not found... rebooting in 1 minute"

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -31,7 +31,7 @@ ROOTFSTYPE=`stat -f -c "%T" /`
 echo "${ROOTFSTYPE}"
 
 
-if [ "${WWROOT}" != "${ROOTFSTYPE}" ]; then
+if [ -n "${WWROOT}" ] && [ "${WWROOT}" != "${ROOTFSTYPE}" ]; then
     echo "Requested rootfs type does not match current rootfs type. Pivoting to new rootfs..."
     if [ "${WWROOT}" == "ramfs" ] || [ "${WWROOT}" == "tmpfs" ]; then
         mkdir /newroot

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -14,7 +14,7 @@ else
     echo b > /proc/sysrq-trigger || /sbin/reboot
 fi
 
-echo "Warewulf v4 is now booting: $WWHOSTNAME"
+echo "Warewulf v4 is now booting: ${WWHOSTNAME}"
 echo
 
 echo "Mounting up kernel file systems"
@@ -30,28 +30,31 @@ echo -n "Checking Rootfs type..."
 ROOTFSTYPE=`stat -f -c "%T" /`
 echo "${ROOTFSTYPE}"
 
-if test "$WWROOT" = "initramfs"; then
-    echo "Provisioned to default initramfs file system: $ROOTFSTYPE"
-    echo "Calling WW Init"
-    exec /warewulf/wwinit
-elif test "$WWROOT" = "tmpfs"; then
-    if test "$ROOTFSTYPE" = "tmpfs"; then
-        echo "ERROR: Switching the root file system requires the kernel argument: 'rootfstype=ramfs'"
-    else
-        echo "Setting up tmpfs root file system"
+
+if [ "${WWROOT}" != "${ROOTFSTYPE}" ]; then
+    echo "Requested rootfs type does not match current rootfs type. Pivoting to new rootfs..."
+    if [ "${WWROOT}" == "ramfs" ] || [ "${WWROOT}" == "tmpfs" ]; then
         mkdir /newroot
-        mount wwroot /newroot -t tmpfs -o mpol=interleave
-        echo "Moving RAMFS to TMPFS"
-        tar -cf - --exclude ./proc --exclude ./sys --exclude ./dev --exclude ./newroot . | tar -xf - -C /newroot
+        mount wwroot /newroot -t ${WWROOT} -o mpol=interleave
+        tar cf - --exclude ./proc --exclude ./sys --exclude ./dev --exclude ./run --exclude ./newroot . | tar xf - -C /newroot
         mkdir /newroot/proc /newroot/dev /newroot/sys /newroot/run 2>/dev/null
-        echo "Calling switch_root and invoking WW Init"
+        echo "Switching to new rootfs and invoking /warewulf/wwinit..."
         exec /sbin/switch_root /newroot /warewulf/wwinit
+    elif [ "${WWROOT}" == "initramfs" ]; then
+        echo "Invoking /warewulf/wwinit..."
+        exec /warewulf/wwinit
+    else
+        echo "Unrecognized rootfs type requested: ${WWROOT}"
+        echo "Rebooting in 1 minute..."
+        sleep 60
+        /sbin/reboot
     fi
 else
-    echo "ERROR: Unknown Warewulf Root file system: $WWROOT"
+    echo "Invoking /warewulf/wwinit..."
+    exec /warewulf/wwinit
 fi
 
 echo
-echo "There was a problem with the provisioning process, rebooting in 1 minute..."
+echo "There was a problem with the initial provisioning process, rebooting in 1 minute..."
 sleep 60
 echo b > /proc/sysrq-trigger || /sbin/reboot

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -26,8 +26,9 @@ mount -t tmpfs tmpfs /run
 
 chmod 755 /warewulf/wwinit
 
-echo "Checking Rootfs type"
+echo -n "Checking Rootfs type..."
 ROOTFSTYPE=`stat -f -c "%T" /`
+echo "${ROOTFSTYPE}"
 
 if test "$WWROOT" = "initramfs"; then
     echo "Provisioned to default initramfs file system: $ROOTFSTYPE"


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR refactors `/init` in the wwinit overlay to more properly address the rootfs option.

After a discussion with @anderbubble about tmpfs vs ramfs vs rootfs, and some light reading about [how the kernel deals with the initramfs](https://www.kernel.org/doc/html/latest/filesystems/ramfs-rootfs-initramfs.html#what-is-rootfs), and poking around in the provisioning environment with a Rocky 8 kernel (4.18.0-425.19.2.el8_7.x86_64), it is apparently true that if a kernel is configured with `CONFIG_TMPFS=y` then it will default to establishing the initial rootfs as a tmpfs implicitly. This makes the default value of `initramfs` for  the `root` property for nodes/profiles a non sequitur, as `initramfs` no longer appears to me to have any intrinsic meaning. This refactoring attempts to address that reality.

For the purposes of this implementation, I've assumed if the `root` property is set to `initramfs`, the implication is the user is indifferent and wants to use whatever the kernel chooses, or has ensured their rootfs is what they want through other means outside the scope of warewulf. I've also accounted for what seems to me to be the logical future wherein the default value of the `root` parameter would be unset, and added a catch condition that outputs messages informing the user that the `initramfs` option is deprecated and to unset the option if their intent is to trust what the kernel provides, but init still proceeds with a normal non-pivoting chain to `/warewulf/wwinit` thus remaining functionally transparent in the interim. This work only accounts for `tmpfs` and `ramfs` as possible options for the `root` property, and abuses that fact to provide the fstype option to mount using the derived $WWROOT value in `/warewulf/config`. This seemed reasonably sane to me, as there does not seem to be any practical value today to having abstracted/arbitrary values de-reference to actual filesystem types. Obviously this logic is not complicated, so that could be addressed sensibly at a later date when something like stateful provisioning may require it.

It is worth noting that if this PR is accepted the way I've written it, there would be a recommended corresponding change in the Go codebase that generates the `defaults.conf` configuration file to remove the default value for the `root` property. I am not a go programmer, so I am not undertaking to make that change, but it does appear to me from casual reading to be reasonably trivial.

It is also worth noting that these changes remove the informational message about the kernel parameter `rootfstype=ramfs` as it does not seem to be necessary if you're committed to doing the mirroring operation from the default rootfs to a new rootfs on your explicitly provided fstype. From my testing, that kernel parameter can be used to influence the default fstype used by the kernel, and if you wanted to _not_ deal with these two different ram-based filesystem options in `init`, an alternative solution would be to use kernel arguments to make the kernel's implicit behavior explicit/deterministic. It would definitely be more efficient and require less boot time for large images by avoiding the copying step, but I think handing this in the init process will best mesh with a potential future case where the new rootfs may be on local media.

### This fixes or addresses the following GitHub issues:

 - Fixes #

There is no existing issue.

#### Before submitting a PR, make sure you have done the following:

- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/development/contributing/contributing.html) 
- [x] Added changes to the [CHANGELOG](https://github.com/hpcng/warewulf/blob/development/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/hpcng/warewulf/tree/development/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [development](https://github.com/hpcng/warewulf/tree/development/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/hpcng/warewulf/blob/development/CONTRIBUTORS.md
