### PR TITLE
Adjusts services open file limit to match systemd precedence

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -53,3 +53,4 @@
 - Karker Said <said.karker@gmail.com> [@kosmolito](https://github.com/kosmolito)
 - Jason Scott <jsco2t@outlook.com> @jsco2t
 - Sujeev Uthayakumar <sujeev.uthayakumar@gmail.com> [@Sujeev-Uthayakumar](https://github.com/Sujeev-Uthayakumar)
+- Jacob Sommerville <jsommerville@dow.com>

--- a/include/systemd/warewulfd.service.in
+++ b/include/systemd/warewulfd.service.in
@@ -11,6 +11,7 @@ User=root
 Group=root
 ExecStart=@BINDIR@/wwctl server $OPTIONS
 ExecReload=/bin/kill -HUP "$MAINPID"
+LimitNOFILE=524288
 Restart=always
 
 [Install]


### PR DESCRIPTION
## Description of the Pull Request (PR):

If you have 1000s of nodes and many files you may run into the issue of hitting the warewulfd service's open file limits. This small change to the systemd unit file will effectively double the number of open files that the service can have open and is in line with systemd precedence of setting services to a high file limit of 512*1024. 

Reference:
[Systemd high nofile limit](https://github.com/search?q=repo%3Asystemd%2Fsystemd%20HIGH_RLIMIT_NOFILE&type=code)
[How to set limits for services in RHEL and systemd](https://access.redhat.com/solutions/1257953)


## This fixes or addresses the following GitHub issues:

 - Had a discussion about this on the Slack channel but I'd be happy to open an issue about it.

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
