### PR TITLE
Add support for machines that do not have a SMBIOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Locally defined `tr` has been dropped, templates updated to use Sprig replace.
 
-## [4.5.0]
+### Fixed
+
+- Systems with no SMBIOS (Raspberry Pi) will create a UUID from
+  `/sys/firmware/devicetree/base/serial-number`
+
+## [4.5.0] 2024-02-08
 
 - Official v4.5.0 release.
 - Publish v4.5.x documentation separately from `main`. #919

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,3 +32,4 @@
 * Andreas Skau <andreas@scheen.no> @buzh
 * Dietmar Rieder <dietmar.rieder@i-med.ac.at>
 * Andreas Henkel <henkel@uni-mainz.de>
+* Timothy Middelkoop <tmiddelkoop@internet2.edu>


### PR DESCRIPTION
## Description of the Pull Request (PR):

Allow machines without a SMBIOS to run wwclieint.  The Raspberry Pi is one such machine.  The PR will try to read from "/sys/firmware/devicetree/base/serial-number" if there is no SMBIOS (Raspberry Pi Serial Number) and create a UUID from that.

## This fixes or addresses the following GitHub issues:

 - Fixes warewulf/warewulf#1108

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
