### PR TITLE
Fix parsing of /etc/group during syncuser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix a locking issue with concurrent read/writes for node status. #1174
 - Fix shim and grub detection for aarch64. #1145
 - wwctl [profile|node] list -a handles now slices correclty. #1113
+- Fix parsing of /etc/group during syncuser. #1202
 
 ## 4.5.0, 2024-02-08
 

--- a/internal/pkg/container/syncuids.go
+++ b/internal/pkg/container/syncuids.go
@@ -166,8 +166,8 @@ func (db syncDB) read(fileName string, fromContainer bool) error {
 		for fileScanner.Scan() {
 			line := fileScanner.Text()
 			fields := strings.Split(line, ":")
-			if len(fields) != 7 {
-				wwlog.Debug("malformed line in passwd: %s", line)
+			if len(fields) != 7 && len(fields) != 4 {
+				wwlog.Debug("malformed line in passwd/group: %s", line)
 				continue
 			}
 			name := fields[0]


### PR DESCRIPTION
## Description of the Pull Request (PR):

A previous fix for #527 broke parsing of /etc/group. This PR allows parsing of both /etc/passwd and /etc/group.

## This fixes or addresses the following GitHub issues:

- Fixes #1202


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
