### PR TITLE
Replace slice in templates with sprig substr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/sys/firmware/devicetree/base/serial-number`
 - Fix `wwctl profile list -a` format when kernerargs are set
 - Fix a rendering bug in the documentation for GRUB boot support. #1132
+- Replace slice in templates with sprig substr. #1093
 
 ## [4.5.0] 2024-02-08
 

--- a/overlays/wwinit/rootfs/etc/NetworkManager/system-connections/ww4-managed.ww
+++ b/overlays/wwinit/rootfs/etc/NetworkManager/system-connections/ww4-managed.ww
@@ -67,7 +67,7 @@ gateway={{ $netdev.Gateway }}
 method=manual
 {{- $dns := "" }}
 {{range $tk, $tv := $netdev.Tags -}}
-{{ $prefix := slice $tk 0 3 -}}
+{{ $prefix := substr 0 3 $tk -}}
 {{ if eq $prefix "DNS" -}}
 {{ $dns = print $dns $tv ";" -}}
 {{ end -}}

--- a/overlays/wwinit/rootfs/etc/resolv.conf.ww
+++ b/overlays/wwinit/rootfs/etc/resolv.conf.ww
@@ -7,7 +7,7 @@
 # Source: {{ $source }}
 {{range $devname, $netdev := .NetDevs -}}
 {{range $tk, $tv := $netdev.Tags -}}
-{{ $prefix := slice $tk 0 3 -}}
+{{ $prefix := substr 0 3 $tk -}}
 {{ if eq $prefix "DNS" -}}
 nameserver {{ $tv }}
 {{ end -}}

--- a/overlays/wwinit/rootfs/etc/sysconfig/network-scripts/ifcfg.ww
+++ b/overlays/wwinit/rootfs/etc/sysconfig/network-scripts/ifcfg.ww
@@ -38,7 +38,7 @@ IPV6_FAILURE_FATAL=no
 IPV6ADDR="{{ $netdev.Ipaddr6 }}"
 {{ end -}}
 {{range $tk, $tv := $netdev.Tags -}}
-{{ $prefix := slice $tk 0 3 -}}
+{{ $prefix := substr 0 3 $tk -}}
 {{ if eq $prefix "DNS" -}}
 {{ $tk }}={{ $tv }}
 {{ end -}}

--- a/overlays/wwinit/rootfs/etc/systemd/system/ww4-disks.target.ww
+++ b/overlays/wwinit/rootfs/etc/systemd/system/ww4-disks.target.ww
@@ -13,14 +13,14 @@ Requisite=ignition-ww4-disks.service
 {{- $prefix := $fsdevice }}
 {{- $prefix = replace "-" "\\x2d" $fsdevice }}
 {{- $prefix = replace "/" "-" $prefix }}
-{{- $prefix = slice $prefix 1 }}{{ $suffix := "mount" }}
+{{- $prefix = substr 1 -1 $prefix }}{{ $suffix := "mount" }}
 {{- if eq $fs.Format "swap"}}
 {{- $prefix = replace "/dev/disk/by-partlabel/" "dev-disk-by\\x2dpartlabel-" $fsdevice }}{{ $suffix = "swap"}}
 {{- else }}
 {{- if ne $fs.Path "" }}
 {{- $prefix = replace "-" "\\x2d" $fs.Path }}
 {{- $prefix = replace "/" "-" $prefix }}
-{{- $prefix = slice $prefix 1 }}
+{{- $prefix = substr 1 -1 $prefix }}
 {{- end }}
 {{- end }}
 Wants={{ print $prefix "." $suffix }}

--- a/overlays/wwinit/rootfs/etc/systemd/system/ww4-mounts.ww
+++ b/overlays/wwinit/rootfs/etc/systemd/system/ww4-mounts.ww
@@ -4,7 +4,7 @@
 {{- range $fsdevice,$fs := .FileSystems }}
 {{- $prefix := replace "-" "\\x2d" $fs.Path }}
 {{- $prefix = replace "/" "-" $prefix }}
-{{- $prefix = slice $prefix 1 }}
+{{- $prefix = substr 1 -1 $prefix }}
 {{ $suffix := "mount"}}
 {{- if $fs.Label }}{{ $prefix = $fs.Label }}{{ end }}
 {{- if eq $fs.Format "swap" }}{{ $prefix = replace "/dev/disk/by-partlabel/" "dev-disk-by\\x2dpartlabel-" $fsdevice }}{{ $suffix = "swap" }}{{ end }}


### PR DESCRIPTION
## Description of the Pull Request (PR):

sprig replaces `slice` with a function that only operates on sprig lists. `substr` is required for use with strings.


## This fixes or addresses the following GitHub issues:

- Fixes: #1139

Fixes a regression that occurred at #1030.


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
