### PR TITLE
Document overriding paths in warewulf.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add multiple output formats (yaml & json) support. #447
 - More aliases for many wwctl commands
 - Add support to render template using `host` or `$(uname -n)` as the value of `overlay show --render`. #623
+- Document warewulf.conf:paths. #635
 
 ### Changed
 

--- a/userdocs/contents/configuration.rst
+++ b/userdocs/contents/configuration.rst
@@ -129,17 +129,27 @@ may be overridden using ``warewulf.conf:paths``.
 .. code-block:: yaml
 
    paths:
-     bindir: /usr/bin
      sysconfdir: /etc
      localstatedir: /var/lib
      ipxesource: /usr/share/ipxe
-     srvdir: /var/lib
-     firewallddir: /usr/lib/firewalld/services
-     systemddir: /usr/lib/systemd/system
      wwoverlaydir: /var/lib/warewulf/overlays
      wwchrootdir: /var/lib/warewulf/chroots
      wwprovisiondir: /var/lib/warewulf/provision
      wwclientdir: /warewulf
+
+* ``sysconfdir``: The parent directory for the ``warewulf`` configuration directory,
+  which stores ``warewulf.conf`` and ``nodes.conf``.
+
+* ``ipxesource``: Where to get iPXE binaries.
+  These files are copied to ``warewulf.conf:tftp:tftproot`` by ``wwctl configure``.
+
+* ``wwoverlaydir``: The source for Warewulf overlays.
+
+* ``wwchrootdir``: The source for Warewulf containers.
+
+* ``wwprovisiondir``: Where to store built overlays, built containers, and imported kernels.
+
+* ``wwclientdir``: Where the Warewulf client looks for its configuration on a provisioned node.
 
 nodes.conf
 ==========

--- a/userdocs/contents/configuration.rst
+++ b/userdocs/contents/configuration.rst
@@ -10,7 +10,7 @@ warewulf.conf
 =============
 
 The Warewulf configuration exists as follows in the current version of
-Warewulf (4.4.0):
+Warewulf (4.5.0):
 
 .. code-block:: yaml
 
@@ -117,6 +117,29 @@ explained as follows:
 * ``container mounts``: These paths are mounted into the container
   during ``container exec`` or ``container shell``, typically to allow
   them to operate in the host environment prior to deployment.
+
+Paths
+-----
+
+*New in Warewulf v4.5.0*
+
+Default paths to containers, overlays, and other Warewulf components
+may be overridden using ``warewulf.conf:paths``.
+
+.. code-block:: yaml
+
+   paths:
+     bindir: /usr/bin
+     sysconfdir: /etc
+     localstatedir: /var/lib
+     ipxesource: /usr/share/ipxe
+     srvdir: /var/lib
+     firewallddir: /usr/lib/firewalld/services
+     systemddir: /usr/lib/systemd/system
+     wwoverlaydir: /var/lib/warewulf/overlays
+     wwchrootdir: /var/lib/warewulf/chroots
+     wwprovisiondir: /var/lib/warewulf/provision
+     wwclientdir: /warewulf
 
 nodes.conf
 ==========


### PR DESCRIPTION
## This fixes or addresses the following GitHub issues:

- Close: #635

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
