### PR TITLE
Fix grub asset key handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   on unused/unmanaged network interfaces.
 - Systems with no SMBIOS (Raspberry Pi) will create a UUID from
   `/sys/firmware/devicetree/base/serial-number`
+- Grub chainload and main configs correctly extract smbios asset key
+  for node authentication
 - Replace slice in templates with sprig substr. #1093
 - Fix an invalid format issue for the GitHub nightly build action. #1258
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,4 +37,4 @@
 * Tobias Ribizel <mail@ribizel.de>
 * Tobias Poschwatta <poschwatta@zib.de>
 * Josh Burks <jeburks2@asu.edu>
-* Elmar Pruessee <pruessee@njhealth.org>
+* Elmar Pruesse <pruessee@njhealth.org> @epruesse

--- a/etc/grub/chainload.ww
+++ b/etc/grub/chainload.ww
@@ -5,14 +5,15 @@
 echo "================================================================================"
 echo "Warewulf v4 now iXPE booting with grub"
 echo "================================================================================"
+smbios --type 3 --get-string 8 --set assetkey
 set timeout=2
 # Must chainload in order to get kernel args for specific node
 menuentry "Load specific configfile" {
-    conf="(http,{{.Ipaddr}}:{{.Warewulf.Port}})/efiboot/grub.cfg"
+    conf="(http,{{.Ipaddr}}:{{.Warewulf.Port}})/efiboot/grub.cfg?assetkey=${assetkey}"
     configfile $conf
 }
 menuentry "Chainload shim of container" {
-    shim="(http,{{.Ipaddr}}:{{.Warewulf.Port}})/efiboot/shim.efi"
+    shim="(http,{{.Ipaddr}}:{{.Warewulf.Port}})/efiboot/shim.efi?assetkey=${assetkey}"
     chainloader ${shim}
 }
 menuentry "UEFI Firmware Settings" --id "uefi-firmware" {

--- a/etc/grub/grub.cfg.ww
+++ b/etc/grub/grub.cfg.ww
@@ -6,7 +6,7 @@ echo
 echo "Warewulf Controller: {{.Ipaddr}}"
 echo
 sleep 1
-smbios --type1 --get-string 8 --set assetkey
+smbios --type 3 --get-string 8 --set assetkey
 
 uri="(http,{{.Ipaddr}}:{{.Port}})/provision/${net_default_mac}?assetkey=${assetkey}"
 kernel="${uri}&stage=kernel"
@@ -70,7 +70,7 @@ menuentry "Network boot node with dracut: {{.Id}}" --id dracut {
 }
 
 menuentry "Chainload specific configfile" {
-    conf="(http,{{.Ipaddr}}:{{.Port}})/efiboot/grub.cfg"
+    conf="(http,{{.Ipaddr}}:{{.Port}})/efiboot/grub.cfg?assetkey=${assetkey}"
     configfile $conf
 }
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

This fixes asset key retrieval in the rendered grub.cfg and adds it to the chainload grub.cfg, allowing asset key based grub boot to work. 

- `--type1` should be `--type 1`
- The `chassis-asset-tag` (as used elsewhere), is not in the type 1 tabke, but in the type 3 table. 
- If an asset tag is listed in the node config, it is checked by wwctl server on all requests, so everything using `(http,<ip:port)` must also use `?assetkey=${assetkey}`, including fetching the templated grub.cfg. 

Note that this is not a full fix. The grub.efi files supplied with Rocky 9.4 do not include the `smbios` command! This has been the case for many years, apparently. I have used a Debian box to run `grub2-makenetdir`, generating a working grub efi.

With that, it is now working.

For testing, you can add an asset key to a KVM VM like this:

```
qm set $VMID --args "-smbios type=3,asset=$KEY"
```


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
