### PR TITLE
add support to render template using `host` or `$(uname -n)` as the value of command `overlay show --render`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added https://github.com/Masterminds/sprig functions to templates #1030
 - Add multiple output formats (yaml & json) support. #447
 - More aliases for many wwctl commands
+- Add support to render template using `host` or `$(uname -n)` as the value of `overlay show --render`. #623
 
 ### Changed
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add support to render template using `host` or `$(uname -n)` as the value of command `overlay show --render`


## This fixes or addresses the following GitHub issues:

 - Fixes #623


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
