### PR TITLE
Ensure autobuilt overlays include contextual overlay contents.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Replace slice in templates with sprig substr. #1093
 - Fix an invalid format issue for the GitHub nightly build action. #1258
 
+## v4.5.6, unreleased
+
+### Fixed
+
+- Ensure autobuilt overlays include contextual overlay contents. #1296
+
 ## v4.5.5, 2024-07-05
 
 ### Fixed

--- a/internal/pkg/warewulfd/util.go
+++ b/internal/pkg/warewulfd/util.go
@@ -63,7 +63,11 @@ func getOverlayFile(
 	}
 
 	if build {
-		err = overlay.BuildOverlay(n, context, stage_overlays)
+		if len(stage_overlays) > 0 {
+			err = overlay.BuildSpecificOverlays([]node.NodeInfo{n}, stage_overlays)
+		} else {
+			err = overlay.BuildAllOverlays([]node.NodeInfo{n})
+		}
 		if err != nil {
 			wwlog.Error("Failed to build overlay: %s, %s, %s\n%s",
 				n.Id.Get(), stage_overlays, stage_file, err)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Following #1249, autobuilt overlays were being built with no contents.

This change follows the pattern in `wwctl overlay build` to include configured overlays when none are explicitly specified.

Inspired by #1296.

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
