### PR TITLE
always build container on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `wwctl clean` to remove OCI cache and overlays from deleted nodes
 - Add `wwctl container import --platform`. #1381
 - Read environment variables from `/etc/default/warewulfd` #725
+- Additional aliases for many wwctl commands. #1144
 
 ### Changed
 
@@ -60,9 +61,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove `wwctl server <start,stop,status,restart,reload>` #508
 - Updated the glossary. #819
 - Upgrade the golang version to 1.19.
-- Always build container on import what was default on 4.4.x
-- Removed `--setdefault` for container build, as this should be done with
-  profile set
+- Build container by default during `wwctl container import`. #1143
+- Removed `wwctl container build --setdefault`. #1143
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `wwctl node list --fullall` has been removed
 - `wwctl profile list --fullall` has been removed
 - Remove `wwctl server <start,stop,status,restart,reload>` #508
+- Updated the glossary. #819
+- Upgrade the golang version to 1.19.
+- Always build container on import what was default on 4.4.x
+- Removed `--setdefault` for container build, as this should be done with
+  profile set
 
 ### Fixed
 

--- a/internal/app/wwctl/container/build/main.go
+++ b/internal/app/wwctl/container/build/main.go
@@ -11,7 +11,6 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		ContainerNames: args,
 		Force:          BuildForce,
 		All:            BuildAll,
-		Default:        SetDefault,
 	}
 	return container.ContainerBuild(cbp)
 }

--- a/internal/app/wwctl/container/build/root.go
+++ b/internal/app/wwctl/container/build/root.go
@@ -29,7 +29,6 @@ var (
 func init() {
 	baseCmd.PersistentFlags().BoolVarP(&BuildAll, "all", "a", false, "(re)Build all VNFS images for all nodes")
 	baseCmd.PersistentFlags().BoolVarP(&BuildForce, "force", "f", false, "Force rebuild, even if it isn't necessary")
-	baseCmd.PersistentFlags().BoolVar(&SetDefault, "setdefault", false, "Set this container for the default profile")
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/internal/app/wwctl/container/imprt/root.go
+++ b/internal/app/wwctl/container/imprt/root.go
@@ -43,7 +43,7 @@ Imported containers are used to create bootable VNFS images.`,
 func init() {
 	baseCmd.PersistentFlags().BoolVarP(&SetForce, "force", "f", false, "Force overwrite of an existing container")
 	baseCmd.PersistentFlags().BoolVarP(&SetUpdate, "update", "u", false, "Update and overwrite an existing container")
-	baseCmd.PersistentFlags().BoolVarP(&SetBuild, "build", "b", false, "Build container after pulling")
+	baseCmd.PersistentFlags().BoolVarP(&SetBuild, "build", "b", true, "Build container when after pulling")
 	baseCmd.PersistentFlags().BoolVar(&SetDefault, "setdefault", false, "Set this container for the default profile")
 	baseCmd.PersistentFlags().BoolVar(&SyncUser, "syncuser", false, "Synchronize UIDs/GIDs from host to container")
 	baseCmd.PersistentFlags().BoolVar(&OciNoHttps, "nohttps", false, "Ignore wrong TLS certificates, superseedes env WAREWULF_OCI_NOHTTPS")


### PR DESCRIPTION
Removed also the --setdefault option for `wwctl container build`
as implict profile manipultion should be avoided

Signed-off-by: Christian Goll <cgoll@suse.com>
