### PR TITLE
Only walk the filesystem during syncuser if writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Dynamically calculate version and release from Git. #1162
 - Update quickstarts to configure firewalld for dhcp. #1133
 - Omit building the API on EL7. #1171
+- Syncuser only walks the file system if it is going to write. #1207
 
 ### Fixed
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

syncuser walks the container file system to see what files need to be updated; but in the past this has been done regardless of whether syncuser is actually running in write mode. Since walking the file system isn't necessary to determine if syncuser is warranted, only walk when writing.

This prevents an unnecessary and otherwise unavoidable file system walk when importing a new container, which, for large containers, can add significant wait time.

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
