### PR TITLE
refactor profile edit using mmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Ensure autobuilt overlays include contextual overlay contents. #1296
 - Fix the failure when updating overlay files existing on different partitions. #1312
 
+### Changed
+
+- Refactor the `profile edit` subcommand.
+
 ## v4.5.5, 2024-07-05
 
 ### Fixed

--- a/internal/pkg/util/mmap.go
+++ b/internal/pkg/util/mmap.go
@@ -1,0 +1,96 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+type MMap struct {
+	Mapper
+}
+
+func (m *MMap) MapFromFile(f *os.File) ([]byte, error) {
+	return syncFromFile(f)
+}
+
+func (m *MMap) MapToFile(data []byte, f *os.File) ([]byte, error) {
+	return syncToFile(data, f)
+}
+
+func (m *MMap) Unmap(data []byte) error {
+	return unix.Munmap(data)
+}
+
+func syncToFile(data []byte, f *os.File) ([]byte, error) {
+	// check target file readable/writable
+	if f == nil {
+		return nil, fmt.Errorf("file is not valid")
+	}
+
+	st, serr := f.Stat()
+	if serr != nil {
+		return nil, fmt.Errorf("input os.File stat has error: %s", serr)
+	}
+	if st.Mode().Perm()&0600 != 0600 {
+		return nil, fmt.Errorf("file is not writable")
+	}
+
+	// check mapping data
+	if len(data) == 0 {
+		return nil, fmt.Errorf("no data to map")
+	}
+
+	mapSize := len(data)
+
+	err := unix.Ftruncate(int(f.Fd()), int64(mapSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to truncate the file, err: %s", err)
+	}
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("unable to rewind the file pointer to the beginning, err: %s", err)
+	}
+
+	// remap
+	d, err := unix.Mmap(int(f.Fd()), 0, int(mapSize), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+	if err != nil {
+		return nil, fmt.Errorf("failed to mmap to file, err: %s", err)
+	}
+	_ = copy(d, data)
+	err = unix.Msync(d, unix.MS_SYNC|unix.MS_INVALIDATE)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sync mmap data, err: %s", err)
+	}
+	return d, nil
+}
+
+func syncFromFile(f *os.File) ([]byte, error) {
+	// check target file readable
+	if f == nil {
+		return nil, fmt.Errorf("file is not valid")
+	}
+
+	st, serr := f.Stat()
+	if serr != nil {
+		return nil, fmt.Errorf("input os.File stat has error: %s", serr)
+	}
+	if st.Mode().Perm()&0400 != 0400 {
+		return nil, fmt.Errorf("file is not readable")
+	}
+
+	fileLen := st.Size()
+	d, err := unix.Mmap(int(f.Fd()), 0, int(fileLen), syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+	if err != nil {
+		return nil, fmt.Errorf("faild to mmap from file, err: %s", err)
+	}
+	return d, nil
+}
+
+type Mapper interface {
+	MapFromFile(*os.File) ([]byte, error)
+	MapToFile([]byte, *os.File) ([]byte, error)
+	Unmap() error
+}

--- a/internal/pkg/util/mmap_test.go
+++ b/internal/pkg/util/mmap_test.go
@@ -1,0 +1,129 @@
+package util
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapToFile(t *testing.T) {
+	f, err := os.CreateTemp(os.TempDir(), "test-*")
+	assert.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	mp := &MMap{}
+	var buffer bytes.Buffer
+	buffer.WriteString("hello world")
+
+	data, err := mp.MapToFile(buffer.Bytes(), f)
+	defer func() {
+		_ = mp.Unmap(data)
+	}()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "hello world", string(data))
+
+	fdata, err := io.ReadAll(f)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello world", string(fdata))
+}
+
+func TestMapFromFile(t *testing.T) {
+	f, err := os.CreateTemp(os.TempDir(), "test-*")
+	assert.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	mp := &MMap{}
+	_, err = f.WriteString("hello world")
+	assert.NoError(t, err)
+
+	data, err := mp.MapFromFile(f)
+	assert.NoError(t, err)
+	defer func() {
+		_ = mp.Unmap(data)
+	}()
+
+	assert.Equal(t, "hello world", string(data))
+}
+
+func TestMapBidirection(t *testing.T) {
+	f, err := os.CreateTemp(os.TempDir(), "test-*")
+	assert.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	mp := &MMap{}
+	var buffer bytes.Buffer
+	buffer.WriteString("hello world")
+
+	data, err := mp.MapToFile(buffer.Bytes(), f)
+	defer func() {
+		_ = mp.Unmap(data)
+	}()
+	assert.NoError(t, err)
+	assert.Equal(t, "hello world", string(data))
+
+	// update file
+	_, err = f.Seek(0, 2)
+	assert.NoError(t, err)
+
+	_, err = f.WriteString("\n another world")
+	assert.NoError(t, err)
+
+	data2, err := mp.MapFromFile(f)
+	assert.NoError(t, err)
+	defer func() {
+		_ = mp.Unmap(data)
+	}()
+
+	assert.Equal(t, "hello world\n another world", string(data2))
+
+	// update buffer again
+	buffer.Reset()
+	_, err = buffer.WriteString("new world")
+	assert.NoError(t, err)
+	data3, err := mp.MapToFile(buffer.Bytes(), f)
+	assert.NoError(t, err)
+	defer func() {
+		_ = mp.Unmap(data)
+	}()
+
+	assert.Equal(t, "new world", string(data3))
+
+	data4, err := io.ReadAll(f)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "new world", string(data4))
+}
+
+func TestFailureBecauseUnwritableFile(t *testing.T) {
+	f, err := os.CreateTemp(os.TempDir(), "test-*")
+	assert.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	err = os.Chmod(f.Name(), 0440)
+	assert.NoError(t, err)
+
+	mp := &MMap{}
+	d, err := mp.MapToFile([]byte("test"), f)
+	assert.Error(t, err)
+	assert.Nil(t, d)
+	assert.Contains(t, err.Error(), "file is not writable")
+}
+
+func TestFailureBecauseUnreadableFile(t *testing.T) {
+	f, err := os.CreateTemp(os.TempDir(), "test-*")
+	assert.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	err = os.Chmod(f.Name(), 0300)
+	assert.NoError(t, err)
+
+	mp := &MMap{}
+	d, err := mp.MapFromFile(f)
+	assert.Error(t, err)
+	assert.Nil(t, d)
+	assert.Contains(t, err.Error(), "file is not readable")
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Following this PR https://github.com/warewulf/warewulf/pull/1313
After reading the `profile edit` code, I am thinking maybe we can simplify the multiple file operations into several mmap operations.
This is a trial attempt. Feel free to leave comments. 

## This fixes or addresses the following GitHub issues:

 - Fixes #


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
