### PR TITLE
Fetch all history during tagged-release

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Build spec and dist
         run: |


### PR DESCRIPTION
Tags are required during tagged-release, but attempting to fetch only tags caused an error of the form:

```
Cannot fetch both <sha> and refs/tags/<name> to refs/tags/<name>
```

Switching to just downloading all history.