### PR TITLE
ignore +:: style lines in passwd/group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix the issue that new files created with wwctl overlay edit have 755 permissions. #1236
 - Mount `/sys` and `/run` during `wwctl container exec`. #1287
 
+### Changed
+
+- Ignore +:::: lines in passwd/group during syncuser. #1286
+
 ## v4.5.4, 2024-06-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Ignore +:::: lines in passwd/group during syncuser. #1286
+- Explicitly ignore compat-style NIS lines in passwd/group during syncuser. #1286
 
 ## v4.5.4, 2024-06-12
 

--- a/internal/pkg/container/syncuids.go
+++ b/internal/pkg/container/syncuids.go
@@ -177,7 +177,8 @@ func (db syncDB) read(fileName string, fromContainer bool) error {
 				continue
 			}
 			// ignore ldap/nis/sssd line
-			if fields[0] == "+" {
+			if strings.HasPrefix(fields[0], "+") || strings.HasPrefix(fields[0], "-") {
+				wwlog.Verbose("Ignoring line %s (unhandled compat-style NIS reference)", line)
 				continue
 			}
 			id, err := strconv.Atoi(fields[2])

--- a/internal/pkg/container/syncuids.go
+++ b/internal/pkg/container/syncuids.go
@@ -176,13 +176,15 @@ func (db syncDB) read(fileName string, fromContainer bool) error {
 			if name == "" {
 				continue
 			}
-
+			// ignore ldap/nis/sssd line
+			if fields[0] == "+" {
+				continue
+			}
 			id, err := strconv.Atoi(fields[2])
 			if err != nil {
 				wwlog.Warn("Ignoring line %s (parse error)", line)
 				continue
 			}
-
 			entry, ok := db[name]
 			if !ok {
 				entry = syncInfo{HostID: -1, ContainerID: -1}

--- a/internal/pkg/container/syncuids_test.go
+++ b/internal/pkg/container/syncuids_test.go
@@ -275,11 +275,13 @@ func Test_network_passwd(t *testing.T) {
 	buf := new(bytes.Buffer)
 	wwlog.SetLogWriter(buf)
 	hostInput := `testuser1:x:1001:1001::/home/testuser:/bin/bash
-+::::::`
++::::::
+-::::::`
 	hostFileName := writeTempFile(t, hostInput)
 	defer os.Remove(hostFileName)
 	db := make(syncDB)
 	err := db.readFromHost(hostFileName)
 	assert.NotContains(t, buf.String(), "parse error")
+	assert.Contains(t, buf.String(), "Ignoring line")
 	assert.NoError(t, err)
 }

--- a/internal/pkg/container/syncuids_test.go
+++ b/internal/pkg/container/syncuids_test.go
@@ -1,10 +1,12 @@
 package container
 
 import (
+	"bytes"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
 func writeTempFile(t *testing.T, input string) string {
@@ -266,5 +268,18 @@ func Test_malformed_passwd(t *testing.T) {
 	defer os.Remove(hostFileName)
 	db := make(syncDB)
 	err := db.readFromHost(hostFileName)
+	assert.NoError(t, err)
+}
+
+func Test_network_passwd(t *testing.T) {
+	buf := new(bytes.Buffer)
+	wwlog.SetLogWriter(buf)
+	hostInput := `testuser1:x:1001:1001::/home/testuser:/bin/bash
++::::::`
+	hostFileName := writeTempFile(t, hostInput)
+	defer os.Remove(hostFileName)
+	db := make(syncDB)
+	err := db.readFromHost(hostFileName)
+	assert.NotContains(t, buf.String(), "parse error")
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
The lines +::::: or +::: are used in passwd/group as
placeholer for users added form the network via ldap/nis/sssd.
These lines should not trigger a warning.
