### PR TITLE
add to built overlays to automatic overlay build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `/sys/firmware/devicetree/base/serial-number`
 - Replace slice in templates with sprig substr. #1093
 - Fix an invalid format issue for the GitHub nightly build action. #1258
+- Automatic building of system and runtime overlays weren't working as #1249 just fixed the build, but the overlays were empty
 
 ## v4.5.5, 2024-07-05
 

--- a/internal/pkg/warewulfd/provision.go
+++ b/internal/pkg/warewulfd/provision.go
@@ -145,6 +145,12 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 			request_overlays = strings.Split(rinfo.overlay, ",")
 		} else {
 			context = rinfo.stage
+			switch context {
+			case "system":
+				request_overlays = node.SystemOverlay.GetSlice()
+			case "runtime":
+				request_overlays = node.RuntimeOverlay.GetSlice()
+			}
 		}
 		stage_file, err = getOverlayFile(
 			node,


### PR DESCRIPTION
After PR #1249 fixed the issue that overlays weren't rebuilt, the issues from #1216 and #1240 remained and were even worse, as the overlays
were rebuilt, but *empty*. This is fixed with this PR.

Signed-off-by: Christian Goll <cgoll@suse.com>
