### PR TITLE
Point to warewulf github in installation docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Replace reference to docusaurus with Sphinx
 
+### Fixed
+
+- Fix installation docs to use github.com/warewulf instead of github.com/hpcng. #1219
+
 ### Security
 
 - Bump golang.org/x/net from 0.22.0 to 0.23.0. #1223

--- a/userdocs/contents/installation.rst
+++ b/userdocs/contents/installation.rst
@@ -87,7 +87,7 @@ tag.
 
 .. code-block:: bash
 
-   git clone https://github.com/hpcng/warewulf.git
+   git clone https://github.com/warewulf/warewulf.git
    cd warewulf
    git checkout development # or switch to a tag like 'v4.5.2'
    make all && sudo make install


### PR DESCRIPTION
- **Point URL to warewulf github instead of hpcng.**
- **Update CHANGELOG.md for this PR.**
