### PR TITLE
Reorder dnsmasq config template to put iPXE last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fix nightly release build failure issue. #1195
+- Reorder dnsmasq config to put iPXE last. #1146
 
 ## v4.5.1, 2024-04-30
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -33,3 +33,4 @@
 * Dietmar Rieder <dietmar.rieder@i-med.ac.at>
 * Andreas Henkel <henkel@uni-mainz.de>
 * Timothy Middelkoop <tmiddelkoop@internet2.edu>
+* Shane Nehring <snehring@iastate.edu>

--- a/overlays/host/rootfs/etc/dnsmasq.d/ww4-hosts.conf.ww
+++ b/overlays/host/rootfs/etc/dnsmasq.d/ww4-hosts.conf.ww
@@ -15,8 +15,6 @@ dhcp-vendorclass=set:efi-http,HTTPClient:Arch:00016
 dhcp-option-force=tag:efi-http,60,HTTPClient
 # for http boot always use shim/grub
 dhcp-boot=tag:efi-http,"http://{{$.Ipaddr}}:{{$.Warewulf.Port}}/efiboot/shim.efi"
-# iPXE binary will get the following configuration file
-dhcp-boot=tag:iPXE,"http://{{$.Ipaddr}}:{{$.Warewulf.Port}}/ipxe/${mac:hexhyp}"
 {{- if $.Warewulf.GrubBoot }}
 dhcp-boot=tag:x86PC,"warewulf/shim.efi"
 {{- else }}
@@ -27,6 +25,8 @@ dhcp-boot=tag:x86PC,"/warewulf/{{ index $.Tftp.IpxeBinaries "00:07" }}"
 dhcp-boot=tag:aarch64,"/warewulf/{{ index $.Tftp.IpxeBinaries "00:0B" }}"
 {{- end }}
 {{- end }}
+# iPXE binary will get the following configuration file
+dhcp-boot=tag:iPXE,"http://{{$.Ipaddr}}:{{$.Warewulf.Port}}/ipxe/${mac:hexhyp}"
 dhcp-no-override
 {{- if $.Tftp.Enabled }}
 # also act as tftp server


### PR DESCRIPTION

Dnsmasq seems to use the most recently applied configuration to a client. If you opt to use dnsmasq as is, what happens is the client just boots infinitely continually grabbing the ipxe image instead of the second stage.

Fixes #1146
