### PR TITLE
fix the issue that new files created via `wwctl overlay edit` have permission 755

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `/sys/firmware/devicetree/base/serial-number`
 - Replace slice in templates with sprig substr. #1093
 
+## v4.5.x, unreleased
+
+### Fixed
+
+- Fix the issue that new files created with wwctl overlay edit have 755 permissions. #1236
+
 ## v4.5.3, unreleased
 
 ### Added

--- a/internal/app/wwctl/overlay/edit/main.go
+++ b/internal/app/wwctl/overlay/edit/main.go
@@ -49,7 +49,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	overlayFileDir := path.Dir(overlayFile)
 	if CreateDirs {
-		err := os.MkdirAll(overlayFileDir, 0755)
+		err := os.MkdirAll(overlayFileDir, os.FileMode(PermMode))
 		if err != nil {
 			wwlog.Error("Could not create directory: %s", overlayFileDir)
 			os.Exit(1)
@@ -122,7 +122,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	destination, destinationErr := os.OpenFile(overlayFile, os.O_RDWR|os.O_CREATE, os.FileMode(PermMode))
+	destination, destinationErr := os.OpenFile(overlayFile, os.O_RDWR|os.O_CREATE, os.FileMode(0644))
 	if destinationErr != nil {
 		wwlog.Error("Unable to update %s: %s", overlayFile, destinationErr)
 		os.Exit(1)


### PR DESCRIPTION
## Description of the Pull Request (PR):

fix the issue that new files created via `wwctl overlay edit` have permission 755

## This fixes or addresses the following GitHub issues:

 - Fixes #1236


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)

## Test
```
[root@localhost warewulf]# wwctl --debug overlay edit debug newfile
DEBUG  : Set log level to: 10, DEBUG
DEBUG  : Reading warewulf.conf from: /usr/local/etc/warewulf/warewulf.conf
DEBUG  : Checking if path exists as a directory: /var/local/warewulf/overlays/debug/rootfs
DEBUG  : Will edit overlay file: /var/local/warewulf/overlays/debug/rootfs/newfile
DEBUG  : Checking if path exists as a directory: /var/local/warewulf/overlays/debug/rootfs
DEBUG  : Using temporary file /tmp/ww-overlay-edit-2979261049
DEBUG  : Checking if path exists as a file: /var/local/warewulf/overlays/debug/rootfs/newfile
DEBUG  : ExecInteractive(/bin/vi, [/tmp/ww-overlay-edit-2979261049])
DEBUG  : Copy /tmp/ww-overlay-edit-2979261049 to /var/local/warewulf/overlays/debug/rootfs/newfile
[root@localhost warewulf]# ls -al /var/local/warewulf/overlays/debug/rootfs/newfile 
-rw-r--r--. 1 root root 10 Jun  6 01:33 /var/local/warewulf/overlays/debug/rootfs/newfile
```