### PR TITLE
Fix a formatting error hiding GRUB configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add the ability to boot nodes with `wwid=[interface]`, which replaces
   `interface` with the interface MAC address
-
-## [4.5.0] 2024-02-08
-
-### Added
-
 - Added https://github.com/Masterminds/sprig functions to templates #1030
 
 ### Changed
@@ -33,10 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.5.0] 2024-02-08
 
-- Official v4.5.0 release.
+Official v4.5.0 release.
+
+### Added
+
 - Publish v4.5.x documentation separately from `main`. #919
-- Fix `Requires: ipxe-botimgs` for building an Enterprise Linux 7 RPM. #1126
 - Update quickstart for Enterprise Linux. #394, #401, #977
+
+### Fixed
+
+- Fix `Requires: ipxe-botimgs` for building an Enterprise Linux 7 RPM. #1126
 
 ## [4.5.0rc2] 2024-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.5.x]
+## [4.5.x] (unreleased)
 
 ### Added
 
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Locally defined `tr` has been dropped, templates updated to use Sprig replace.
-- Updated the glossary #819
+- Updated the glossary. #819
 
 ### Fixed
 
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Systems with no SMBIOS (Raspberry Pi) will create a UUID from
   `/sys/firmware/devicetree/base/serial-number`
 - Fix `wwctl profile list -a` format when kernerargs are set
+- Fix a rendering bug in the documentation for GRUB boot support. #1132
 
 ## [4.5.0] 2024-02-08
 

--- a/userdocs/contents/boot-management.rst
+++ b/userdocs/contents/boot-management.rst
@@ -64,7 +64,7 @@ scenarios.
 
 In order to enable the grub boot method it has to be enabled in `warewulf.conf`.
 
-.. code-block: yaml
+.. code-block:: yaml
 
    warewulf:
      grubboot: true


### PR DESCRIPTION
## Description of the Pull Request (PR):

A minor typo in the rst formatting was causing the code block demonstrating how to configure `grubboot: true` to not render.

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
