### PR TITLE
Restore previous behavior of static dhcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix a regression in overlay autobuild. #1216
 - Fix wwclient not reading asset-tag. #1110
 - Fix dhcp not passing asset tag or uuid to iPXE. #1110
+- Restored previous static dhcp behavior. #1263
 
 ## v4.5.4, 2024-06-12
 

--- a/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
+++ b/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
@@ -51,8 +51,10 @@ if exists user-class and option user-class = "iPXE" {
 
 subnet {{$.Network}} netmask {{$.Netmask}} {
     max-lease-time 120;
+{{- if ne .Dhcp.Template "static" }}
     range {{$.Dhcp.RangeStart}} {{$.Dhcp.RangeEnd}};
     next-server {{.Ipaddr}};
+{{- end }}
 }
 
 {{- if eq .Dhcp.Template "static" }}
@@ -60,20 +62,19 @@ subnet {{$.Network}} netmask {{$.Netmask}} {
 {{- range $netname, $netdevs := $nodes.NetDevs}}
 host {{$nodes.Id.Get}}-{{$netname}}
 {
-    {{- if $netdevs.Primary.GetB}}
     {{- if $netdevs.Hwaddr.Defined}}
     hardware ethernet {{$netdevs.Hwaddr.Get}};
     {{- end }}
     {{- if $netdevs.Ipaddr.Defined}}
     fixed-address {{$netdevs.Ipaddr.Get}};
     {{- end }}
+    {{- if $netdevs.Primary.GetB}}
     option host-name "{{$nodes.Id.Get}}";
     {{- end }}
 }
 {{end -}}{{/* range NetDevs */}}
 {{end -}}{{/* range AllNodes */}}
 {{end -}}{{/* if static */}}
-
 {{- else}}
 {{abort}}
 {{- end}}{{/* dhcp enabled */}}


### PR DESCRIPTION
## Description of the Pull Request (PR):

- Disable dynamic pool when using static dhcp
- Populate configuration of non-primary interfaces for static dhcp

This behavior appears to have been changed somewhat accidentally during the implementation of GRUB booting.

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
