### PR TITLE
fix the nightly release build failure

### DIFF
--- a/.github/actions/generate/action.yml
+++ b/.github/actions/generate/action.yml
@@ -2,10 +2,6 @@ name: 'Generate warewulf metadata'
 description: 'Generate warewulf.spec and dist, collect commits info'
 
 inputs:
-  nightly:
-    description: "Whether it is nightly release"
-    required: true
-    default: 'false'
   token:
     description: "Github token"
     required: true
@@ -29,14 +25,15 @@ runs:
   steps:
     - name: Extract current branch tag
       run: |
-        echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        echo "BRANCH=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        echo "TAG=`./script/get-version.sh`" >> $GITHUB_ENV
       shell: bash
 
     - name: Extract last 24 hours commits info
       id: commits
       run: |
-        echo "raw=`git reflog ${{ env.TAG }} --since="24 hours ago"`" >> $GITHUB_OUTPUT
-        echo "commits=`git log ${{ env.TAG }} --pretty --since="24 hours ago"  | jq --raw-input . | jq --slurp . | jq -c .`" >> $GITHUB_OUTPUT
+        echo "raw=`git reflog ${{ env.BRANCH }} --since="24 hours ago"`" >> $GITHUB_OUTPUT
+        echo "commits=`git log ${{ env.BRANCH }} --pretty --since="24 hours ago"  | jq --raw-input . | jq --slurp . | jq -c .`" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Whether should continue
@@ -50,13 +47,13 @@ runs:
       shell: bash
 
     - name: Build spec and dist
-      if: inputs.nightly == 'false' || inputs.nightly == 'true' && steps.should-continue.outputs.continue == 'true'
+      if: steps.should-continue.outputs.continue == 'true'
       run: |
         make warewulf.spec dist
       shell: bash
 
     - name: Set DIST
-      if: inputs.nightly == 'false' || inputs.nightly == 'true' && steps.should-continue.outputs.continue == 'true'
+      if: steps.should-continue.outputs.continue == 'true'
       id: dist
       run: |
         dist="warewulf-${{ env.TAG }}.tar.gz"
@@ -76,30 +73,21 @@ runs:
       shell: bash
 
     - name: Upload warewulf.spec
-      if: inputs.nightly == 'false' || inputs.nightly == 'true' && steps.should-continue.outputs.continue == 'true'
+      if: steps.should-continue.outputs.continue == 'true'
       uses: actions/upload-artifact@v3
       with:
         name: warewulf.spec
         path: warewulf.spec
 
     - name: Upload DIST
-      if: inputs.nightly == 'false' || inputs.nightly == 'true' && steps.should-continue.outputs.continue == 'true'
+      if: steps.should-continue.outputs.continue == 'true'
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.DIST }}
         path: ${{ env.DIST }}
 
-    - name: Normal dist release
-      uses: xresloader/upload-to-github-release@v1
-      if: inputs.nightly == 'false'
-      env:
-        GITHUB_TOKEN: ${{ inputs.token }}
-      with:
-        release_id: ${{ inputs.event-id }}
-        file: ${{ env.DIST }}
-
     - name: Write nightly release content
-      if: inputs.nightly == 'true' && steps.should-continue.outputs.continue == 'true'
+      if: steps.should-continue.outputs.continue == 'true'
       run: |
         cat << EOF >> nightly.release.note
         THIS IS A NIGHTLY RELEASE
@@ -116,7 +104,7 @@ runs:
 
     - name: Nightly dist release
       uses: xresloader/upload-to-github-release@v1
-      if: inputs.nightly == 'true' && steps.should-continue.outputs.continue == 'true'
+      if: steps.should-continue.outputs.continue == 'true'
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       with:
@@ -129,7 +117,7 @@ runs:
         default_release_name: "warewulf nightly release"
 
     - name: Update nightly release content
-      if: inputs.nightly == 'true' && steps.should-continue.outputs.continue == 'true'
+      if: steps.should-continue.outputs.continue == 'true'
       uses: tubone24/update_release@v1.3.1
       id: release
       env:

--- a/.github/actions/rpm/action.yml
+++ b/.github/actions/rpm/action.yml
@@ -52,11 +52,13 @@ runs:
     - name: Set RPM and SRPM
       run: |
         VERSION=$(rpm -q --qf "%{VERSION}\n" --specfile warewulf.spec)
-        GENERIC_RELEASE=$(rpm -q --qf "%{RELEASE}\n" --specfile warewulf.spec | cut -d. -f1-2)
+        GENERIC_RELEASE=$(rpm -q --qf "%{RELEASE}\n" --specfile warewulf.spec | cut -d. -f1)
         RPM=warewulf-${VERSION}-${GENERIC_RELEASE}.${{ inputs.dist }}.${{ inputs.arch }}.rpm
         SRPM=warewulf-${VERSION}-${GENERIC_RELEASE}.${{ inputs.dist }}.src.rpm
+        DRACUT=wareful-dracut-${VERSION}-${GENERIC_RELEASE}.${{ inputs.dist }}.noarch.rpm
         echo "RPM=${RPM}" >> $GITHUB_ENV
         echo "SRPM=${SRPM}" >> $GITHUB_ENV
+        echo "DRACUT=${DRACUT}" >> $GITHUB_ENV
       shell: bash
 
     - name: Build RPMs and run tests
@@ -77,10 +79,18 @@ runs:
         name: ${{ env.SRPM }}
         path: /var/lib/mock/${{ inputs.target }}/result/${{ env.SRPM }}
 
-    - name: Attach RPM and SRPM to release
+    - name: Upload dracut RPM
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.DRACUT }}
+        path: /var/lib/mock/${{ inputs.target }}/result/${{ env.DRACUT }}
+        if-no-files-found: 'ignore'
+
+    - name: Attach all files to release
       uses: xresloader/upload-to-github-release@v1
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       with:
         release_id: ${{ inputs.event-id }}
-        file: "/var/lib/mock/${{ inputs.target }}/result/${{ env.RPM }};/var/lib/mock/${{ inputs.target }}/result/${{ env.SRPM }}"
+        file: " warewulf-${{ env.EXPECTED_VERSION }}.tar.gz;/var/lib/mock/${{ inputs.target }}/result/${{ env.RPM }};/var/lib/mock/${{ inputs.target }}/result/${{ env.SRPM }};/var/lib/mock/${{ inputs.target }}/result/${{ env.DRACUT }}"
+        overwrite: true

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -14,17 +14,16 @@ jobs:
           should-continue: ${{ steps.generate.outputs.should-continue }}
           version: ${{ steps.generate.outputs.version }}
           release-id: ${{ steps.generate.outputs.release-id }}
-        permissions: write-all # might not be used for realy deployment
+        permissions: write-all
         steps:
           - name: Checkout Code
             uses: actions/checkout@v4
             with:
-              ref: 'main'
+              fetch-depth: 0
           - uses: ./.github/actions/generate
             name: generate warewulf spec, dist and collect commits info
             id: generate
             with:
-              nightly: 'true'
               token: ${{ secrets.GITHUB_TOKEN }}
               event-id: ${{ github.event.release.id }}
 
@@ -46,19 +45,16 @@ jobs:
               - target: rocky+epel-9-x86_64
                 arch: x86_64
                 dist: el9
-              - target: centos+epel-7-x86_64
-                arch: x86_64
-                dist: el7
               - target: opensuse-leap-15.5-x86_64
                 arch: x86_64
                 dist: suse.lp155
-        permissions: write-all # might not be used for realy deployment
+        permissions: write-all
 
         steps:
           - name: Checkout Code
             uses: actions/checkout@v4
             with:
-              ref: 'main'
+              fetch-depth: 0
           - uses: ./.github/actions/rpm
             name: build rpms
             id: rpm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `/sys/firmware/devicetree/base/serial-number`
 - Replace slice in templates with sprig substr. #1093
 
+## v4.5.2, unreleased
+
+### Fixed
+
+- Fix nightly release build failure issue. #1195
+
 ## v4.5.1, 2024-04-30
 
 ### Added


### PR DESCRIPTION
## Description of the Pull Request (PR):

`$(rpm -q --qf "%{RELEASE}\n" --specfile warewulf.spec` now returns a slightly changed release info, causing the failure of nightly build failure. Also we need to remove the old centos 7 build. 


## This fixes or addresses the following GitHub issues:

 - Fixes #1195


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)

### Test

Build on my repo
![image](https://github.com/warewulf/warewulf/assets/2051711/60a1acb8-d377-49a7-8677-c9e6dab89f49)