### PR TITLE
run go mod tidy after go mod vendor

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -29,3 +29,7 @@ runs:
     - name: Prepare vendor directory
       run: make vendor
       shell: bash
+
+    - name: Run go mod tidy
+      run: make tidy
+      shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `wwctl container import` now only runs syncuser if explicitly requested. #1212
 - wwinit now configures NetworkManager to not retain configurations from dracut. #1115
 - Improved detection of SELinux capable root fs #1093
+- Run `go mod tidy` after `go mod vendor`
 
 ### Fixed
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Some PRs require the `go mod tidy` after `go mod vendor`
See: https://github.com/warewulf/warewulf/actions/runs/9412139832/job/25926760773?pr=1217


## This fixes or addresses the following GitHub issues:

 - Fixes #


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
