### PR TITLE
create soft links from overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `wwctl <node|profile> <add|set> --kernelversion` to specify the desired kernel version or path. #1556
 - Add `wwctl container kernels` to list discovered kernels from containers. #1556
 - Add possibility to define a softlink target with an overlay template
+- Support defining a symlink with an overlay template. #1303
+- New "localtime" overlay to define the system time zone. #1303
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Document "known issues."
 - Add `wwctl <node|profile> <add|set> --kernelversion` to specify the desired kernel version or path. #1556
 - Add `wwctl container kernels` to list discovered kernels from containers. #1556
+- Add possibility to define a softlink target with an overlay template
 
 ### Changed
 

--- a/internal/pkg/overlay/funcmap.go
+++ b/internal/pkg/overlay/funcmap.go
@@ -125,10 +125,14 @@ func createIgnitionJson(node *node.Node) string {
 }
 
 func importSoftlink(lnk string) string {
-	path, err := filepath.EvalSymlinks(lnk)
+	target, err := filepath.EvalSymlinks(lnk)
 	if err != nil {
 		return "abort"
 	}
-	wwlog.Debug("importing softlink pointing to: %s", path)
-	return fmt.Sprintf("{{ /* softlink \"%s\" */ }}", path)
+	wwlog.Debug("importing softlink pointing to: %s", target)
+	return softlink(target)
+}
+
+func softlink(target string) string {
+	return fmt.Sprintf("{{ /* softlink \"%s\" */ }}", target)
 }

--- a/internal/pkg/overlay/funcmap.go
+++ b/internal/pkg/overlay/funcmap.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
@@ -121,4 +122,13 @@ func createIgnitionJson(node *node.Node) string {
 	}
 	tmpYaml, _ := json.Marshal(&conf)
 	return string(tmpYaml)
+}
+
+func importSoftlink(lnk string) string {
+	path, err := filepath.EvalSymlinks(lnk)
+	if err != nil {
+		return "abort"
+	}
+	wwlog.Debug("importing softlink pointing to: %s", path)
+	return fmt.Sprintf("{{ /* softlink \"%s\" */ }}", path)
 }

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -249,7 +249,7 @@ func BuildOverlayIndir(nodeData node.Node, overlayNames []string, outputDir stri
 							wwlog.Debug("Creating soft link %s -> %s", destFileName, softlinkFromTemplate[0][1])
 							return os.Symlink(softlinkFromTemplate[0][1], path.Join(outputDir, destFileName))
 						} else if len(filenameFromTemplate) != 0 {
-							wwlog.Debug("Found multiple comment, new filename %s", filenameFromTemplate[0][1])
+							wwlog.Debug("Writing file %s", filenameFromTemplate[0][1])
 							if foundFileComment {
 								err = CarefulWriteBuffer(path.Join(outputDir, destFileName),
 									fileBuffer, backupFile, info.Mode())
@@ -381,7 +381,8 @@ func RenderTemplateFile(fileName string, data TemplateStruct) (
 		"inc":          func(i int) int { return i + 1 },
 		"dec":          func(i int) int { return i - 1 },
 		"file":         func(str string) string { return fmt.Sprintf("{{ /* file \"%s\" */ }}", str) },
-		"softlink":     func(str string) string { return fmt.Sprintf("{{ /* softlink \"%s\" */ }}", str) },
+		"softlink":     softlink,
+		"readlink":     filepath.EvalSymlinks,
 		"IgnitionJson": func() string {
 			str := createIgnitionJson(data.ThisNode)
 			if str != "" {

--- a/overlays/localtime/internal/localtime_test.go
+++ b/overlays/localtime/internal/localtime_test.go
@@ -1,0 +1,56 @@
+package localtime
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/config"
+	"github.com/warewulf/warewulf/internal/pkg/testenv"
+	"github.com/warewulf/warewulf/internal/pkg/wwlog"
+)
+
+func Test_localtimeOverlay(t *testing.T) {
+	env := testenv.New(t)
+	defer env.RemoveAll(t)
+	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	assert.NoError(t, config.Get().Read(env.GetPath("etc/warewulf/warewulf.conf")))
+	env.ImportFile(t, "var/lib/warewulf/overlays/localtime/rootfs/etc/localtime.ww", "../rootfs/etc/localtime.ww")
+
+	tests := []struct {
+		name string
+		args []string
+		log  string
+	}{
+		{
+			name: "/etc/localtime",
+			args: []string{"--render", "node1", "localtime", "etc/localtime.ww"},
+			log:  localtime,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := show.GetCommand()
+			cmd.SetArgs(tt.args)
+			stdout := bytes.NewBufferString("")
+			stderr := bytes.NewBufferString("")
+			logbuf := bytes.NewBufferString("")
+			cmd.SetOut(stdout)
+			cmd.SetErr(stderr)
+			wwlog.SetLogWriter(logbuf)
+			err := cmd.Execute()
+			assert.NoError(t, err)
+			assert.Empty(t, stdout.String())
+			assert.Empty(t, stderr.String())
+			assert.Equal(t, tt.log, logbuf.String())
+		})
+	}
+}
+
+const localtime string = `backupFile: true
+writeFile: true
+Filename: etc/localtime
+{{ /* softlink "/usr/share/zoneinfo/GMT" */ }}
+`

--- a/overlays/localtime/internal/nodes.conf
+++ b/overlays/localtime/internal/nodes.conf
@@ -1,0 +1,4 @@
+nodes:
+  node1:
+    tags:
+      localtime: "GMT"

--- a/overlays/localtime/rootfs/etc/localtime.ww
+++ b/overlays/localtime/rootfs/etc/localtime.ww
@@ -1,0 +1,1 @@
+{{ ImportLink "/etc/localtime" }}

--- a/overlays/localtime/rootfs/etc/localtime.ww
+++ b/overlays/localtime/rootfs/etc/localtime.ww
@@ -1,1 +1,1 @@
-{{ ImportLink "/etc/localtime" }}
+{{ if .Tags.localtime }}{{ printf "%s/%s" "/usr/share/zoneinfo" .Tags.localtime | softlink }}{{ else }}{{ ImportLink "/etc/localtime" }}{{ end }}

--- a/userdocs/contents/templating.rst
+++ b/userdocs/contents/templating.rst
@@ -215,13 +215,18 @@ A given string can be split into substrings.
 softlink
 ^^^^^^^^
 
-Will create a soft link to the given string for the template.
+Creates a soft link to the given string for the template.
 
 ImportLink
 ^^^^^^^^^^
 
-Tries to evaluate the soft link on the host running `wwctl`/`warewulfd` and
-then create the soft link to it.
+Evaluates the soft link on the Warewulf server and
+then create the soft link to it in the overlay.
+
+readlink
+^^^^^^^^
+
+Evaluates the soft link on the Warewulf server and returns the target.
 
 
 Node specific files

--- a/userdocs/contents/templating.rst
+++ b/userdocs/contents/templating.rst
@@ -212,6 +212,17 @@ A given string can be split into substrings.
   {{ $y := (split $x ":") -}}
   {{ range $y }} {{.}} {{ end }}
 
+softlink
+^^^^^^^^
+
+Will create a soft link to the given string for the template.
+
+ImportLink
+^^^^^^^^^^
+
+Tries to evaluate the soft link on the host running `wwctl`/`warewulfd` and
+then create the soft link to it.
+
 
 Node specific files
 -------------------

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -212,6 +212,7 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/wicked/rootfs/*
 %attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/wwclient/rootfs/*
 %attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/wwinit/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/localtime/rootfs/*
 
 %attr(-, root, root) %{_bindir}/wwctl
 %attr(-, root, root) %{_prefix}/lib/firewalld/services/warewulf.xml


### PR DESCRIPTION
Add the the function softlink to the template rendering, so that
{{ softlink: "/bin/bash" }} for the file `/bin/run.ww` will create
a soft link to `/bin/bash`
It's also possible to "import" soft links from the host, e.g. the
template
{{ ImportLink "/etc/localtime" }}
set the timezone from the host.
