### PR TITLE
Remove redundant wwclient startup script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change too-verbose warning message level from `Warn` to `Debug`. #1025
 - Fixed a bug where error occurs when editing node. #1024
 - Optionally detect network and netmask from CIDR IP address. #1016
+- Fix startup of wwclient on systemd hosts #1066
 
 ### Changed
 

--- a/overlays/wwinit/warewulf/init.d/80-wwclient
+++ b/overlays/wwinit/warewulf/init.d/80-wwclient
@@ -1,7 +1,0 @@
-#!/bin/sh
-. /warewulf/config
-# Only start if the systemd is no available
-test -d /run/systemd/system  && exit 0
-echo "Starting wwclient"
-nohup /warewulf/wwclient >/var/log/wwclient.log 2>&1 </dev/null &
-


### PR DESCRIPTION
80-wwclient was previously supplanted by 80-wwclient.ww, but the static version was retained. Meanwhile, the static version can only detect systemd when it is running, which it isn't during wwinit. This led to wwclient starting during wwinit and then being killed by systemd.

- Closes #1066

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
