### PR TITLE
check real path of `nodes.conf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create `/etc/systemd/network/10-persistent-net-<netdev>.link` file per network device
 - Fix the issue that the same tag added in `node set` is ignored. #967
 - Change too-verbose warning message level from `Warn` to `Debug`. #1025
+- Fix wwctl node/profile edit
 
 ### Changed
 

--- a/internal/pkg/api/util/util.go
+++ b/internal/pkg/api/util/util.go
@@ -1,11 +1,13 @@
 package util
 
 import (
+	"path"
 	"syscall"
+
+	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
 
 	"github.com/manifoldco/promptui"
 	"github.com/warewulf/warewulf/internal/pkg/api/routes/wwapiv1"
-	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
@@ -30,9 +32,11 @@ Simple check if the config can be written in case wwctl isn't run as root
 */
 func CanWriteConfig() (canwrite *wwapiv1.CanWriteConfig) {
 	canwrite = new(wwapiv1.CanWriteConfig)
-	err := syscall.Access(node.ConfigFile, syscall.O_RDWR)
+	conf := warewulfconf.Get()
+	confFile := path.Join(conf.Paths.Sysconfdir, "warewulf/nodes.conf")
+	err := syscall.Access(confFile, syscall.O_RDWR)
 	if err != nil {
-		wwlog.Warn("Couldn't open %s:%s", node.ConfigFile, err)
+		wwlog.Warn("Couldn't open %s:%s", confFile, err)
 		canwrite.CanWriteConfig = false
 	} else {
 		canwrite.CanWriteConfig = true


### PR DESCRIPTION
as init() isn't call any more on 8323cb8aa781d52ccca7c2b121ef5b91b0c0f0f9 the test of nodes.conf failed
