### PR TITLE
Accept + within kernel versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Explicitly ignore compat-style NIS lines in passwd/group during syncuser. #1286
+- Accept `+` within kernel version. #1268
 
 ## v4.5.4, 2024-06-12
 

--- a/internal/pkg/kernel/kernel.go
+++ b/internal/pkg/kernel/kernel.go
@@ -252,7 +252,7 @@ func FindKernel(root string) (kPath string, version string, err error) {
 		}
 		for _, foundKernel := range potentialKernel {
 			wwlog.Debug("Parsing out kernel version for %s", foundKernel)
-			re := regexp.MustCompile(fmt.Sprintf(path.Join(root, searchPath), `([\w\d-\.]*)`))
+			re := regexp.MustCompile(fmt.Sprintf(path.Join(root, searchPath), `([\w\d-\.+]*)`))
 			version := re.FindAllStringSubmatch(foundKernel, -1)
 			if version == nil {
 				return foundKernel, "", fmt.Errorf("could not parse kernel version")

--- a/internal/pkg/kernel/kernel_test.go
+++ b/internal/pkg/kernel/kernel_test.go
@@ -19,30 +19,29 @@ var kernelBuildTests = []struct {
 }{
 	{"4.3.2.1", "kernel1", "vmlinuz-1.2.3.4.gz", false},
 	{"1.2.3.4", "kernel1", "vmlinuz-1.2.3.4.gz", true},
+	{"1.2+3+4", "kernel1", "vmlinuz-1.2+3+4.gz", true},
 }
 
 func Test_BuildKernel(t *testing.T) {
 	wwlog.SetLogLevel(wwlog.DEBUG)
-	srvDir, err := os.MkdirTemp(os.TempDir(), "ww-test-srv-*")
-	assert.NoError(t, err)
-	defer os.RemoveAll(srvDir)
-	conf := warewulfconf.Get()
-	conf.Paths.WWProvisiondir = srvDir
-	kernelDir, err := os.MkdirTemp(os.TempDir(), "ww-test-kernel-*")
-	assert.NoError(t, err)
-	defer os.RemoveAll(kernelDir)
-	{
-		err = os.MkdirAll(path.Join(kernelDir, "boot"), 0755)
+	for _, tt := range kernelBuildTests {
+		srvDir, err := os.MkdirTemp(os.TempDir(), "ww-test-srv-*")
 		assert.NoError(t, err)
-		err = os.MkdirAll(path.Join(kernelDir, "lib/modules/old-kernel"), 0755)
+		conf := warewulfconf.Get()
+		conf.Paths.WWProvisiondir = srvDir
+		kernelDir, err := os.MkdirTemp(os.TempDir(), "ww-test-kernel-*")
 		assert.NoError(t, err)
-		_, err = os.Create(path.Join(kernelDir, "lib/modules/old-kernel/old-module"))
-		assert.NoError(t, err)
-		err = os.MkdirAll(path.Join(kernelDir, "lib/firmware"), 0755)
-		assert.NoError(t, err)
-		_, err = os.Create(path.Join(kernelDir, "lib/firmware/test-firmware"))
-		assert.NoError(t, err)
-		for _, tt := range kernelBuildTests {
+		{
+			err = os.MkdirAll(path.Join(kernelDir, "boot"), 0755)
+			assert.NoError(t, err)
+			err = os.MkdirAll(path.Join(kernelDir, "lib/modules/old-kernel"), 0755)
+			assert.NoError(t, err)
+			_, err = os.Create(path.Join(kernelDir, "lib/modules/old-kernel/old-module"))
+			assert.NoError(t, err)
+			err = os.MkdirAll(path.Join(kernelDir, "lib/firmware"), 0755)
+			assert.NoError(t, err)
+			_, err = os.Create(path.Join(kernelDir, "lib/firmware/test-firmware"))
+			assert.NoError(t, err)
 			_, err = os.Create(path.Join(kernelDir, "boot", tt.kernelFileName))
 			assert.NoError(t, err)
 			err = os.MkdirAll(path.Join(kernelDir, "lib/modules", tt.kernelVersion, "/nested"), 0755)
@@ -52,8 +51,6 @@ func Test_BuildKernel(t *testing.T) {
 			err = os.Symlink(path.Join(kernelDir, "lib/modules/old-kernel/old-module"), path.Join(kernelDir, "lib/modules", tt.kernelVersion, "symlink-module"))
 			assert.NoError(t, err)
 		}
-	}
-	for _, tt := range kernelBuildTests {
 		t.Run(tt.kernelName, func(t *testing.T) {
 			err = Build(tt.kernelVersion, tt.kernelName, kernelDir)
 			if tt.succeed {
@@ -63,10 +60,16 @@ func Test_BuildKernel(t *testing.T) {
 				assert.FileExists(t, path.Join(srvDir, "kernel", tt.kernelName, "kmods.img"))
 				files, err := util.CpioFiles(path.Join(srvDir, "kernel", tt.kernelName, "kmods.img"))
 				assert.NoError(t, err)
-				assert.ElementsMatch(t, files, []string{"lib/firmware/test-firmware", "lib/modules/1.2.3.4/symlink-module", "lib/modules/1.2.3.4/test-module", "lib/modules/1.2.3.4/nested"})
+				assert.ElementsMatch(t, files, []string{
+					"lib/firmware/test-firmware",
+					"lib/modules/" + tt.kernelVersion + "/symlink-module",
+					"lib/modules/" + tt.kernelVersion + "/test-module",
+					"lib/modules/" + tt.kernelVersion + "/nested"})
 			} else {
 				assert.Error(t, err)
 			}
 		})
+		os.RemoveAll(srvDir)
+		os.RemoveAll(kernelDir)
 	}
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Accept `+` within kernel release version strings.

`kernel-64k` from the Rocky9 repos has a kernel release of `5.14.0-427.18.1.el9_4.aarch64+64k` which doesn't match the pattern Warewulf currently checks.

```bash
# wwctl -d kernel import -C test_arm -D
DEBUG  : Set log level to: 10, DEBUG
DEBUG  : Reading warewulf.conf from: /etc/warewulf/warewulf.conf
DEBUG  : Checking if path exists as a directory: /var/lib/warewulf/chroots/test_arm/rootfs
DEBUG  : root: /var/lib/warewulf/chroots/test_arm/rootfs
DEBUG  : Looking for kernel version with pattern at: /var/lib/warewulf/chroots/test_arm/rootfs/boot/Image-*
DEBUG  : Looking for kernel version with pattern at: /var/lib/warewulf/chroots/test_arm/rootfs/boot/vmlinuz-linux
DEBUG  : Looking for kernel version with pattern at: /var/lib/warewulf/chroots/test_arm/rootfs/boot/vmlinuz-*
DEBUG  : Looking for kernel version with pattern at: /var/lib/warewulf/chroots/test_arm/rootfs/boot/vmlinuz-*.gz
DEBUG  : Looking for kernel version with pattern at: /var/lib/warewulf/chroots/test_arm/rootfs/lib/modules/*/vmlinuz
DEBUG  : Parsing out kernel version for /var/lib/warewulf/chroots/test_arm/rootfs/lib/modules/5.14.0-427.18.1.el9_4.aarch64+64k/vmlinuz
ERROR: could not parse kernel version

STACK TRACE: could not parse kernel version
```


## This fixes or addresses the following GitHub issues:

 - Fixes #


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
