### PR TITLE
Add support for tagged VLAN interfaces and static routes to NM

### DIFF
--- a/overlays/wwinit/rootfs/etc/NetworkManager/system-connections/ww4-managed.ww
+++ b/overlays/wwinit/rootfs/etc/NetworkManager/system-connections/ww4-managed.ww
@@ -8,6 +8,8 @@
 # Host:   {{ $host }}
 # Time:   {{ $time }}
 # Source: {{ $source }}
+
+# Connection
 [connection]
 id={{ $connection_id }}
 interface-name={{ $netdev.Device }}
@@ -18,12 +20,14 @@ slave-type=bond
 {{- $master := $conn._0 }}
 master={{ $master }}
 type=ethernet
-{{ else }}
+{{ else -}}
 type={{ $netdev.Type }}
 autoconnect=true
 {{ end -}}
+{{ "" }}
 {{ end -}}
 
+# Ethernet
 {{ if $netdev.Hwaddr -}}
 {{ if eq $netdev.Type "ethernet" -}}
 [ethernet]
@@ -32,32 +36,45 @@ mac-address={{ $netdev.Hwaddr }}
 mtu={{ $netdev.MTU }}
 {{ end -}}
 {{ end -}}
+{{ "" }}
 {{ end -}}
 
-# bond
+# Bond
 {{ if eq $netdev.Type "bond" -}}
 [ethernet]
 {{ if $netdev.MTU -}}
 mtu={{ $netdev.MTU }}
 {{ end -}}
-
+{{ "" }}
 [bond]
 downdelay=0
 miimon=100
 mode=802.3ad
 xmit_hash_policy=layer2+3
 updelay=0
-
+{{ "" }}
 {{ end -}}
 
+# Infiniband
 {{ if eq $netdev.Type "infiniband" -}}
 [infiniband]
 transport-mode=datagram
 {{ if $netdev.MTU -}}
 mtu={{ $netdev.MTU }}
 {{ end -}}
+{{ "" }}
 {{ end -}}
 
+# VLAN
+{{ if eq $netdev.Type "vlan" -}}
+[vlan]
+interface-name={{ $netdev.Device }}
+parent={{ $netdev.Tags.parent_device }}
+id={{ $netdev.Tags.vlan_id }}
+{{ "" }}
+{{ end -}}
+
+# IPv4
 {{ if and ($netdev.IpCIDR) (ne $netdev.Type "bond-slave") -}}
 [ipv4]
 address={{ $netdev.IpCIDR }}
@@ -67,16 +84,21 @@ gateway={{ $netdev.Gateway }}
 method=manual
 {{- $dns := "" }}
 {{range $tk, $tv := $netdev.Tags -}}
-{{ $prefix := substr 0 3 $tk -}}
+{{ $prefix := slice $tk 0 3 -}}
 {{ if eq $prefix "DNS" -}}
 {{ $dns = print $dns $tv ";" -}}
 {{ end -}}
 {{ end -}}
-{{ if ne $dns "" -}}
-dns={{$dns}}
+{{ if ne $dns "" }}dns={{$dns}}{{ end -}}
 {{ end -}}
+{{range $tk, $tv := $netdev.Tags -}}
+{{ if ge (len $tk) 5 -}}
+{{ $prefix := slice $tk 0 5 -}}
+{{ if eq $prefix "route" }}{{$tk}}={{$tv}}{{ end }}
 {{ end -}}
+{{ end }}
 
+# IPv6
 {{/* always autoconfigure ipv6 */}}
 [ipv6]
 addr-gen-mode=stable-privacy

--- a/overlays/wwinit/rootfs/etc/wicked/ifconfig/ifcfg.xml.ww
+++ b/overlays/wwinit/rootfs/etc/wicked/ifconfig/ifcfg.xml.ww
@@ -13,7 +13,15 @@ Source: {{ $source }}
 <interface origin="static generated warewulf config">
   <name>{{$netdev.Device}}</name>
   {{ if $netdev.Type -}}
+  {{ if eq $netdev.Type "vlan" -}}
+  <vlan>
+    <device> {{ $netdev.Tags.parent_device }} </device>
+    <tag> {{ $netdev.Tags.vlan_id }} </tag>
+    <protocol>ieee802-1Q</protocol>
+  </vlan>
+  {{ else -}}
   <link-type>{{ $netdev.Type }}</link-type>
+  {{ end -}}
   {{ end -}}
   {{ if $netdev.MTU -}}
   <mtu>{{ $netdev.MTU }}</mtu>

--- a/userdocs/contents/nodeconfig.rst
+++ b/userdocs/contents/nodeconfig.rst
@@ -256,6 +256,24 @@ You will have provide all the necessary network information.
      --type infiniband \
      n001
 
+VLAN
+----
+
+You can set the type also to `vlan`. This settings needs the two
+additional network tags `vlan_id` and `parent_device` and is only 
+supported for wicked and NetworkManager.
+
+.. code-block:: shell
+
+   wwctl node set \
+     --netdev vlan42 \
+     --ipaddr 10.0.42.1 \
+     --netmask 255.255.252.0 \
+     --netname iband \
+     --type vlan \
+     --nettagadd "vlan_id=42,parent_device=eth0" \
+     n001
+
 
 Node Discovery
 --------------


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add support for tagged VLAN interfaces and static routes to NM by adding a new "vlan" device type and tags to specify vlan ID, parent device and static route definitions. Example `nodes.conf` configuration:

```
    network devices:
      untagged:
        primary: true
        device: eth0
      tagged:
        primary: false
        type: vlan
        device: eth0.902
        tags:
          vlan_id: 902
          parent_device: eth0
          route1: "192.168.1.0/24,192.168.2.254"
```

## This fixes or addresses the following GitHub issues:

 - Closes #1257

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
