### PR TITLE
Never attempt to build protocol buffers offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `wwctl profile list -a` format when kernerargs are set
 - Fix a rendering bug in the documentation for GRUB boot support. #1132
 - Replace slice in templates with sprig substr. #1093
+- Don't attempt to rebuild protocol buffers in offline mode. #1155
 
 ## [4.5.0] 2024-02-08
 

--- a/Makefile
+++ b/Makefile
@@ -160,25 +160,6 @@ reference: wwctl
 
 latexpdf: reference
 	make -C userdocs latexpdf
-protofiles = internal/pkg/api/routes/wwapiv1/routes.pb.go \
-	internal/pkg/api/routes/wwapiv1/routes.pb.gw.go \
-	internal/pkg/api/routes/wwapiv1/routes_grpc.pb.go
-.PHONY: proto
-proto: $(protofiles)
-
-routes_proto = internal/pkg/api/routes/v1/routes.proto
-$(protofiles): $(routes_proto)
-	PATH=$(TOOLS_BIN):$(PATH) $(PROTOC) \
-		-I /usr/include -I $(shell dirname $(routes_proto)) -I=. \
-		--grpc-gateway_opt logtostderr=true \
-		--go_out=. \
-		--go-grpc_out=. \
-		--grpc-gateway_out=. \
-		routes.proto
-
-.PHONY: cleanproto
-cleanproto:
-	rm -f $(protofiles)
 
 .PHONY: cleanconfig
 cleanconfig:
@@ -231,7 +212,25 @@ dist: vendor
 
 lint: $(GOLANGCI_LINT)
 
-$(protofiles): $(PROTOC) $(PROTOC_GEN_GRPC_GATEWAY) $(PROTOC_GEN_GO) $(PROTOC_GEN_GO_GRPC)
+protofiles = internal/pkg/api/routes/wwapiv1/routes.pb.go \
+	internal/pkg/api/routes/wwapiv1/routes.pb.gw.go \
+	internal/pkg/api/routes/wwapiv1/routes_grpc.pb.go
+.PHONY: proto
+proto: $(protofiles)
+
+routes_proto = internal/pkg/api/routes/v1/routes.proto
+$(protofiles): $(routes_proto) $(PROTOC) $(PROTOC_GEN_GRPC_GATEWAY) $(PROTOC_GEN_GO) $(PROTOC_GEN_GO_GRPC)
+	PATH=$(TOOLS_BIN):$(PATH) $(PROTOC) \
+		-I /usr/include -I $(shell dirname $(routes_proto)) -I=. \
+		--grpc-gateway_opt logtostderr=true \
+		--go_out=. \
+		--go-grpc_out=. \
+		--grpc-gateway_out=. \
+		routes.proto
+
+.PHONY: cleanproto
+cleanproto:
+	rm -f $(protofiles)
 
 clean: cleanvendor
 endif


### PR DESCRIPTION
Building protocol buffers requires fetching utilities from the Internet. Typically this is done at development time and the finished buffers are included in dist; but if timestamps get off this can lead mock to try to rebuild them during an offline build, causing the build to fail.

This change moves all of the protoc targets into a section of the Makefile that is disabled during an offline build.

- Closes #1155

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
