### PR TITLE
Alternative URL /container-by-name/NAME for containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add man pages and command reference to userdocs. #1488
 - Document building images from scratch with Apptainer. #1485
 - Added warewulfd:/overlay-file/{overlay}/{path...}?render={id}
+- Added an alternative image URL /images/{{.ContainerName}} that does not contain a MAC addresses
 
 ### Changed
 

--- a/internal/pkg/config/buildconfig.go.in
+++ b/internal/pkg/config/buildconfig.go.in
@@ -46,6 +46,7 @@ type WarewulfConf struct {
 	AutobuildOverlaysP *bool `yaml:"autobuild overlays,omitempty" default:"true"`
 	EnableHostOverlayP *bool `yaml:"host overlay,omitempty" default:"true"`
 	GrubBootP          *bool `yaml:"grubboot,omitempty" default:"false"`
+	CacheControl       string `yaml:"cachecontrol" default:"max-age=60"`
 }
 
 func (conf WarewulfConf) Secure() bool {

--- a/internal/pkg/warewulfd/images.go
+++ b/internal/pkg/warewulfd/images.go
@@ -1,0 +1,41 @@
+package warewulfd
+
+import (
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/warewulf/warewulf/internal/pkg/image"
+	"github.com/warewulf/warewulf/internal/pkg/util"
+	"github.com/warewulf/warewulf/internal/pkg/wwlog"
+)
+
+func ImagesSend(w http.ResponseWriter, req *http.Request) {
+	wwlog.Debug("Requested URL: %s", req.URL.String())
+
+	url := strings.Split(req.URL.Path, "?")[0]
+	path_parts := strings.Split(url, "/")
+
+	if len(path_parts) != 3 {
+		w.WriteHeader(http.StatusBadRequest)
+		wwlog.Error("invalid /images/$name URL")
+		return
+	}
+
+	image_name := path_parts[2]
+	wwlog.Debug("images: %s", image_name)
+
+	stage_file := path.Join(image.ImageParentDir(), image_name)
+	wwlog.Serv("stage_file '%s'", stage_file)
+
+	if util.IsFile(stage_file) {
+		err := sendFile(w, req, stage_file, "")
+		if err != nil {
+			wwlog.ErrorExc(err, "")
+			return
+		}
+	} else {
+		w.WriteHeader(http.StatusNotFound)
+		wwlog.Error("images: not found: %s", stage_file)
+	}
+}

--- a/internal/pkg/warewulfd/images.go
+++ b/internal/pkg/warewulfd/images.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"strings"
 
+	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/image"
 	"github.com/warewulf/warewulf/internal/pkg/util"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -12,6 +13,7 @@ import (
 
 func ImagesSend(w http.ResponseWriter, req *http.Request) {
 	wwlog.Debug("Requested URL: %s", req.URL.String())
+	conf := warewulfconf.Get()
 
 	url := strings.Split(req.URL.Path, "?")[0]
 	path_parts := strings.Split(url, "/")
@@ -28,14 +30,19 @@ func ImagesSend(w http.ResponseWriter, req *http.Request) {
 	stage_file := path.Join(image.ImageParentDir(), image_name)
 	wwlog.Serv("stage_file '%s'", stage_file)
 
-	if util.IsFile(stage_file) {
-		err := sendFile(w, req, stage_file, "")
-		if err != nil {
-			wwlog.ErrorExc(err, "")
-			return
-		}
-	} else {
+	if !util.IsFile(stage_file) {
 		w.WriteHeader(http.StatusNotFound)
 		wwlog.Error("images: not found: %s", stage_file)
+		return
+	}
+
+	if conf.Warewulf.CacheControl != "" {
+		w.Header().Set("Cache-Control", conf.Warewulf.CacheControl)
+	}
+
+	err := sendFile(w, req, stage_file, "")
+	if err != nil {
+		wwlog.ErrorExc(err, "")
+		return
 	}
 }

--- a/internal/pkg/warewulfd/warewulfd.go
+++ b/internal/pkg/warewulfd/warewulfd.go
@@ -75,6 +75,7 @@ func RunServer() error {
 	wwHandler.HandleFunc("/overlay-runtime/", ProvisionSend)
 	wwHandler.HandleFunc("/overlay-file/", OverlaySend)
 	wwHandler.HandleFunc("/status", StatusSend)
+	wwHandler.HandleFunc("/images/", ImagesSend)
 
 	conf := warewulfconf.Get()
 


### PR DESCRIPTION
By default, warewulf is using a node's MAC address to locate the image. The URL generated for ipxe or grub look like this:

  http://.../provision/{{.Hwaddr}}?...&stage=container&compress=gz

where Hwaddr contains the node's default interface MAC address.

Because containers are not specific to a node, an URL without MAC address could be used. For example:

  http://.../container-by-name/{{.ContainerName}}.img.gz

to refer to the compressed image.

This form can easily be used with standard HTTP proxy caches (e.g. nginx), since many nodes will download the same URL.

## Description of the Pull Request (PR):

This idea to scale warewulf provisioning has been discussed briefly in the warewulf slack help channel (July 24th, @griznog, @mslacken).

We're currently using one proxy with warewulf and iPXE boot, and modified dracut.ipxe to contain:

```
set dracut_wwinit ... wwinit.container="http://$PROXY/images/{{.ContainerName}}.img.gz" ...
```

Without this change, the proxy (nginx) needs a configuration like this that contains some $FAKEMAC MAC address which can be a real node or a dummy node. This, however, is error prone, and you may need to duplicate the config for the uncompressed version.

```
        location /images/$NAMEOFIMAGE.img.gz {
                proxy_pass http://$WAREWULF:9873/provision/$FAKEMAC?assetkey=&stage=container&compress=gz;
                proxy_cache_valid 200 302 1h;
                proxy_cache mycache;
                expires max;
        }
```

With this change, the proxy config would be much simpler.


## This fixes or addresses the following GitHub issues:

 - none


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [X] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [X] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
