### PR TITLE
Use lightweight tags when generating version

### DIFF
--- a/scripts/get-version.sh
+++ b/scripts/get-version.sh
@@ -32,7 +32,7 @@ fi
 # gitdesc extracts the closest version tag, removing the leading "v" and
 # returning the rest
 gitdesc() {
-	git describe --match='v[0-9]*' --always --candidates=1 "$@" 2>/dev/null |
+	git describe --tags --match='v[0-9]*' --always --candidates=1 "$@" 2>/dev/null |
 	sed -e 's,^v,,'
 }
 


### PR DESCRIPTION
GitHub tags for draft releases are lightweight tags.