### PR TITLE
Update issue templates to reflect our new dedicated Slack

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
         a lot in fixing it quickly and effectively!
 
         If you want to ask a question about Warewulf (how to use it, what it
-        can currently do, etc.), try the `#warewulf` channel on [our
+        can currently do, etc.), try asking on [our
         Slack](https://warewulf.org/help) first. We have a welcoming community
         and chances are you'll get your reply faster and without opening an
         issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -35,7 +35,7 @@ body:
     attributes:
       value: |
         If you want to ask a question about Warewulf (how to use it, what it
-        can currently do, etc.), try the `#warewulf` channel on [our
+        can currently do, etc.), try asking on [our
         Slack](https://warewulf.org/help) first. We have a welcoming community
         and chances are you'll get your reply faster and without opening an
         issue.


### PR DESCRIPTION
## Description of the Pull Request (PR):

The current issue templates suggest asking questions in a `#warewulf` channel on Slack. This no longer exists, since we have an entire Slack team just for Warewulf now.