### PR TITLE
add CIDR format to warewulf.conf parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Block unprivileged requests for arbitrary overlays in secure mode. #1215
 - Fix installation docs to use github.com/warewulf instead of github.com/hpcng. #1219
+- Fix the issue that warewulf.conf parse does not support CIDR format. #1130
 
 ### Security
 

--- a/internal/pkg/config/root.go
+++ b/internal/pkg/config/root.go
@@ -101,6 +101,19 @@ func (conf *RootConf) Parse(data []byte) error {
 	if len(conf.TFTP.IpxeBinaries) == 0 {
 		conf.TFTP.IpxeBinaries = defIpxe
 	}
+
+	// check whether ip addr is CIDR type and configure related fields as required
+	if ip, network, err := net.ParseCIDR(conf.Ipaddr); err == nil {
+		conf.Ipaddr = ip.String()
+		if conf.Network == "" {
+			conf.Network = network.IP.String()
+		}
+		if conf.Netmask == "" {
+			mask := network.Mask
+			conf.Netmask = fmt.Sprintf("%d.%d.%d.%d", mask[0], mask[1], mask[2], mask[3])
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

when parsing warewulf.conf, CIDR format will cause issue.


## This fixes or addresses the following GitHub issues:

 - Fixes #1130


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
