### PR TITLE
added {{ .Overlay }} to templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Document warewulf.conf:paths. #635
+- New "Overlay" template variable contains the name of the overlay being built. #1052  
 
 ### Changed
 

--- a/internal/app/wwctl/overlay/show/main_test.go
+++ b/internal/app/wwctl/overlay/show/main_test.go
@@ -14,8 +14,11 @@ import (
 )
 
 var (
-	overlayCont = `
+	overlayEmail = `
 {{ if .Tags.email }}eMail: {{ .Tags.email }}{{else}} noMail{{- end }}
+`
+	overlayOverlay = `
+overlay name {{ .Overlay }}
 `
 )
 
@@ -38,7 +41,8 @@ nodes:
       - empty
 `)
 
-	env.WriteFile(t, path.Join(testenv.WWOverlaydir, "testoverlay/email.ww"), overlayCont)
+	env.WriteFile(t, path.Join(testenv.WWOverlaydir, "testoverlay/email.ww"), overlayEmail)
+	env.WriteFile(t, path.Join(testenv.WWOverlaydir, "testoverlay/overlay.ww"), overlayOverlay)
 	defer env.RemoveAll(t)
 	warewulfd.SetNoDaemon()
 	t.Run("overlay show raw", func(t *testing.T) {
@@ -50,7 +54,7 @@ nodes:
 		wwlog.SetLogWriter(buf)
 		err := baseCmd.Execute()
 		assert.NoError(t, err)
-		assert.Contains(t, buf.String(), overlayCont)
+		assert.Contains(t, buf.String(), overlayEmail)
 	})
 	t.Run("overlay show rendered node tag", func(t *testing.T) {
 		baseCmd.SetArgs([]string{"-r", "node1", "testoverlay", "email.ww"})
@@ -84,6 +88,17 @@ nodes:
 		err := baseCmd.Execute()
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "noMail")
+	})
+	t.Run("overlay shows overlay", func(t *testing.T) {
+		baseCmd.SetArgs([]string{"-r", "node1", "testoverlay", "overlay.ww"})
+		baseCmd := GetCommand()
+		buf := new(bytes.Buffer)
+		baseCmd.SetOut(buf)
+		baseCmd.SetErr(buf)
+		wwlog.SetLogWriter(buf)
+		err := baseCmd.Execute()
+		assert.NoError(t, err)
+		assert.Contains(t, buf.String(), "testoverlay")
 	})
 }
 

--- a/internal/pkg/overlay/datastructure.go
+++ b/internal/pkg/overlay/datastructure.go
@@ -27,6 +27,7 @@ type TemplateStruct struct {
 	Netmask       string
 	Network       string
 	NetworkCIDR   string
+	Overlay       string
 	Ipv6          bool
 	Dhcp          warewulfconf.DHCPConf
 	Nfs           warewulfconf.NFSConf

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -352,6 +352,18 @@ func RenderTemplateFile(fileName string, data TemplateStruct) (
 	err error) {
 	backupFile = true
 	writeFile = true
+	// parse the overlay name out of the absolute path
+	overlayPath, _ := filepath.Rel(OverlaySourceTopDir(), fileName)
+	withoutRootfs, err := filepath.Rel("rootfs", overlayPath)
+	if err != nil {
+		overlayPath = withoutRootfs
+	}
+	overlayPathElem := strings.Split(overlayPath, "/")
+	if len(overlayPathElem) > 1 {
+		data.Overlay = overlayPathElem[0]
+	} else {
+		data.Overlay = ""
+	}
 
 	// Build our FuncMap
 	funcMap := template.FuncMap{

--- a/overlays/debug/rootfs/warewulf/template-variables.md.ww
+++ b/overlays/debug/rootfs/warewulf/template-variables.md.ww
@@ -72,6 +72,7 @@ data from other structures.
 - BuildTime: {{ .BuildTime }}
 - BuildTimeUnix: {{ .BuildTimeUnix }}
 - BuildSource: {{ .BuildSource }}
+- Overlay: {{ .Overlay }}
 
 
 ## Network


### PR DESCRIPTION
{{ .Overlay }} contains the overlay name in which the template is located, otherwise
its values is "UNDEF" if the RenderTempalte is called outside the warewulf
overlay tree

* Closes #1052

Signed-off-by: Christian Goll <cgoll@suse.com>
