### PR TITLE
fix the issue that new files created via wwctl overlay edit have permission 755 && removing lines during wwctl overlay edit didn't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix dhcp not passing asset tag or uuid to iPXE. #1110
 - Restored previous static dhcp behavior. #1263
 - Capture "broken" symlinks during container build. #1267
+- Fix the issue that removing lines during wwctl overlay edit didn't work. #1235
+- Fix the issue that new files created with wwctl overlay edit have 755 permissions. #1236
 
 ## v4.5.4, 2024-06-12
 

--- a/internal/app/wwctl/overlay/edit/main.go
+++ b/internal/app/wwctl/overlay/edit/main.go
@@ -105,13 +105,6 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	tempFileReader, tempFileErr := os.Open(tempFile.Name())
-	if tempFileErr != nil {
-		wwlog.Error("Unable to open %s: %s", tempFile.Name(), tempFileErr)
-		os.Exit(1)
-	}
-	defer tempFileReader.Close()
-
 	if fileInfo, err := os.Stat(tempFile.Name()); err != nil {
 		wwlog.Error("Unable to stat %s: %s", tempFile.Name(), err)
 		os.Exit(1)
@@ -122,16 +115,9 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	destination, destinationErr := os.OpenFile(overlayFile, os.O_RDWR|os.O_CREATE, os.FileMode(PermMode))
-	if destinationErr != nil {
-		wwlog.Error("Unable to update %s: %s", overlayFile, destinationErr)
-		os.Exit(1)
-	}
-	defer destination.Close()
-
-	wwlog.Debug("Copy %s to %s", tempFileReader.Name(), destination.Name())
-	if _, copyErr := io.Copy(destination, tempFileReader); copyErr != nil {
-		wwlog.Error("Unable to update %s: %s", destination.Name(), copyErr)
+	err := os.Rename(tempFile.Name(), overlayFile)
+	if err != nil {
+		wwlog.Error("Unable to update %s: %s", overlayFile, err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

It looks like this PR can fix two issues at the same time. (issue #1235 and issue #1236)
By directly doing `os.Rename` from temp file created each time for the edit to the targeted overlay file, we can solve the both issues at the same time. 

## This fixes or addresses the following GitHub issues:

 - Fixes #1235 
 - Fixes #1236 

## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)

## Test
https://github.com/warewulf/warewulf/assets/2051711/bbad7ebc-1a6e-40bb-a167-2b64b1c3ceb5