### PR TITLE
sanitize wwclient url data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Ensure autobuilt overlays include contextual overlay contents. #1296
 - Fix the failure when updating overlay files existing on different partitions. #1312
+- Escape asset tag for `wwclient` query strings when pulling runtime overlays. #1310
 
 ## v4.5.5, 2024-07-05
 

--- a/internal/app/wwclient/root.go
+++ b/internal/app/wwclient/root.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -129,7 +130,7 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 		if tag == "Unknown" {
 			dmiOut, err := exec.Command("dmidecode", "-s", "chassis-asset-tag").Output()
 			if err == nil {
-				chassisAssetTag := strings.TrimSpace(string(dmiOut))
+				chassisAssetTag := url.QueryEscape(strings.TrimSpace(string(dmiOut)))
 				if chassisAssetTag != "" {
 					tag = chassisAssetTag
 				}


### PR DESCRIPTION
- **Sanitize/escape asset tag strings from dmidecode.**
- **Update CHANGELOG.md**

## Description of the Pull Request (PR):

When `wwclient` falls back to `dmidecode` it's possible to get values which
have spaces and posisbly other characters not friendly to URLs. This PR uses
the `net/url` package to properly escape the `dmidecode` result for the asset
tag.

- Closes #1310

