### PR TITLE
Update metadata for 4.5.0rc1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [4.5.0] 2024-02-08
 
 ### Added
 
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add container rename command. #583
 - Add container build flags and warn message after container sync. #509
 - Add DNS fields to network configuration overlays. #922
+- Added support for booting nodes with grub. Enable this behavior using
+  warewulf.grubboot: true in warewulf.conf. For unknown nodes, grub.efi
+  and shim.efi are extracted from the Warewulf host. If the booted node
+  has a container these binaries are extracted from the container image.
 
 ### Fixed
 - Make Variables.mk consistent with spec file w.r.t. WWPROVISIONDIR, e.g.
@@ -82,6 +86,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `warwulfconf print` which will print the used `warewulf.conf`. If there is no valid
      `warewulf.conf` a valid configuration is provided, prefilled with default values
      and an IP configuration derived from the network configuration of the host
+- Added support for file systems, partitions and disks. Values for these objects can
+  be set with `wwctl profile/node set/add`. The format of this objects is inspired by
+  butane/ignition, but where butane/ignition uses lists for holding disks, partitions
+  and file systems, warewulf uses maps instead. For disks the map key is the underlying
+  block device, for partitions its the partition label and for file systems its the path
+  to the partitions (e.g. `/dev/disk/by-partlabel/scratch`).
+  Not all available options of butane/ignition are exposed to the commandline, but are
+  available via `wwctl node/profile edit`.
+
+### Changed
+
+- The primary hostname and warewulf server fqdn are now the canonical name in
+  `/etc/hosts`
+- Refactored `profile add` command to make it alike `node add`. #658 #659
+- The ifcfg ONBOOT parameter is no longer statically `true`, so unconfigured
+  interfaces may not be enabled by default. (#644)
+- Write log messages to stderr rather than stdout. #768
 - All paths can now be configured in `warewulf.conf`, check the paths section of of
    `wwctl --emptyconf genconfig warewulfconf print` for the available paths.
 - Added experimental dnsmasq support.
@@ -96,14 +117,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Specify primary network device per-node rather than per-netdev
 - refactored output `wwctl node/profile list` so that `-a` will only show all the
   set values and `-A` will show all fields included the ones without a set value
-- Added support for file systems, partitions and disks. Values for these objects can
-  be set with `wwctl profile/node set/add`. The format of this objects is inspired by
-  butane/ignition, but where butane/ignition uses lists for holding disks, partitions
-  and file systems, warewulf uses maps instead. For disks the map key is the underlying
-  block device, for partitions its the partition label and for file systems its the path
-  to the partitions (e.g. `/dev/disk/by-partlabel/scratch`).
-  Not all available options of butane/ignition are exposed to the commandline, but are
-  available via `wwctl node/profile edit`.
 - Added the template function `{{ createIgnitionJson }}` which will create a json object
   compatible with ignition.
 - Container images need ignition and sgdisk installed in order to the disk management.
@@ -140,10 +153,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `warewulf.conf`. For unknown nodes `grub.efi` and `shim.efi` will be extracted from
   the host running warewulf. If node has container it will get these binaries from the
   container image.
-- Added support for booting nodes with grub. Enable this behavior using
-  warewulf.grubboot: true in warewulf.conf. For unknown nodes, grub.efi
-  and shim.efi are extracted from the Warewulf host. If the booted node
-  has a container these binaries are extracted from the container image.
 - overlays from different profiles for one node are now merged, overlays can be
   excluded with ~ prefix and in listings are listed as !{excluded_profile} #885
 - modules are now correctly included

--- a/Variables.mk
+++ b/Variables.mk
@@ -14,6 +14,7 @@ VARLIST := OS
 VARLIST += WAREWULF VERSION RELEASE
 WAREWULF ?= warewulf
 VERSION ?= 4.5.x
+
 GIT_TAG := $(shell test -e .git && git log -1 --format="%h")
 
 ifdef GIT_TAG

--- a/Variables.mk
+++ b/Variables.mk
@@ -13,7 +13,7 @@ VARLIST := OS
 # Project Information
 VARLIST += WAREWULF VERSION RELEASE
 WAREWULF ?= warewulf
-VERSION ?= 4.5.x
+VERSION ?= 4.5.0-rc1
 
 GIT_TAG := $(shell test -e .git && git log -1 --format="%h")
 

--- a/cmd/update_configuration/vers43/nodes.conf
+++ b/cmd/update_configuration/vers43/nodes.conf
@@ -1,4 +1,4 @@
-WW_INTERNAL: 43
+WW_INTERNAL: 45
 nodeprofiles:
   default:
     comment: This profile is automatically included for each node

--- a/docs/man/man5/warewulf.conf.5
+++ b/docs/man/man5/warewulf.conf.5
@@ -283,7 +283,7 @@ A sample configuration file for a typical deployment, with all
 dependent services enabled.
 
 .EX
-WW_INTERNAL: 43
+WW_INTERNAL: 45
 ipaddr: 10.0.0.1
 network: 10.0.0.0
 netmask: 255.255.0.0

--- a/internal/app/wwctl/root.go
+++ b/internal/app/wwctl/root.go
@@ -87,6 +87,7 @@ func rootPersistentPreRunE(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 	if err != nil {
+		wwlog.Error("version: %s relase: %s WW_INTERNAL: %s", warewulfconf.Version, warewulfconf.Release, warewulfconf.Confversion)
 		return
 	}
 	err = conf.SetDynamicDefaults()

--- a/internal/pkg/config/buildconfig.go.in
+++ b/internal/pkg/config/buildconfig.go.in
@@ -14,17 +14,13 @@ type BuildConfig struct {
 	WWChrootdir    string `default:"@WWCHROOTDIR@"`
 	WWProvisiondir string `default:"@WWPROVISIONDIR@"`
 	WWClientdir    string `default:"@WWCLIENTDIR@"`
-	version        string `default:"@VERSION@"`
-	release        string `default:"@RELEASE@"`
 }
 
-func (conf BuildConfig) Version() string {
-	return conf.version
-}
+const Version = "@VERSION@"
+const Release = "@RELEASE@"
 
-func (conf BuildConfig) Release() string {
-	return conf.release
-}
+// must be set .in file so that its available for tests
+const Confversion = "45"
 
 type TFTPConf struct {
 	Enabled     bool   `yaml:"enabled" default:"true"`

--- a/internal/pkg/config/root_test.go
+++ b/internal/pkg/config/root_test.go
@@ -51,8 +51,6 @@ func TestDefaultRootConf(t *testing.T) {
 	assert.NotEmpty(t, conf.Paths.WWOverlaydir)
 	assert.NotEmpty(t, conf.Paths.WWChrootdir)
 	assert.NotEmpty(t, conf.Paths.WWProvisiondir)
-	assert.NotEmpty(t, conf.Paths.Version)
-	assert.NotEmpty(t, conf.Paths.Release)
 	assert.NotEmpty(t, conf.Paths.WWClientdir)
 }
 

--- a/internal/pkg/overlay/funcmap_test.go
+++ b/internal/pkg/overlay/funcmap_test.go
@@ -1,9 +1,10 @@
 package overlay
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/pkg/node"
-	"testing"
 )
 
 func Test_createIgnitionJson(t *testing.T) {

--- a/internal/pkg/testenv/testenv.go
+++ b/internal/pkg/testenv/testenv.go
@@ -11,8 +11,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
+
 	"github.com/stretchr/testify/assert"
-	"github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/node"
 )
 
@@ -62,7 +63,7 @@ func New(t *testing.T) (env *TestEnv) {
 	env.WriteFile(t, path.Join(Datadir, "warewulf/defaults.conf"), initDefaultsConf)
 
 	// re-read warewulf.conf
-	conf := config.New()
+	conf := warewulfconf.New()
 	err = conf.Read(env.GetPath(path.Join(Sysconfdir, "warewulf/warewulf.conf")))
 	assert.NoError(t, err)
 

--- a/internal/pkg/version/version.go
+++ b/internal/pkg/version/version.go
@@ -11,8 +11,7 @@ import (
 Return the version of wwctl
 */
 func GetVersion() string {
-	conf := warewulfconf.Get()
-	return fmt.Sprintf("%s-%s", conf.Paths.Version(), conf.Paths.Release())
+	return fmt.Sprintf("%s-%s", warewulfconf.Version, warewulfconf.Release)
 }
 
 /*

--- a/userdocs/contents/configuration.rst
+++ b/userdocs/contents/configuration.rst
@@ -14,7 +14,7 @@ Warewulf (4.4.0):
 
 .. code-block:: yaml
 
-   WW_INTERNAL: 43
+   WW_INTERNAL: 45
    ipaddr: 10.0.0.1
    netmask: 255.255.252.0
    network: 10.0.0.0

--- a/userdocs/contributing/development-environment-vagrant.rst
+++ b/userdocs/contributing/development-environment-vagrant.rst
@@ -190,7 +190,7 @@ Vagrantfile
 
             head.vm.provision "shell", inline: <<-SHELL
                 cat << 'CONF' | sudo tee /etc/warewulf/warewulf.conf
-    WW_INTERNAL: 43
+    WW_INTERNAL: 45
     ipaddr: 192.168.200.254
     netmask: 255.255.255.0
     network: 192.168.200.0

--- a/userdocs/quickstart/debian12.rst
+++ b/userdocs/quickstart/debian12.rst
@@ -64,7 +64,7 @@ address of your cluster's private network interface:
 
 .. code-block:: yaml
 
-	WW_INTERNAL: 43
+	WW_INTERNAL: 45
 	ipaddr: 192.168.200.1
 	netmask: 255.255.255.0
 	network: 192.168.200.0

--- a/userdocs/quickstart/el8.rst
+++ b/userdocs/quickstart/el8.rst
@@ -57,7 +57,7 @@ address of your cluster's private network interface:
 
 .. code-block:: yaml
 
-    WW_INTERNAL: 43
+    WW_INTERNAL: 45
     ipaddr: 192.168.200.1
     netmask: 255.255.255.0
     network: 192.168.200.0

--- a/userdocs/quickstart/el9.rst
+++ b/userdocs/quickstart/el9.rst
@@ -57,7 +57,7 @@ address of your cluster's private network interface:
 
 .. code-block:: yaml
 
-    WW_INTERNAL: 43
+    WW_INTERNAL: 45
     ipaddr: 192.168.200.1
     netmask: 255.255.255.0
     network: 192.168.200.0


### PR DESCRIPTION
Updated the metadata for the 4.5.0rc1 release. Its a quite big
patch as
* for the config files the confversion 45 must be set seperately
* tests get the version by the compiled in confversion

Also Version and Release are now const strings to make obivous
that this values can't be changed, as this might be suggested by
unexported variables.

@anderbubble must be rebased after #1037 is merged
