### PR TITLE
removed static if clause for dhcpd.conf.ww

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,6 +285,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changed. #495, #637
 - `wwctl power` commands no longer separates node output with
   additional whitespace. #514
+- dhcpd configs are now always static
 
 ### Fixed
 

--- a/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
+++ b/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
@@ -55,7 +55,6 @@ subnet {{$.Network}} netmask {{$.Netmask}} {
     next-server {{.Ipaddr}};
 }
 
-{{- if eq .Dhcp.Template "static" }}
 {{- range $nodes := $.AllNodes}}
 {{- range $netname, $netdevs := $nodes.NetDevs}}
 host {{$nodes.Id.Get}}-{{$netname}}
@@ -72,7 +71,6 @@ host {{$nodes.Id.Get}}-{{$netname}}
 }
 {{end -}}{{/* range NetDevs */}}
 {{end -}}{{/* range AllNodes */}}
-{{end -}}{{/* if static */}}
 
 {{- else}}
 {{abort}}


### PR DESCRIPTION
`static` isn't a keyword in `warewulf.conf` any more, so removed the use in the template
