### PR TITLE
Prevent make dist from including previous dists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ init:
 dist:
 	rm -rf .dist/ $(WAREWULF)-$(VERSION).tar.gz
 	mkdir -p .dist/$(WAREWULF)-$(VERSION)
-	rsync -a --exclude=".github"  --exclude=".vscode" --exclude "*~" * .dist/$(WAREWULF)-$(VERSION)/
+	rsync -a --exclude=".github"  --exclude=".vscode" --exclude "*~" --exclude $(WAREWULF)-*.tar.gz * .dist/$(WAREWULF)-$(VERSION)/
 	scripts/get-version.sh >.dist/$(WAREWULF)-$(VERSION)/VERSION
 	cd .dist; tar -czf ../$(WAREWULF)-$(VERSION).tar.gz $(WAREWULF)-$(VERSION)
 	rm -rf .dist


### PR DESCRIPTION
## Description of the Pull Request (PR):

`make dist` may accidentially include previously-made dist tarballs; this change adjusts the target to exclude these tarballs from the dist.

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
