### PR TITLE
Add option for wwclient port number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add multiple output formats (yaml & json) support. #447
 - More aliases for many wwctl commands
 - Add support to render template using `host` or `$(uname -n)` as the value of `overlay show --render`. #623
+- Added option for wwclient port number
 
 ### Changed
 

--- a/internal/app/wwclient/root.go
+++ b/internal/app/wwclient/root.go
@@ -98,7 +98,10 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	localTCPAddr := net.TCPAddr{}
-	if conf.Warewulf.Secure {
+	if conf.WWClient != nil && conf.WWClient.Port > 0 {
+		localTCPAddr.Port = int(conf.WWClient.Port)
+		wwlog.Info("Running from configured port %d", conf.WWClient.Port)
+	} else if conf.Warewulf.Secure {
 		// Setup local port to something privileged (<1024)
 		localTCPAddr.Port = 987
 		wwlog.Info("Running from trusted port")

--- a/internal/pkg/config/root.go
+++ b/internal/pkg/config/root.go
@@ -41,6 +41,7 @@ type RootConf struct {
 	SSH             *SSHConf      `yaml:"ssh,omitempty"`
 	MountsContainer []*MountEntry `yaml:"container mounts" default:"[{\"source\": \"/etc/resolv.conf\", \"dest\": \"/etc/resolv.conf\"}]"`
 	Paths           *BuildConfig  `yaml:"paths"`
+	WWClient        *WWClientConf `yaml:"wwclient"`
 
 	warewulfconf string
 }

--- a/internal/pkg/config/wwclient.go
+++ b/internal/pkg/config/wwclient.go
@@ -1,0 +1,5 @@
+package config
+
+type WWClientConf struct {
+	Port uint16 `yaml:"port" default:"0"`
+}


### PR DESCRIPTION
With this change, you can specify a port number for wwclient. If

```
  wwclient:
    port: NUMBER
```

is specified in warewulf.conf, wwclient will bind to the specified local port NUMBER. If no port is specified, wwclient will use any available port, or port 987 if secure is true.

Port 987 is in the default port range used by the Linux NFS client (665-1023, see linux/include/linux/sunrpc/xprtsock.h). Changing the port can avoid failures when port 987 is already in use.

## Description of the Pull Request (PR):

We want wwclient to use a port <1024. Currently, the way to achieve this is to set "secure" to true in warewulf.conf.
But sometimes, wwclient fails to start, because port 987 is already in use by the Linux kernel NFS client.

We see two options to avoid this conflict.

a) Set min_resvport or max_resvport kernel parameters for the sunrpc module
b) Move wwclient to a port outside of the sunrpc default port range (665-1023).

Although (a) is already possible, we'd like to also have option (b). The change is small, and may be useful in other cases, too. Maybe it can be extended later to become a port range, which would further improve robustness.

## This fixes or addresses the following GitHub issues:

 - Fixes port already in use errors on wwclient startup.

## Before submitting a PR, make sure you have done the following:

- [X] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [X] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [X] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [X] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
