### PR TITLE
Fix excludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `/sys/firmware/devicetree/base/serial-number`
 - Replace slice in templates with sprig substr. #1093
 - Fix an invalid format issue for the GitHub nightly build action. #1258
+- Fix broken `/etc/warewulf/excludes` handling #1266
 
 ## v4.5.4, 2024-06-12
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,3 +34,4 @@
 * Andreas Henkel <henkel@uni-mainz.de>
 * Timothy Middelkoop <tmiddelkoop@internet2.edu>
 * Shane Nehring <snehring@iastate.edu>
+* Tobias Ribizel <mail@ribizel.de>

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -260,6 +260,10 @@ func FindFilterFiles(
 	ignorePattern []string,
 	ignore_xdev bool) (ofiles []string, err error) {
 	wwlog.Debug("Finding files: %s include: %s ignore: %s", path, includePattern, ignorePattern)
+	// preprocess patterns to remove leading (and trailing) /, as we are handling relative paths
+	for i, pattern := range ignorePattern {
+		ignorePattern[i] = strings.Trim(pattern, "/")
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		return ofiles, err
@@ -319,6 +323,7 @@ func FindFilterFiles(
 				}
 				for _, ignored_pat := range ignorePattern {
 					if ignored, _ := filepath.Match(ignored_pat, location); ignored {
+						wwlog.Debug("Ignored %s due to pattern %s", location, ignored_pat)
 						return filepath.SkipDir
 					}
 				}

--- a/internal/pkg/util/util_test.go
+++ b/internal/pkg/util/util_test.go
@@ -1,0 +1,50 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/warewulf/warewulf/internal/pkg/wwlog"
+)
+
+func TryCreatePath(t *testing.T, elem ...string) {
+	err := os.MkdirAll(filepath.Join(elem...), os.ModePerm)
+	if err != nil {
+		t.Errorf("Failed creating dir: %v", err)
+		t.FailNow()
+	}
+}
+
+func Test_FindFilterFiles(t *testing.T) {
+	wwlog.SetLogLevel(wwlog.DEBUG)
+	dir, err := os.MkdirTemp(os.TempDir(), "warewulf-test")
+	if err != nil {
+		t.Errorf("Failed creating tmpdir: %v", err)
+		t.FailNow()
+	}
+	defer os.RemoveAll(dir)
+	TryCreatePath(t, dir, "boot")
+	TryCreatePath(t, dir, "usr", "local")
+	TryCreatePath(t, dir, "usr", "bin")
+	TryCreatePath(t, dir, "usr", "usr", "local")
+	TryCreatePath(t, dir, "bin")
+	TryCreatePath(t, dir, "lib")
+
+	files, err := FindFilterFiles(dir, []string{"boot", "usr", "bin"}, []string{"/b*/", "/usr/local"}, true)
+
+	if err != nil {
+		t.Errorf("FindFilerFiles failed: %v", err)
+		t.FailNow()
+	}
+
+	expected := []string{"usr", "usr/bin", "usr/usr", "usr/usr/local"}
+	sort.Strings(expected)
+	sort.Strings(files)
+	if !reflect.DeepEqual(files, expected) {
+		t.Errorf("expected %v, got %v", expected, files)
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

The `/etc/warewulf/excludes` file is currently broken in two ways: It doesn't work correctly with either leading or trailing slashes. This is due to the underlying `FindFilterFiles` function relying on string comparisons via `filepath.Match`, which don't allow trailing slashes in the patterns, and the fact that we are using relative paths, which makes the leading slash incorrect as well. This PR fixes the issues and adds a test to prevent regressions in the future.

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
