### PR TITLE
Fixed profile list bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Systems with no SMBIOS (Raspberry Pi) will create a UUID from
   `/sys/firmware/devicetree/base/serial-number`
+- Fix `wwctl profile list -a` format when kernerargs are set
 
 ## [4.5.0] 2024-02-08
 

--- a/internal/app/wwctl/profile/list/main.go
+++ b/internal/app/wwctl/profile/list/main.go
@@ -26,9 +26,9 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 		}
 
 		if len(profileInfo.Output) > 0 {
-			ph := helper.NewPrintHelper(strings.Split(profileInfo.Output[0], "="))
+			ph := helper.NewPrintHelper(strings.Split(profileInfo.Output[0], ":=:"))
 			for _, val := range profileInfo.Output[1:] {
-				ph.Append(strings.Split(val, "="))
+				ph.Append(strings.Split(val, ":=:"))
 			}
 			ph.Render()
 		}

--- a/internal/pkg/api/profile/list.go
+++ b/internal/pkg/api/profile/list.go
@@ -32,20 +32,20 @@ func ProfileList(ShowOpt *wwapiv1.GetProfileList) (profileList wwapiv1.ProfileLi
 	if ShowOpt.ShowAll || ShowOpt.ShowFullAll {
 		for _, p := range profiles {
 			profileList.Output = append(profileList.Output,
-				fmt.Sprintf("%s=%s=%s=%s", "PROFILE", "FIELD", "PROFILE", "VALUE"))
+				fmt.Sprintf("%s:=:%s:=:%s", "PROFILE", "FIELD", "VALUE"))
 			fields := p.GetFields(ShowOpt.ShowFullAll)
 			for _, f := range fields {
 				profileList.Output = append(profileList.Output,
-					fmt.Sprintf("%s=%s=%s=%s", p.Id.Print(), f.Field, f.Source, f.Value))
+					fmt.Sprintf("%s:=:%s:=:%s", p.Id.Print(), f.Field, f.Value))
 			}
 		}
 	} else {
 		profileList.Output = append(profileList.Output,
-			fmt.Sprintf("%s=%s", "PROFILE NAME", "COMMENT/DESCRIPTION"))
+			fmt.Sprintf("%s:=:%s", "PROFILE NAME", "COMMENT/DESCRIPTION"))
 
 		for _, profile := range profiles {
 			profileList.Output = append(profileList.Output,
-				fmt.Sprintf("%s=%s", profile.Id.Print(), profile.Comment.Print()))
+				fmt.Sprintf("%s:=:%s", profile.Id.Print(), profile.Comment.Print()))
 		}
 	}
 	return


### PR DESCRIPTION
Fixed a bug with profile list when kernelargs are set with 'var=val' format. This also removed the unnecessary '--' for the source profile since it's never used.

## Description of the Pull Request (PR):

If kernelargs are set, `profile list -a` format is messed up due to profile uses '=' as separator, e.g.,

```
# wwctl.orig profile list -a default
  PROFILE  FIELD                        PROFILE  VALUE
  default  Id                           --       default
  default  Comment                      --       This profile is automatically included for each node
  default  Kernel.Args                  --       crashkernel                                           no vga  791 net.naming-scheme  v238
```


## This fixes or addresses the following GitHub issues:

This fix standardized the field separator to ':=:' which is what node uses.
