### PR TITLE
Update tagged-release to accommodate new artifact names

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -12,10 +12,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set DIST
-        run: |
-          echo "DIST=warewulf-${GITHUB_REF#refs/tags/v}.tar.gz" >> $GITHUB_ENV
-
       - name: Checkout Code
         uses: actions/checkout@v4
 
@@ -29,16 +25,16 @@ jobs:
           name: spec-and-dist
           path: |
             warewulf.spec
-            ${{ env.DIST }}
+            warewulf-*.tar.gz
 
       - name: Attach dist to release
         uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          file: ${{ env.DIST }}
+          delete_file: "warewulf-*.tar.gz;warewulf-*.rpm"
+          file: warewulf-*.tar.gz
           tags: true
-          draft: true
 
   rpm:
     name: Build RPMs
@@ -57,9 +53,6 @@ jobs:
           - target: rocky+epel-9-x86_64
             arch: x86_64
             dist: el9
-          - target: centos+epel-7-x86_64
-            arch: x86_64
-            dist: el7
           - target: opensuse-leap-15.5-x86_64
             arch: x86_64
             dist: suse.lp155
@@ -76,27 +69,15 @@ jobs:
         with:
           name: spec-and-dist
 
-      - name: Configure the environment
-        run: |
-          VERSION=$(rpm -q --qf "%{VERSION}\n" --specfile warewulf.spec)
-          GENERIC_RELEASE=$(rpm -q --qf "%{RELEASE}\n" --specfile warewulf.spec | sed 's/\.[^.]*$//')
-          RPM=warewulf-${VERSION}-${GENERIC_RELEASE}.${{ matrix.dist }}.${{ matrix.arch }}.rpm
-          SRPM=warewulf-${VERSION}-${GENERIC_RELEASE}.${{ matrix.dist }}.src.rpm
-
-          echo "EXPECTED_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
-          echo "RPM=${RPM}" >> $GITHUB_ENV
-          echo "SRPM=${SRPM}" >> $GITHUB_ENV
-
       - name: Build RPMs and run tests
         run: |
-          mock -r ${{ matrix.target }} --rebuild --spec=warewulf.spec --sources=.
-          mock -r ${{ matrix.target }} --chroot -- make -C /builddir/build/BUILD/warewulf-${{ env.EXPECTED_VERSION }} test
+          mock -r ${{ matrix.target }} --rebuild --spec=warewulf.spec --sources=. \
+          && mock -r ${{ matrix.target }} --chroot -- bash -c "make -C /builddir/build/BUILD/warewulf-*/ test"
 
       - name: Attach RPM and SRPM to release
         uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          file: "/var/lib/mock/${{ matrix.target }}/result/${{ env.RPM }};/var/lib/mock/${{ matrix.target }}/result/${{ env.SRPM }}"
+          file: "/var/lib/mock/${{ matrix.target }}/result/warewulf-*.rpm"
           tags: true
-          draft: true


### PR DESCRIPTION
Dynamic versioning of Warewulf releases broke the release process. This simplifies and fixes finding of release artifacts during tagged-release.

This also removes CentOS 7 as a release target, as previous attempts to fix building on CentOS 7 by omitting the API still failed to run the testsuite.

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
