### PR TITLE
Update init to not require rootfs=initramfs to use tmpfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Locally defined `tr` has been dropped, templates updated to use Sprig replace.
 - Updated the glossary. #819
 - Upgrade the golang version to 1.19.
+- Update init to not require rootfs=initramfs to use tmpfs. #1093
 
 ### Fixed
 

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -9,7 +9,7 @@
 if test -f "/warewulf/config"; then
     . /warewulf/config
 else
-    echo "ERROR: Warewulf configuration file not found... rebooting in 1 minute"
+    echo "ERROR: Warewulf configuration file not found. Rebooting in 1 minute..."
     sleep 60
     echo b > /proc/sysrq-trigger || /sbin/reboot
 fi
@@ -17,7 +17,7 @@ fi
 echo "Warewulf v4 is now booting: $WWHOSTNAME"
 echo
 
-echo "Mounting up kernel file systems"
+echo "Mounting kernel file systems"
 mkdir /proc /dev /sys /run 2>/dev/null
 mount -t proc proc /proc
 mount -t devtmpfs devtmpfs /dev
@@ -26,31 +26,24 @@ mount -t tmpfs tmpfs /run
 
 chmod 755 /warewulf/wwinit
 
-echo "Checking Rootfs type"
-ROOTFSTYPE=`stat -f -c "%T" /`
-
 if test "$WWROOT" = "initramfs"; then
-    echo "Provisioned to default initramfs file system: $ROOTFSTYPE"
-    echo "Calling WW Init"
+    echo "Provisioned to default initramfs file system"
+    echo "Calling wwinit"
     exec /warewulf/wwinit
 elif test "$WWROOT" = "tmpfs"; then
-    if test "$ROOTFSTYPE" = "tmpfs"; then
-        echo "ERROR: Switching the root file system requires the kernel argument: 'rootfstype=ramfs'"
-    else
-        echo "Setting up tmpfs root file system"
-        mkdir /newroot
-        mount wwroot /newroot -t tmpfs
-        echo "Moving RAMFS to TMPFS"
-        tar -cf - --exclude ./proc --exclude ./sys --exclude ./dev --exclude ./newroot . | tar -xf - -C /newroot
-        mkdir /newroot/proc /newroot/dev /newroot/sys /newroot/run 2>/dev/null
-        echo "Calling switch_root and invoking WW Init"
-        exec /sbin/switch_root /newroot /warewulf/wwinit
-    fi
+    echo "Setting up tmpfs root file system"
+    mkdir /newroot
+    mount wwroot /newroot -t tmpfs
+    echo "Moving to tmpfs"
+    tar -cf - --exclude ./proc --exclude ./sys --exclude ./dev --exclude ./newroot . | tar -xf - -C /newroot
+    mkdir /newroot/proc /newroot/dev /newroot/sys /newroot/run 2>/dev/null
+    echo "Calling switch_root and invoking wwinit"
+    exec /sbin/switch_root /newroot /warewulf/wwinit
 else
     echo "ERROR: Unknown Warewulf Root file system: $WWROOT"
 fi
 
 echo
-echo "There was a problem with the provisioning process, rebooting in 1 minute..."
+echo "There was a problem with the provisioning process. Rebooting in 1 minute..."
 sleep 60
 echo b > /proc/sysrq-trigger || /sbin/reboot


### PR DESCRIPTION
## Description of the Pull Request (PR):

Using SELinux requires setting root=tmpfs; but the implementation of `/init` also required `rootfstype=ramfs` unnecessarily.


## This fixes or addresses the following GitHub issues:

- Closes #1093


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
