### PR TITLE
Install Graphviz in userdocs CI workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,6 +32,10 @@ jobs:
         run: |
           sudo apt-get install -f -y texlive-latex-extra latexmk
 
+      - name: Install graphviz
+        run: |
+          sudo apt-get install -f -y graphviz
+
       - name: Setup Python
         uses: actions/setup-python@v1
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Docs CI workflow was not installing graphviz, leading to unrendered diagrams.


## This fixes or addresses the following GitHub issues:

 - Fixes #1105