### PR TITLE
Refactor syncuser to reduce walks of the container fs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Replace reference to docusaurus with Sphinx
+- `wwctl container import` now only runs syncuser if explicitly requested. #1212
 
 ### Fixed
 
 - Block unprivileged requests for arbitrary overlays in secure mode. #1215
 - Fix installation docs to use github.com/warewulf instead of github.com/hpcng. #1219
 - Fix the issue that warewulf.conf parse does not support CIDR format. #1130
+- Reduce the number of times syncuser walks the container file system. #1209
 
 ### Security
 

--- a/internal/app/wwctl/container/exec/main.go
+++ b/internal/app/wwctl/container/exec/main.go
@@ -121,7 +121,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 	wwlog.Debug("group: %v", time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec)))
 	if syncuids && SyncUser {
-		err = container.SyncUids(containerName, true)
+		err = container.SyncUids(containerName, false)
 		if err != nil {
 			wwlog.Error("Error in user sync, fix error and run 'syncuser' manually, but trying to build container: %s", err)
 		}

--- a/internal/app/wwctl/container/syncuser/main.go
+++ b/internal/app/wwctl/container/syncuser/main.go
@@ -16,7 +16,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	if !container.ValidName(containerName) {
 		return fmt.Errorf("%s is not a valid container", containerName)
 	}
-	err := container.SyncUids(containerName, !write)
+	err := container.SyncUids(containerName, write)
 	if err != nil {
 		wwlog.Error("Error in synchronize: %s", err)
 		os.Exit(1)

--- a/internal/pkg/api/container/container.go
+++ b/internal/pkg/api/container/container.go
@@ -231,12 +231,11 @@ func ContainerImport(cip *wwapiv1.ContainerImportParameter) (containerName strin
 		return
 	}
 
-	SyncUserShowOnly := !cip.SyncUser
-	err = container.SyncUids(cip.Name, SyncUserShowOnly)
-	if err != nil {
-		err = fmt.Errorf("error in user sync, fix error and run 'syncuser' manually: %s", err)
-		wwlog.Error(err.Error())
-		if cip.SyncUser {
+	if cip.SyncUser {
+		err = container.SyncUids(cip.Name, true)
+		if err != nil {
+			err = fmt.Errorf("error in user sync, fix error and run 'syncuser' manually: %s", err)
+			wwlog.Error(err.Error())
 			return
 		}
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR refactors syncuser to only walk the container fs twice: once for user changes and once for group changes. The previous implementation of syncuser walked the container file system for every user and group being sync'd. This caused syncuser to take a very long time when large images were combined with large user/group counts.

This PR also changes the (internal) semantics of syncuser to consistently use a "write" boolean throughout, rather than "write" in some places and "showOnly" in others.

To reduce some frequently-observed confusion, `wwctl container import` has been adjusted to only run syncuser if `--syncuser` is specified, rather than always running it in "showOnly" mode when `--syncuser=false`. This eliminates a spurious "error" report for users who do not intend to use syncuser.

## This fixes or addresses the following GitHub issues:

- Closes #1209

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
