### PR TITLE
Document HTTP proxy environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Document warewulf.conf:paths. #635
-- New "Overlay" template variable contains the name of the overlay being built. #1052  
+- New "Overlay" template variable contains the name of the overlay being built. #1052 
+- Documented HTTP proxy environment variables for `wwctl container import`. #1214
 
 ### Changed
 

--- a/userdocs/contents/containers.rst
+++ b/userdocs/contents/containers.rst
@@ -125,6 +125,26 @@ directly.
    $ apptainer build --sandbox ./rockylinux-8/ docker://ghcr.io/warewulf/warewulf-rockylinux:8
    $ sudo wwctl container import ./rockylinux-8/ rockylinux-8
 
+HTTP proxies
+------------
+
+You can set ``HTTP_PROXY``, ``HTTPS_PROXY``, and ``NO_PROXY`` (or their
+lower-case versions) to use a proxy during ``wwctl container import``.
+
+.. code-block:: shell
+
+   export HTTPS_PROXY=squid.localdomain
+   wwctl conatiner import docker://ghcr.io/warewulf/warewulf-rockylinux:8
+
+See ProxyFromEnvironment_ For more information.
+
+.. _ProxyFromEnvironment: https://pkg.go.dev/net/http#ProxyFromEnvironment
+
+.. note::
+
+   OCI and ORAS registries typically use HTTPS, so you probably need to set
+   ``HTTPS_PROXY`` or ``https_proxy`` rather than the ``HTTP`` variants.
+
 Syncuser
 ========
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

`wwctl container import` can use `HTTP_PROXY` et al to configure an HTTP proxy. This PR adds some documentation about this support.

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
