### PR TITLE
mount /sys and /run during container exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Capture "broken" symlinks during container build. #1267
 - Fix the issue that removing lines during wwctl overlay edit didn't work. #1235
 - Fix the issue that new files created with wwctl overlay edit have 755 permissions. #1236
+- Mount `/sys` and `/run` during `wwctl container exec`. #1287
 
 ## v4.5.4, 2024-06-12
 

--- a/internal/app/wwctl/container/exec/child/main.go
+++ b/internal/app/wwctl/container/exec/child/main.go
@@ -135,11 +135,6 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	err = syscall.Mount("/dev", path.Join(containerPath, "/dev"), "", syscall.MS_BIND, "")
-	if err != nil {
-		return errors.Wrap(err, "failed to mount /dev")
-	}
-
 	for _, mntPnt := range mountPts {
 		err = syscall.Mount(mntPnt.Source, path.Join(containerPath, mntPnt.Dest), "", syscall.MS_BIND, "")
 		if err != nil {
@@ -166,9 +161,17 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 		return errors.Wrap(err, "failed to chdir")
 	}
 
-	err = syscall.Mount("/proc", "/proc", "proc", 0, "")
-	if err != nil {
-		return errors.Wrap(err, "failed to mount proc")
+	if err := syscall.Mount("devtmpfs", "/dev", "devtmpfs", 0, ""); err != nil {
+		return errors.Wrap(err, "failed to mount /dev")
+	}
+	if err := syscall.Mount("sysfs", "/sys", "sysfs", 0, ""); err != nil {
+		return errors.Wrap(err, "failed to mount /sys")
+	}
+	if err := syscall.Mount("proc", "/proc", "proc", 0, ""); err != nil {
+		return errors.Wrap(err, "failed to mount /proc")
+	}
+	if err := syscall.Mount("tmpfs", "/run", "tmpfs", 0, ""); err != nil {
+		return errors.Wrap(err, "failed to mount /run")
 	}
 
 	os.Setenv("PS1", ps1Str)


### PR DESCRIPTION
Also unify mounting of sys, run, proc, and dev as occuring within the chroot and without bind mounts from the host.

## Description of the Pull Request (PR):

mount /sys and /run during container exec.

Also unify mounting of sys, run, proc, and dev as occuring within the chroot and without bind mounts from the host.

## This fixes or addresses the following GitHub issues:

 - Replaces #1287


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
