### PR TITLE
mount /sys on exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add multiple output formats (yaml & json) support. #447
 - More aliases for many wwctl commands
 - Add support to render template using `host` or `$(uname -n)` as the value of `overlay show --render`. #623
+- Also mount `/sys` into container for `wwctl container exec`
 
 ### Changed
 

--- a/internal/app/wwctl/container/exec/child/main.go
+++ b/internal/app/wwctl/container/exec/child/main.go
@@ -139,6 +139,10 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "failed to mount /dev")
 	}
+	err = syscall.Mount("/sys", path.Join(containerPath, "/sys"), "", syscall.MS_BIND, "")
+	if err != nil {
+		return errors.Wrap(err, "failed to mount /sys")
+	}
 
 	for _, mntPnt := range mountPts {
 		err = syscall.Mount(mntPnt.Source, path.Join(containerPath, mntPnt.Dest), "", syscall.MS_BIND, "")


### PR DESCRIPTION
SUSEConnect need `/sys` to be present in the container
for telemetry reasons. As `/dev/` is mounted we can also
mount `/sys`
