### PR TITLE
Enable creating a bonding network interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- ability to create bonded network interfaces
 - ipxe script to boot node from local disk.
 - Option to change the `ipmitool` escape character
 - New documentation for the hostlist syntax. #611

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,3 +30,4 @@
 * Arnaud LECOMTE <contact@arnaud-lcm.com>
 * Ryan Novosielski <novosirj@rutgers.edu>
 * Andreas Skau <andreas@scheen.no> @buzh
+* Dietmar Rieder <dietmar.rieder@i-med.ac.at>

--- a/overlays/wwinit/etc/NetworkManager/system-connections/ww4-managed.ww
+++ b/overlays/wwinit/etc/NetworkManager/system-connections/ww4-managed.ww
@@ -12,9 +12,17 @@
 id={{ $connection_id }}
 interface-name={{ $netdev.Device }}
 {{ if $netdev.Type -}}
+{{ if eq $netdev.Type "bond-slave" -}}
+slave-type=bond
+{{- $conn := split $connection_id "_" }}
+{{- $master := index $conn 0 }}
+master={{ $master }}
+type=ethernet
+{{ else }}
 type={{ $netdev.Type }}
-{{ end -}}
 autoconnect=true
+{{ end -}}
+{{ end -}}
 
 {{ if $netdev.Hwaddr -}}
 {{ if eq $netdev.Type "ethernet" -}}
@@ -26,6 +34,22 @@ mtu={{ $netdev.MTU }}
 {{ end -}}
 {{ end -}}
 
+# bond
+{{ if eq $netdev.Type "bond" -}}
+[ethernet]
+{{ if $netdev.MTU -}}
+mtu={{ $netdev.MTU }}
+{{ end -}}
+
+[bond]
+downdelay=0
+miimon=100
+mode=802.3ad
+xmit_hash_policy=layer2+3
+updelay=0
+
+{{ end -}}
+
 {{ if eq $netdev.Type "infiniband" -}}
 [infiniband]
 transport-mode=datagram
@@ -34,7 +58,7 @@ mtu={{ $netdev.MTU }}
 {{ end -}}
 {{ end -}}
 
-{{ if $netdev.IpCIDR -}}
+{{ if and ($netdev.IpCIDR) (ne $netdev.Type "bond-slave") -}}
 [ipv4]
 address={{ $netdev.IpCIDR }}
 {{ if $netdev.Gateway -}}

--- a/userdocs/contents/nodeconfig.rst
+++ b/userdocs/contents/nodeconfig.rst
@@ -230,6 +230,18 @@ container, kernel, and network:
   # wwctl node list -a n001 | grep cluster
   n001                 cluster            --           cluster01
 
+
+To configure a bonded (link aggreagtion) network interface the following commands can be used:
+
+.. code-block:: console
+
+  # wwctl node set --netname=bond0_member_1 --netdev=eth2 --type=bond-slave n001
+  # wwctl node set --netname=bond0_member_2 --netdev=eth3 --type=bond-slave n001
+  # wwctl node set --netname=bond0 --netdev=bond0 --onboot=true --type=bond --ipaddr 10.0.3.1 --netmask=255.255.255.0 --mtu=9000 n001
+
+Note: the netnames of the member interterfaces need to match the "netname" of the bonded interface until the first "_" (in the example bond0)
+
+
 Node Discovery
 --------------
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

The changes to `ww4-managed.ww` enable users to create bonded network interfaces.
