### PR TITLE
node set must have an argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or "runtime") rather than a concatenated list of individual overlays. This
   removes a limit on the number of overlays that could be included in a node or
   profile. #852, #876, #883, #896, #903
+- `wwctl node set` needs now an argument #502
 
 ## [4.4.0] 2023-01-18
 

--- a/internal/app/wwctl/node/set/root.go
+++ b/internal/app/wwctl/node/set/root.go
@@ -34,7 +34,7 @@ func GetCommand() *cobra.Command {
 		Use:                   "set [OPTIONS] PATTERN [PATTERN ...]",
 		Short:                 "Configure node properties",
 		Long:                  "This command sets configuration properties for nodes matching PATTERN.\n\nNote: use the string 'UNSET' to remove a configuration",
-		Args:                  cobra.MinimumNArgs(0),
+		Args:                  cobra.MinimumNArgs(1),
 		RunE:                  CobraRunE(&vars),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {


### PR DESCRIPTION
`wwctl node set` needs now a node range as if a value should be set
for all nodes still this node range can be specified via argument

close #502

Signed-off-by: Christian Goll <cgoll@suse.com>
