### PR TITLE
Fix lsmod wrong spelling

### DIFF
--- a/userdocs/contributing/development-environment-vagrant.rst
+++ b/userdocs/contributing/development-environment-vagrant.rst
@@ -29,7 +29,7 @@ KVM kernel module
 
 .. code-block:: bash
 
-   lsmode | grep kvm
+   lsmod | grep kvm
    ccp                   118784  1 kvm_amd
    kvm                  1105920  1 kvm_amd
    irqbypass              16384  1 kvm


### PR DESCRIPTION
lsmod command is misspelled in the Vagrant Documentation part.