### PR TITLE
Capture "broken" symlinks during container build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix wwclient not reading asset-tag. #1110
 - Fix iPXE script not including asset-tag #1110
 
+## v4.5.6, unreleased
+
+### Fixed
+
+- Capture "broken" symlinks during container buildA. #1267
+
 ## v4.5.4, 2024-06-12
 
 ### Fixed

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -297,11 +297,8 @@ func FindFilterFiles(
 	dev := path_stat.Sys().(*syscall.Stat_t).Dev
 	for _, inc := range globedInclude {
 		wwlog.Debug("inc %s", inc)
-		stat, err := os.Stat(inc)
-		if os.IsNotExist(err) {
-			// there may be broken softlinks
-			continue
-		} else if err != nil {
+		stat, err := os.Lstat(inc)
+		if err != nil {
 			return ofiles, err
 		}
 		if stat.IsDir() {

--- a/internal/pkg/util/util_test.go
+++ b/internal/pkg/util/util_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
@@ -33,14 +34,16 @@ func Test_FindFilterFiles(t *testing.T) {
 	TryCreatePath(t, dir, "bin")
 	TryCreatePath(t, dir, "lib")
 
-	files, err := FindFilterFiles(dir, []string{"boot", "usr", "bin"}, []string{"/b*/", "/usr/local"}, true)
+	assert.NoError(t, os.Symlink("/path/to/target", filepath.Join(dir, "symlink")))
+
+	files, err := FindFilterFiles(dir, []string{"boot", "usr", "bin", "symlink"}, []string{"/b*/", "/usr/local"}, true)
 
 	if err != nil {
 		t.Errorf("FindFilerFiles failed: %v", err)
 		t.FailNow()
 	}
 
-	expected := []string{"usr", "usr/bin", "usr/usr", "usr/usr/local"}
+	expected := []string{"usr", "usr/bin", "usr/usr", "usr/usr/local", "symlink"}
 	sort.Strings(expected)
 	sort.Strings(files)
 	if !reflect.DeepEqual(files, expected) {


### PR DESCRIPTION
## Description of the Pull Request (PR):

The use of `os.Stat` caused `FindFilterFiles` to look at symlink targets rather than symlinks themselves. This made it impossible to include a dangling symlink in a container image.

This PR uses `os.Lstat` to inspect symlinks directly.

## This fixes or addresses the following GitHub issues:

- Fixes #1267


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
