### PR TITLE
Refactor url build in wwclient with url.URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `wwctl conatiner list --kernel` shows the kernel detected for each container. #1283
 - `wwctl container list --size` shows the uncompressed size of each container. `--compressed` shows the compressed size, and `--chroot` shows the size of the container source on the server. #954, #1117
 - Add a logrotate config for `warewulfd.log`. #1311
+### Changed
+
+- Refactor URL handling in wwclient to consistently escape arguments.
+
+## v4.5.6, unreleased
 
 ### Fixed
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Generalizes @griznog's fix in #1309 to all arguments, utilizing `url.URL` to build the url used by `wwclient`.

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
