### PR TITLE
changed typo in the word belonging

### DIFF
--- a/userdocs/contents/containers.rst
+++ b/userdocs/contents/containers.rst
@@ -134,7 +134,7 @@ mismatch, the import command will print out a warning.  By setting the
 ``--syncuser`` flag you advise Warewulf to try to syncronize the users
 from the host to the container, which means that ``/etc/passwd`` and
 ``/etc/group`` of the imported container are updated and all the files
-belonning to these UIDs and GIDs will also be updated.
+belonging to these UIDs and GIDs will also be updated.
 
 A check if the users of the host and container matches can be
 triggered with the ``syncuser`` command.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Changed typo in the word "belonging"


## This fixes or addresses the following GitHub issues:

 - Fixes #


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
