### PR TITLE
removed dead `boot method` from defaults.conf

### DIFF
--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -31,7 +31,6 @@ defaultnode:
   init: /sbin/init
   root: initramfs
   ipxe template: default
-  boot method: ipxe
   profiles:
   - default
   network devices:


### PR DESCRIPTION
dead code removal

Signed-off-by: Christian Goll <cgoll@suse.com>
