### PR TITLE
fix the failure when updating overlay files existing on different par…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Ensure autobuilt overlays include contextual overlay contents. #1296
+- Fix the failure when updating overlay files existing on different partitions. #1312
 
 ## v4.5.5, 2024-07-05
 

--- a/internal/app/wwctl/overlay/edit/main.go
+++ b/internal/app/wwctl/overlay/edit/main.go
@@ -115,10 +115,17 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// try renaming the tempfile to overlayfile first
 	err := os.Rename(tempFile.Name(), overlayFile)
 	if err != nil {
-		wwlog.Error("Unable to update %s: %s", overlayFile, err)
-		os.Exit(1)
+		// if it fails, which probably means that they exists on different partitions
+		// fallback to data copy
+		wwlog.Debug("Unable to rename temp file: %s to overlay file: %s, try copying the data", tempFile.Name(), overlayFile)
+		cerr := util.CopyFile(tempFile.Name(), overlayFile)
+		if cerr != nil {
+			wwlog.Error("Unable to copy data from temp file: %s to target file: %s, err: %s", tempFile.Name(), overlayFile, err)
+			os.Exit(1)
+		}
 	}
 
 	return nil

--- a/internal/app/wwctl/overlay/edit/main.go
+++ b/internal/app/wwctl/overlay/edit/main.go
@@ -124,7 +124,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		cerr := util.CopyFile(tempFile.Name(), overlayFile)
 		if cerr != nil {
 			wwlog.Error("Unable to copy data from temp file: %s to target file: %s, err: %s", tempFile.Name(), overlayFile, err)
-			os.Exit(1)
+			return cerr
 		}
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix the failure that when editing overlay files on different partitions (tmpfs and /var are on different partitions). 


## This fixes or addresses the following GitHub issues:

 - Fixes #1312


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)

## Test

1. Before patch
![Screenshot 2024-07-25 140318](https://github.com/user-attachments/assets/66244a9f-abbd-4f0e-870b-227466d4c43a)

2. After patch
![Screenshot 2024-07-25 140721](https://github.com/user-attachments/assets/3e8bdd9d-f003-4ad4-bd9f-40b09606e46a)
