### PR TITLE
Fix ipxe-bootimgs in warewulf.spec.in for el7

### DIFF
--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -52,8 +52,12 @@ BuildRequires: golang >= 1.16
 BuildRequires: firewalld-filesystem
 Requires: tftp-server
 Requires: nfs-utils
+%if 0%{?rhel} < 8
+Requires: ipxe-bootimgs
+%else
 Requires: ipxe-bootimgs-x86
 Requires: ipxe-bootimgs-aarch64
+%endif
 %endif
 
 %if 0%{?rhel} >= 8 || 0%{?suse_version} || 0%{?fedora}


### PR DESCRIPTION
## Description of the Pull Request (PR):

CentOS 7 only has ipxe-bootimgs, so update requires in the RPM when building for el7.