### PR TITLE
Fix overlay directory location/creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix the issue that warewulf.conf parse does not support CIDR format. #1130
 - Reduce the number of times syncuser walks the container file system. #1209
 - Create ssh key also when calling `wwctl configure --all` #1250
+- Remove the temporary overlay dir. #1180
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Reduce the number of times syncuser walks the container file system. #1209
 - Create ssh key also when calling `wwctl configure --all` #1250
 - Remove the temporary overlay dir. #1180
+- Remove the temporary overlayfs dir and create them besides rootfs #1180
 
 ### Security
 
@@ -70,6 +71,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Allow specification of the ssh-keys to be to be created. #1185
+
+### Changed
+
+- The command `wwctl container exec` locks now this container during execution. #830
 
 ### Fixed
 

--- a/internal/app/wwctl/container/exec/child/main.go
+++ b/internal/app/wwctl/container/exec/child/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
-const exitEval = `$(VALU="$?" ; if [ $VALU == 0 ]; then echo write; else echo discard; fi)`
+const exitEval = `$(VALU="$?" ; if [ $VALU == 0 ]; then echo create new image; else echo no new image; fi)`
 
 func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 	if os.Getpid() != 1 {

--- a/internal/app/wwctl/container/exec/child/root.go
+++ b/internal/app/wwctl/container/exec/child/root.go
@@ -13,16 +13,13 @@ var (
 		Args:                  cobra.MinimumNArgs(1),
 		FParseErrWhitelist:    cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
-	binds      []string
-	nodename   string
-	overlayDir string
+	binds    []string
+	nodename string
 )
 
 func init() {
 	baseCmd.Flags().StringVarP(&nodename, "node", "n", "", "create ro overlay for given node")
 	baseCmd.Flags().StringArrayVarP(&binds, "bind", "b", []string{}, "bind points")
-	baseCmd.Flags().StringVar(&overlayDir, "overlaydir", "", "overlayDir")
-
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/internal/app/wwctl/container/exec/child/root.go
+++ b/internal/app/wwctl/container/exec/child/root.go
@@ -13,13 +13,16 @@ var (
 		Args:                  cobra.MinimumNArgs(1),
 		FParseErrWhitelist:    cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
-	binds    []string
-	nodename string
+	binds      []string
+	nodename   string
+	overlayDir string
 )
 
 func init() {
 	baseCmd.Flags().StringVarP(&nodename, "node", "n", "", "create ro overlay for given node")
 	baseCmd.Flags().StringArrayVarP(&binds, "bind", "b", []string{}, "bind points")
+	baseCmd.Flags().StringVar(&overlayDir, "overlaydir", "", "overlayDir")
+
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/internal/app/wwctl/container/exec/root.go
+++ b/internal/app/wwctl/container/exec/root.go
@@ -25,17 +25,17 @@ var (
 		},
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
-	SyncUser bool
-	binds    []string
-	tempDir  string
-	nodeName string
+	SyncUser   bool
+	binds      []string
+	overlayDir string
+	nodeName   string
 )
 
 func init() {
 	baseCmd.AddCommand(child.GetCommand())
 	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, "Bind a local path into the container (must exist)")
 	baseCmd.PersistentFlags().BoolVar(&SyncUser, "syncuser", false, "Synchronize UIDs/GIDs from host to container")
-	baseCmd.PersistentFlags().StringVar(&tempDir, "tempdir", "", "Use tempdir for constructing the overlay fs (only used if mount points don't exist in container)")
+	baseCmd.PersistentFlags().StringVar(&overlayDir, "overlaydir", "", "Use tempdir for constructing the overlay fs (only used if mount points don't exist in container)")
 	baseCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Create a read only view of the container for the given node")
 }
 

--- a/internal/app/wwctl/container/exec/root.go
+++ b/internal/app/wwctl/container/exec/root.go
@@ -25,17 +25,15 @@ var (
 		},
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
-	SyncUser   bool
-	binds      []string
-	overlayDir string
-	nodeName   string
+	SyncUser bool
+	binds    []string
+	nodeName string
 )
 
 func init() {
 	baseCmd.AddCommand(child.GetCommand())
 	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, "Bind a local path into the container (must exist)")
 	baseCmd.PersistentFlags().BoolVar(&SyncUser, "syncuser", false, "Synchronize UIDs/GIDs from host to container")
-	baseCmd.PersistentFlags().StringVar(&overlayDir, "overlaydir", "", "Use tempdir for constructing the overlay fs (only used if mount points don't exist in container)")
 	baseCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Create a read only view of the container for the given node")
 }
 

--- a/internal/pkg/config/root.go
+++ b/internal/pkg/config/root.go
@@ -42,14 +42,14 @@ type RootConf struct {
 	MountsContainer []*MountEntry `yaml:"container mounts" default:"[{\"source\": \"/etc/resolv.conf\", \"dest\": \"/etc/resolv.conf\"}]"`
 	Paths           *BuildConfig  `yaml:"paths"`
 
-	fromFile bool
+	warewulfconf string
 }
 
 // New caches and returns a new [RootConf] initialized with empty
 // values, clearing replacing any previously cached value.
 func New() *RootConf {
 	cachedConf = RootConf{}
-	cachedConf.fromFile = false
+	cachedConf.warewulfconf = ""
 	cachedConf.Warewulf = new(WarewulfConf)
 	cachedConf.DHCP = new(DHCPConf)
 	cachedConf.TFTP = new(TFTPConf)
@@ -77,12 +77,12 @@ func Get() *RootConf {
 // file.
 func (conf *RootConf) Read(confFileName string) error {
 	wwlog.Debug("Reading warewulf.conf from: %s", confFileName)
+	conf.warewulfconf = confFileName
 	if data, err := os.ReadFile(confFileName); err != nil {
 		return err
 	} else if err := conf.Parse(data); err != nil {
 		return err
 	} else {
-		conf.fromFile = true
 		return nil
 	}
 }
@@ -200,5 +200,9 @@ func (conf *RootConf) SetDynamicDefaults() (err error) {
 // InitializedFromFile returns true if [RootConf] memory was read from
 // a file, or false otherwise.
 func (conf *RootConf) InitializedFromFile() bool {
-	return conf.fromFile
+	return conf.warewulfconf != ""
+}
+
+func (conf *RootConf) GetWarewulfConf() string {
+	return conf.warewulfconf
 }

--- a/internal/pkg/config/root_test.go
+++ b/internal/pkg/config/root_test.go
@@ -67,6 +67,7 @@ func TestInitializedFromFile(t *testing.T) {
 	assert.False(t, conf.InitializedFromFile())
 	assert.NoError(t, conf.Read(tempWarewulfConf.Name()))
 	assert.True(t, conf.InitializedFromFile())
+	assert.Equal(t, conf.GetWarewulfConf(), tempWarewulfConf.Name())
 }
 
 func TestExampleRootConf(t *testing.T) {

--- a/internal/pkg/container/config.go
+++ b/internal/pkg/container/config.go
@@ -33,6 +33,10 @@ func RootFsDir(name string) string {
 	return path.Join(SourceDir(name), "rootfs")
 }
 
+func RunDir(name string) string {
+	return path.Join(SourceDir(name), "run")
+}
+
 func ImageParentDir() string {
 	conf := warewulfconf.Get()
 	return path.Join(conf.Paths.WWProvisiondir, "container/")


### PR DESCRIPTION
- Close #1180
- Close #830
- using the right overlay directory and remove it
- use warewulf.conf from parent on child

The directories for the overlays needed for the bind mount are now created under `conf.Paths.WWChrootdir/$CONTAINERNAME/run`. This directory can be used as lock, so that there can't be congruent shell/exec calls to the same container.
