### PR TITLE
refactor the shebang usage in scripts of init.d folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   excluded with ~ prefix and in listings are listed as !{excluded_profile} #885
 - modules are now correctly included
 - move hostlist into internal alongside other warewulf code #804
+- uniform shebang usage in scripts of init.d folder #821
 
 ## [4.4.0] 2023-01-18
 

--- a/overlays/wwinit/warewulf/init.d/50-ipmi
+++ b/overlays/wwinit/warewulf/init.d/50-ipmi
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 . /warewulf/config
 

--- a/overlays/wwinit/warewulf/init.d/90-selinux
+++ b/overlays/wwinit/warewulf/init.d/90-selinux
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 . /warewulf/config
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

renaming and uniforming the shebang of scripts in folder init.d to `#/bin/sh`. 


## This fixes or addresses the following GitHub issues:

 - Fixes #821


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
