### PR TITLE
Dracut boot refinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix the issue that removing lines during wwctl overlay edit didn't work. #1235
 - Fix the issue that new files created with wwctl overlay edit have 755 permissions. #1236
 - Mount `/sys` and `/run` during `wwctl container exec`. #1287
+- Fix dracut booting with secure mode #1261
 
 ### Changed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,3 +35,4 @@
 * Timothy Middelkoop <tmiddelkoop@internet2.edu>
 * Shane Nehring <snehring@iastate.edu>
 * Tobias Ribizel <mail@ribizel.de>
+* Josh Burks <jeburks2@asu.edu>

--- a/dracut/modules.d/90wwinit/load-wwinit.sh
+++ b/dracut/modules.d/90wwinit/load-wwinit.sh
@@ -8,6 +8,8 @@ do
     if [ -n "${archive}" ]
     then
         info "Loading ${archive}"
-        (curl --silent -L "${archive}" | gzip -d | cpio -im --directory="${NEWROOT}") || die "Unable to load ${archive}"
+	#Load only runtime overlays from a static privledge port
+        [[ "$archive" == *"runtime"* ]] && localport="--local-port 986" || localport=""
+        (curl --silent $localport -L "${archive}" | gzip -d | cpio -im --directory="${NEWROOT}") || die "Unable to load ${archive}"
     fi
 done

--- a/dracut/modules.d/90wwinit/module-setup.sh
+++ b/dracut/modules.d/90wwinit/module-setup.sh
@@ -14,7 +14,7 @@ depends() {
 }
 
 install() {
-    inst_multiple cpio curl
+    inst_multiple cpio curl dmidecode
     inst_hook cmdline 30 "$moddir/parse-wwinit.sh"
     inst_hook pre-mount 30 "$moddir/load-wwinit.sh"
 }

--- a/dracut/modules.d/90wwinit/parse-wwinit.sh
+++ b/dracut/modules.d/90wwinit/parse-wwinit.sh
@@ -6,10 +6,12 @@
 if [ "${root}" = "wwinit" ]
 then
     info "root=${root}"
-    export wwinit_container=$(getarg wwinit.container=); info "wwinit.container=${wwinit_container}"
-    export wwinit_system=$(getarg wwinit.system=); info "wwinit.system=${wwinit_system}"
-    export wwinit_runtime=$(getarg wwinit.runtime=); info "wwinit.runtime=${wwinit_runtime}"
-    export wwinit_kmods=$(getarg wwinit.kmods=); info "wwinit.kmods=${wwinit_kmods}"
+    export wwinit_uri="http://$(getarg wwinit.uri)/provision/$(getarg wwid)?assetkey=$(dmidecode -s chassis-asset-tag)&uuid=$(dmidecode -s system-uuid)&stage="
+    export wwinit_container="${wwinit_uri}container&compress=gz"; info "wwinit.container=${wwinit_container}"
+    export wwinit_system="${wwinit_uri}system&compress=gz"; info "wwinit.system=${wwinit_system}"
+    export wwinit_runtime="${wwinit_uri}runtime&compress=gz"; info "wwinit.runtime=${wwinit_runtime}"
+    wwinit_kmods_passed=$(getarg wwinit.kmods=)
+    [ -n "$wwinit_kmods_passed" ] && export wwinit_kmods="${wwinit_uri}kmods&compress=gz"; info "wwinit.kmods=${wwinit_kmods}"
 
     wwinit_tmpfs_size=$(getarg wwinit.tmpfs.size=)
     if [ -n "$wwinit_tmpfs_size" ]

--- a/etc/ipxe/dracut.ipxe
+++ b/etc/ipxe/dracut.ipxe
@@ -29,7 +29,7 @@ echo Downloading initramfs
 initrd --name initramfs ${uri}&stage=initramfs || goto reboot
 
 set dracut_net rd.neednet=1 {{range $devname, $netdev := .NetDevs}}{{if and $netdev.Hwaddr $netdev.Device}} ifname={{$netdev.Device}}:{{$netdev.Hwaddr}} {{end}}{{end}}
-set dracut_wwinit root=wwinit wwinit.container=${uri}&stage=container&compress=gz wwinit.system=${uri}&stage=system&compress=gz wwinit.runtime=${uri}&stage=runtime&compress=gz {{if ne .KernelOverride ""}}wwinit.kmods=${uri}&stage=kmods&compress=gz{{end}} init=/init
+set dracut_wwinit root=wwinit wwinit_uri={{.Ipaddr}}:{{.Port}} {{if ne .KernelOverride ""}}wwinit.kmods=true{{end}} init=/init
 
 echo Booting initramfs
 #echo Network KernelArgs: ${dracut_net}

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -91,6 +91,9 @@ Requires: dracut
 %else
 Requires: dracut-network
 %endif
+Requires: curl
+Requires: cpio
+Requires: dmidecode
 
 %description dracut
 Warewulf is a stateless and diskless container operating system provisioning
@@ -210,6 +213,9 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 
 
 %changelog
+* Tue Jun 18 2024 Josh Burks <jeburks2@asu.edu>
+- Add curl, cpio, dmidecode as requires for warewulf-dracut
+
 * Thu Apr 18 2024 Jonathon Anderson <janderson@ciq.com>
 - New warewulf-dracut subpackage
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

The new dracut boot method bloated /proc/cmdline, and exposed asset-tag and uuid to unprivileged users. This PR moves the parsing of dracut URIs from iPXE to the dracut script pase-wwinit.sh, using dmidecode to obtain asset-tag and uuid, leaving only the IP and port of the warewulf server in /proc/cmdline. 

Additionally, it forces runtime overlays to be pulled from a static local port (986) to allow dracut boot to be used with secure mode. Port 986 is used instead of 987 to prevent a race condition of the system releasing the port before wwclient starts and tries to bind to 987. 

Lastly, add the required curl, cpio and now dmidecode packages to warewulf.spec for warewulf-dracut subpackage 

## This fixes or addresses the following GitHub issues:

 - Fixes #1261 


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
