### PR TITLE
fix the issue that system/runtime overlays are not auto-rebuilt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix a regression that caused an error when passing flags to `wwctl container exec` and `wwctl container shell`. #1250
 
+## v4.5.x, unreleased
+
+### Fixed
+
+- Fix the issue that system/runtime overlays are not auto-rebuilt. #1216
+
 ## v4.5.3, 2024-06-07
 
 ### Added

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -127,9 +127,10 @@ func OverlayInit(overlayName string) error {
 Build the given overlays for a node and create a Image for them
 */
 func BuildOverlay(nodeInfo node.NodeInfo, context string, overlayNames []string) error {
-	if len(overlayNames) == 0 {
+	if len(overlayNames) == 0 && context == "" {
 		return nil
 	}
+
 	// create the dir where the overlay images will reside
 	name := fmt.Sprintf("overlay %s/%v", nodeInfo.Id.Get(), overlayNames)
 	overlayImage := OverlayImage(nodeInfo.Id.Get(), context, overlayNames)

--- a/internal/pkg/overlay/overlay_test.go
+++ b/internal/pkg/overlay/overlay_test.go
@@ -40,11 +40,11 @@ var buildOverlayTests = []struct {
 		contents:    nil,
 	},
 	{
-		description: "if only context is specified then no overlay image is generated",
+		description: "if only context is specified then context named image is generated",
 		nodeName:    "",
 		context:     "system",
 		overlays:    nil,
-		image:       "",
+		image:       "__SYSTEM__.img",
 		contents:    nil,
 	},
 	{
@@ -80,19 +80,19 @@ var buildOverlayTests = []struct {
 		contents:    []string{"o1.txt", "o2.txt"},
 	},
 	{
-		description: "if no node system overlays are specified, then no overlay image is generated",
+		description: "if no node system overlays are specified, then context pointed overlay is generated",
 		nodeName:    "node1",
 		context:     "system",
 		overlays:    nil,
-		image:       "",
+		image:       "node1/__SYSTEM__.img",
 		contents:    nil,
 	},
 	{
-		description: "if no node runtime overlays are specified, then no overlay image is generated",
+		description: "if no node runtime overlays are specified, then context pointed overlay is generated",
 		nodeName:    "node1",
 		context:     "runtime",
 		overlays:    nil,
-		image:       "",
+		image:       "node1/__RUNTIME__.img",
 		contents:    nil,
 	},
 	{
@@ -147,9 +147,6 @@ func Test_BuildOverlay(t *testing.T) {
 	}
 
 	for _, tt := range buildOverlayTests {
-		assert.True(t, (tt.image != "" && tt.contents != nil) || (tt.image == "" && tt.contents == nil),
-			"image and contents must eiher be populated or empty together")
-
 		nodeInfo := node.NodeInfo{}
 		nodeInfo.Id.Set(tt.nodeName)
 		t.Run(tt.description, func(t *testing.T) {
@@ -196,18 +193,18 @@ var buildAllOverlaysTests = []struct {
 		createdOverlays: nil,
 	},
 	{
-		description:     "a node with no overlays creates no overlays",
+		description:     "a node with no overlays creates default system/runtime overlays",
 		nodes:           []string{"node1"},
-		systemOverlays:  nil,
-		runtimeOverlays: nil,
-		createdOverlays: nil,
+		systemOverlays:  [][]string{{"o1"}},
+		runtimeOverlays: [][]string{{"o1"}},
+		createdOverlays: []string{"node1/__SYSTEM__.img.gz", "node1/__RUNTIME__.img.gz"},
 	},
 	{
-		description:     "multiple nodes with no overlays creates no overlays",
+		description:     "multiple nodes with no overlays creates default system/runtime overlays",
 		nodes:           []string{"node1", "node2"},
-		systemOverlays:  nil,
-		runtimeOverlays: nil,
-		createdOverlays: nil,
+		systemOverlays:  [][]string{{"o1"}, {"o2"}},
+		runtimeOverlays: [][]string{{"o1"}, {"o2"}},
+		createdOverlays: []string{"node1/__SYSTEM__.img.gz", "node1/__RUNTIME__.img.gz", "node2/__SYSTEM__.img.gz", "node2/__RUNTIME__.img.gz"},
 	},
 	{
 		description:     "a system overlay for a node generates a system overlay for that node",


### PR DESCRIPTION
## Description of the Pull Request (PR):

The root cause of this mentioned issue is that 
https://github.com/warewulf/warewulf/blob/a0bec6bf60125bcdd52350fd99935f07259c8441/internal/pkg/overlay/overlay.go#L130
`overlayNames` var is empty when calling with url mentioned in the following issue ticket.
So in this PR, we've added building system/runtime overlay specified by context


## This fixes or addresses the following GitHub issues:

 - Fixes #1216
 - Fixed #1240 


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)

## Test
Does not send overlay request parameters won't cause this issue any longer. 
```
[root@localhost warewulf]# curl -v --local-port 500-1000 'http://localhost:9873/provision/11:22:33:44:55:66?stage=runtime'
*   Trying 127.0.0.1:9873...
* Local port: 500
* Connected to localhost (127.0.0.1) port 9873 (#0)
> GET /provision/11:22:33:44:55:66?stage=runtime HTTP/1.1
> Host: localhost:9873
> User-Agent: curl/7.76.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Accept-Ranges: bytes
< Content-Length: 6144
< Content-Type: application/x-raw-disk-image
< Last-Modified: Mon, 10 Jun 2024 08:46:52 GMT
< Date: Mon, 10 Jun 2024 08:56:59 GMT
< 
Warning: Binary output can mess up your terminal. Use "--output -" to tell 
Warning: curl to output it to your terminal anyway, or consider "--output 
Warning: <FILE>" to save to a file.
* Failure writing output to destination
* Closing connection 0
[root@localhost warewulf]# cat /var/log/warewulfd.log 
[Mon Jun 10 08:40:01 UTC 2024] RECV   : hwaddr: 11:22:33:44:55:66, ipaddr: 127.0.0.1:500, stage: runtime
[Mon Jun 10 08:40:01 UTC 2024] SEND   : ---------- context: runtime, stage_overlays: [], build: true
[Mon Jun 10 08:40:01 UTC 2024] SERV   : stage_file '/var/local/warewulf/provision/overlays/n1/__RUNTIME__.img'
[Mon Jun 10 08:40:01 UTC 2024] ERROR  : Not found: /var/local/warewulf/provision/overlays/n1/__RUNTIME__.img
[Mon Jun 10 08:56:59 UTC 2024] RECV   : hwaddr: 11:22:33:44:55:66, ipaddr: 127.0.0.1:500, stage: runtime
[Mon Jun 10 08:56:59 UTC 2024] SERV   : stage_file '/var/local/warewulf/provision/overlays/n1/__RUNTIME__.img'
[Mon Jun 10 08:56:59 UTC 2024] SEND   :              n1: /var/local/warewulf/provision/overlays/n1/__RUNTIME__.img
```
