### PR TITLE
Asset-tag fixes in dhcpd.conf.ww and wwclient 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Replace slice in templates with sprig substr. #1093
 - Fix an invalid format issue for the GitHub nightly build action. #1258
 - Fix broken `/etc/warewulf/excludes` handling #1266
+- Fix wwclient not reading asset-tag. #1110
 
 ## v4.5.4, 2024-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix an invalid format issue for the GitHub nightly build action. #1258
 - Fix broken `/etc/warewulf/excludes` handling #1266
 - Fix wwclient not reading asset-tag. #1110
+- Fix iPXE script not including asset-tag #1110
 
 ## v4.5.4, 2024-06-12
 

--- a/internal/app/wwclient/root.go
+++ b/internal/app/wwclient/root.go
@@ -126,6 +126,15 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 		localUUID, _ = sysinfoDump.UUID()
 		x := smbiosDump.SystemEnclosure()
 		tag = strings.ReplaceAll(x.AssetTagNumber(), " ", "_")
+		if tag == "Unknown" {
+			dmiOut, err := exec.Command("dmidecode", "-s", "chassis-asset-tag").Output()
+			if err == nil {
+				chassisAssetTag := strings.TrimSpace(string(dmiOut))
+				if chassisAssetTag != "" {
+					tag = chassisAssetTag
+				}
+			}
+		}
 	} else {
 		// Raspberry Pi serial and DUID locations
 		// /sys/firmware/devicetree/base/serial-number

--- a/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
+++ b/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
@@ -39,7 +39,7 @@ if substring (option vendor-class-identifier, 0, 9) = "PXEClient" {
 }
 {{- else }}
 if exists user-class and option user-class = "iPXE" {
-    filename "http://{{$.Ipaddr}}:{{$.Warewulf.Port}}/ipxe/${mac:hexhyp}";
+    filename "http://{{$.Ipaddr}}:{{$.Warewulf.Port}}/ipxe/${mac:hexhyp}?assetkey=${asset}&uuid=${uuid}"";
 } else {
 {{range $type,$name := $.Tftp.IpxeBinaries }}
     if option architecture-type = {{ $type }} {

--- a/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
+++ b/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
@@ -39,7 +39,7 @@ if substring (option vendor-class-identifier, 0, 9) = "PXEClient" {
 }
 {{- else }}
 if exists user-class and option user-class = "iPXE" {
-    filename "http://{{$.Ipaddr}}:{{$.Warewulf.Port}}/ipxe/${mac:hexhyp}?assetkey=${asset}&uuid=${uuid}"";
+    filename "http://{{$.Ipaddr}}:{{$.Warewulf.Port}}/ipxe/${mac:hexhyp}?assetkey=${asset}&uuid=${uuid}";
 } else {
 {{range $type,$name := $.Tftp.IpxeBinaries }}
     if option architecture-type = {{ $type }} {

--- a/overlays/host/rootfs/etc/dnsmasq.d/ww4-hosts.conf.ww
+++ b/overlays/host/rootfs/etc/dnsmasq.d/ww4-hosts.conf.ww
@@ -26,7 +26,7 @@ dhcp-boot=tag:aarch64,"/warewulf/{{ index $.Tftp.IpxeBinaries "00:0B" }}"
 {{- end }}
 {{- end }}
 # iPXE binary will get the following configuration file
-dhcp-boot=tag:iPXE,"http://{{$.Ipaddr}}:{{$.Warewulf.Port}}/ipxe/${mac:hexhyp}"
+dhcp-boot=tag:iPXE,"http://{{$.Ipaddr}}:{{$.Warewulf.Port}}/ipxe/${mac:hexhyp}?assetkey=${asset}&uuid=${uuid}"
 dhcp-no-override
 {{- if $.Tftp.Enabled }}
 # also act as tftp server


### PR DESCRIPTION
## Description of the Pull Request (PR):

The default dhcpd.conf.ww in the host overlay does not pass the asset-tag to the next-server filename, this adds the asset-tag and uuid to the filename parameter to allow nodes to boot with asset-tags configured. 

This also update enables wwclient to utilize dmidecode for retrieving the node asset tag when the SMBIOS does not provide a valid asset tag. This enhancement requires that dmidecode be installed within the container. If dmidecode is not installed, wwclient will continue to operate, but the asset tag may default to "Unknown". An alternative approach could involve reading from the kernel file system at /sys/devices/virtual/dmi/id/chassis-asset-tag. However, the consistency of this path across different kernel versions is uncertain.

## This fixes or addresses the following GitHub issues:

 - Fixes #1110


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
