### PR TITLE
Dracut boot refinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added option for wwclient port number. #1349
 
+### Fixed
+
+- Fix dracut booting with secure mode. #1261
+
 ### Changed
 
 - Added a link to an example SELinux-enabled node image in documentation. #1305

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,3 +36,4 @@
 * Shane Nehring <snehring@iastate.edu>
 * Tobias Ribizel <mail@ribizel.de>
 * Tobias Poschwatta <poschwatta@zib.de>
+* Josh Burks <jeburks2@asu.edu>

--- a/dracut/modules.d/90wwinit/load-wwinit.sh
+++ b/dracut/modules.d/90wwinit/load-wwinit.sh
@@ -8,6 +8,8 @@ do
     if [ -n "${archive}" ]
     then
         info "Loading ${archive}"
-        (curl --silent -L "${archive}" | gzip -d | cpio -im --directory="${NEWROOT}") || die "Unable to load ${archive}"
+	#Load only runtime overlays from a static privledge port
+        [[ "$archive" == *"runtime"* ]] && localport="--local-port 986" || localport=""
+        (curl --silent $localport -L "${archive}" | gzip -d | cpio -im --directory="${NEWROOT}") || die "Unable to load ${archive}"
     fi
 done

--- a/dracut/modules.d/90wwinit/load-wwinit.sh
+++ b/dracut/modules.d/90wwinit/load-wwinit.sh
@@ -8,8 +8,13 @@ do
     if [ -n "${archive}" ]
     then
         info "Loading ${archive}"
-	#Load only runtime overlays from a static privledge port
-        [[ "$archive" == *"runtime"* ]] && localport="--local-port 986" || localport=""
-        (curl --silent $localport -L "${archive}" | gzip -d | cpio -im --directory="${NEWROOT}") || die "Unable to load ${archive}"
+        # Load runtime overlay from a static privledged port.
+        # Others use default settings.
+        localport=""
+        if [[ "$archive" == *"runtime"* ]]
+        then
+            localport="--local-port 1-1023"
+        fi
+        (curl --silent ${localport} -L "${archive}" | gzip -d | cpio -im --directory="${NEWROOT}") || die "Unable to load ${archive}"
     fi
 done

--- a/dracut/modules.d/90wwinit/load-wwinit.sh
+++ b/dracut/modules.d/90wwinit/load-wwinit.sh
@@ -11,7 +11,7 @@ do
         # Load runtime overlay from a static privledged port.
         # Others use default settings.
         localport=""
-        if [[ "$archive" == *"runtime"* ]]
+        if [[ "${archive}" == "${wwinit_runtime}" ]]
         then
             localport="--local-port 1-1023"
         fi

--- a/dracut/modules.d/90wwinit/module-setup.sh
+++ b/dracut/modules.d/90wwinit/module-setup.sh
@@ -14,7 +14,7 @@ depends() {
 }
 
 install() {
-    inst_multiple cpio curl
+    inst_multiple cpio curl dmidecode
     inst_hook cmdline 30 "$moddir/parse-wwinit.sh"
     inst_hook pre-mount 30 "$moddir/load-wwinit.sh"
 }

--- a/dracut/modules.d/90wwinit/module-setup.sh
+++ b/dracut/modules.d/90wwinit/module-setup.sh
@@ -14,7 +14,7 @@ depends() {
 }
 
 install() {
-    inst_multiple cpio curl dmidecode
+    inst_multiple cpio curl
     inst_hook cmdline 30 "$moddir/parse-wwinit.sh"
     inst_hook pre-mount 30 "$moddir/load-wwinit.sh"
 }

--- a/dracut/modules.d/90wwinit/parse-wwinit.sh
+++ b/dracut/modules.d/90wwinit/parse-wwinit.sh
@@ -6,10 +6,12 @@
 if [ "${root}" = "wwinit" ]
 then
     info "root=${root}"
-    export wwinit_container=$(getarg wwinit.container=); info "wwinit.container=${wwinit_container}"
-    export wwinit_system=$(getarg wwinit.system=); info "wwinit.system=${wwinit_system}"
-    export wwinit_runtime=$(getarg wwinit.runtime=); info "wwinit.runtime=${wwinit_runtime}"
-    export wwinit_kmods=$(getarg wwinit.kmods=); info "wwinit.kmods=${wwinit_kmods}"
+    export wwinit_uri="http://$(getarg wwinit.uri)/provision/$(getarg wwid)?assetkey=$(dmidecode -s chassis-asset-tag)&uuid=$(dmidecode -s system-uuid)&stage="
+    export wwinit_container="${wwinit_uri}container&compress=gz"; info "wwinit.container=${wwinit_container}"
+    export wwinit_system="${wwinit_uri}system&compress=gz"; info "wwinit.system=${wwinit_system}"
+    export wwinit_runtime="${wwinit_uri}runtime&compress=gz"; info "wwinit.runtime=${wwinit_runtime}"
+    wwinit_kmods_passed=$(getarg wwinit.kmods=)
+    [ -n "$wwinit_kmods_passed" ] && export wwinit_kmods="${wwinit_uri}kmods&compress=gz"; info "wwinit.kmods=${wwinit_kmods}"
 
     wwinit_tmpfs_size=$(getarg wwinit.tmpfs.size=)
     if [ -n "$wwinit_tmpfs_size" ]

--- a/dracut/modules.d/90wwinit/parse-wwinit.sh
+++ b/dracut/modules.d/90wwinit/parse-wwinit.sh
@@ -7,12 +7,12 @@ if [ "${root}" = "wwinit" ]
 then
     info "root=${root}"
     wwinit_uri="$(getarg wwinit.uri)"
-    export wwinit_container="${wwinit_uri}container&compress=gz"; info "wwinit.container=${wwinit_container}"
-    export wwinit_system="${wwinit_uri}system&compress=gz"; info "wwinit.system=${wwinit_system}"
-    export wwinit_runtime="${wwinit_uri}runtime&compress=gz"; info "wwinit.runtime=${wwinit_runtime}"
+    export wwinit_container="${wwinit_uri}container&compress=gz"; info "wwinit_container=${wwinit_container}"
+    export wwinit_system="${wwinit_uri}system&compress=gz"; info "wwinit_system=${wwinit_system}"
+    export wwinit_runtime="${wwinit_uri}runtime&compress=gz"; info "wwinit_runtime=${wwinit_runtime}"
     if [ -n "$(getarg wwinit.KernelOverride)" ]
     then
-        export wwinit_kmods="${wwinit_uri}kmods&compress=gz"; info "wwinit.kmods=${wwinit_kmods}"
+        export wwinit_kmods="${wwinit_uri}kmods&compress=gz"; info "wwinit_kmods=${wwinit_kmods}"
     fi
 
     wwinit_tmpfs_size=$(getarg wwinit.tmpfs.size=)

--- a/dracut/modules.d/90wwinit/parse-wwinit.sh
+++ b/dracut/modules.d/90wwinit/parse-wwinit.sh
@@ -6,7 +6,7 @@
 if [ "${root}" = "wwinit" ]
 then
     info "root=${root}"
-    export wwinit_uri="http://$(getarg wwinit.uri)/provision/$(getarg wwid)?assetkey=$(dmidecode -s chassis-asset-tag)&uuid=$(dmidecode -s system-uuid)&stage="
+    wwinit_uri="$(getarg wwinit.uri)"
     export wwinit_container="${wwinit_uri}container&compress=gz"; info "wwinit.container=${wwinit_container}"
     export wwinit_system="${wwinit_uri}system&compress=gz"; info "wwinit.system=${wwinit_system}"
     export wwinit_runtime="${wwinit_uri}runtime&compress=gz"; info "wwinit.runtime=${wwinit_runtime}"

--- a/dracut/modules.d/90wwinit/parse-wwinit.sh
+++ b/dracut/modules.d/90wwinit/parse-wwinit.sh
@@ -6,7 +6,9 @@
 if [ "${root}" = "wwinit" ]
 then
     info "root=${root}"
-    wwinit_uri="$(getarg wwinit.uri)"
+    uuid=$(dmidecode -s system-uuid)
+    assetkey=$(dmidecode -s chassis-asset-tag | sed -E -e 's/(^ +| +$)//g' -e 's/^(Unknown|Not Specified)$//g' -e 's/ /_/g')
+    wwinit_uri="$(getarg wwinit.uri)?assetkey=${assetkey}&uuid=${uuid}"
     export wwinit_container="${wwinit_uri}&stage=container&compress=gz"; info "wwinit_container=${wwinit_container}"
     export wwinit_system="${wwinit_uri}&stage=system&compress=gz"; info "wwinit_system=${wwinit_system}"
     export wwinit_runtime="${wwinit_uri}&stage=runtime&compress=gz"; info "wwinit_runtime=${wwinit_runtime}"

--- a/dracut/modules.d/90wwinit/parse-wwinit.sh
+++ b/dracut/modules.d/90wwinit/parse-wwinit.sh
@@ -7,12 +7,12 @@ if [ "${root}" = "wwinit" ]
 then
     info "root=${root}"
     wwinit_uri="$(getarg wwinit.uri)"
-    export wwinit_container="${wwinit_uri}container&compress=gz"; info "wwinit_container=${wwinit_container}"
-    export wwinit_system="${wwinit_uri}system&compress=gz"; info "wwinit_system=${wwinit_system}"
-    export wwinit_runtime="${wwinit_uri}runtime&compress=gz"; info "wwinit_runtime=${wwinit_runtime}"
+    export wwinit_container="${wwinit_uri}&stage=container&compress=gz"; info "wwinit_container=${wwinit_container}"
+    export wwinit_system="${wwinit_uri}&stage=system&compress=gz"; info "wwinit_system=${wwinit_system}"
+    export wwinit_runtime="${wwinit_uri}&stage=runtime&compress=gz"; info "wwinit_runtime=${wwinit_runtime}"
     if [ -n "$(getarg wwinit.KernelOverride)" ]
     then
-        export wwinit_kmods="${wwinit_uri}kmods&compress=gz"; info "wwinit_kmods=${wwinit_kmods}"
+        export wwinit_kmods="${wwinit_uri}&stage=kmods&compress=gz"; info "wwinit_kmods=${wwinit_kmods}"
     fi
 
     wwinit_tmpfs_size=$(getarg wwinit.tmpfs.size=)

--- a/dracut/modules.d/90wwinit/parse-wwinit.sh
+++ b/dracut/modules.d/90wwinit/parse-wwinit.sh
@@ -10,8 +10,10 @@ then
     export wwinit_container="${wwinit_uri}container&compress=gz"; info "wwinit.container=${wwinit_container}"
     export wwinit_system="${wwinit_uri}system&compress=gz"; info "wwinit.system=${wwinit_system}"
     export wwinit_runtime="${wwinit_uri}runtime&compress=gz"; info "wwinit.runtime=${wwinit_runtime}"
-    wwinit_kmods_passed=$(getarg wwinit.kmods=)
-    [ -n "$wwinit_kmods_passed" ] && export wwinit_kmods="${wwinit_uri}kmods&compress=gz"; info "wwinit.kmods=${wwinit_kmods}"
+    if [ -n "$(getarg wwinit.KernelOverride)" ]
+    then
+        export wwinit_kmods="${wwinit_uri}kmods&compress=gz"; info "wwinit.kmods=${wwinit_kmods}"
+    fi
 
     wwinit_tmpfs_size=$(getarg wwinit.tmpfs.size=)
     if [ -n "$wwinit_tmpfs_size" ]

--- a/etc/grub/grub.cfg.ww
+++ b/etc/grub/grub.cfg.ww
@@ -42,7 +42,7 @@ menuentry "Network boot node: {{.Id}}" --id ww4 {
 menuentry "Network boot node with dracut: {{.Id}}" --id dracut {
     initramfs="${uri}&stage=initramfs"
 
-    wwinit_uri="http://{{.Ipaddr}}:{{.Port}}/provision/${net_default_mac}?assetkey=${assetkey}"
+    wwinit_uri="http://{{.Ipaddr}}:{{.Port}}/provision/${net_default_mac}"
 
     {{if .KernelOverride }}
     echo "Kernel:                {{.KernelOverride}}"

--- a/etc/grub/grub.cfg.ww
+++ b/etc/grub/grub.cfg.ww
@@ -42,10 +42,7 @@ menuentry "Network boot node: {{.Id}}" --id ww4 {
 menuentry "Network boot node with dracut: {{.Id}}" --id dracut {
     initramfs="${uri}&stage=initramfs"
 
-    uri="http://{{.Ipaddr}}:{{.Port}}/provision/${net_default_mac}?assetkey=${assetkey}"
-    container="${uri}&stage=container&compress=gz"
-    system="${uri}&stage=system&compress=gz"
-    runtime="${uri}&stage=runtime&compress=gz"
+    wwinit_uri="http://{{.Ipaddr}}:{{.Port}}/provision/${net_default_mac}?assetkey=${assetkey}"
 
     {{if .KernelOverride }}
     echo "Kernel:                {{.KernelOverride}}"
@@ -55,7 +52,7 @@ menuentry "Network boot node with dracut: {{.Id}}" --id dracut {
     echo "KernelArgs:            {{.KernelArgs}}"
 
     net_args="rd.neednet=1 {{range $devname, $netdev := .NetDevs}}{{if and $netdev.Hwaddr $netdev.Device}} ifname={{$netdev.Device}}:{{$netdev.Hwaddr}} {{end}}{{end}}"
-    wwinit_args="root=wwinit wwinit.container=${container} wwinit.system=${system} wwinit.runtime=${runtime} init=/init"
+    wwinit_args="root=wwinit wwinit.uri=${wwinit_uri}"
     linux $kernel wwid=${net_default_mac} {{.KernelArgs}} $net_args $wwinit_args
 
     if [ x$? = x0 ] ; then

--- a/etc/ipxe/dracut.ipxe
+++ b/etc/ipxe/dracut.ipxe
@@ -13,7 +13,8 @@ echo Kernel:        {{.ContainerName}} (container default)
 echo KernelArgs:    {{.KernelArgs}}
 echo
 
-set uri http://{{.Ipaddr}}:{{.Port}}/provision/{{.Hwaddr}}?assetkey=${asset}&uuid=${uuid}
+set baseuri http://{{.Ipaddr}}:{{.Port}}/provision/{{.Hwaddr}}
+set uri ${baseuri}?assetkey=${asset}&uuid=${uuid}
 echo Warewulf Controller: {{.Ipaddr}}
 
 echo Downloading Kernel Image:
@@ -29,7 +30,7 @@ echo Downloading initramfs
 initrd --name initramfs ${uri}&stage=initramfs || goto reboot
 
 set dracut_net rd.neednet=1 {{range $devname, $netdev := .NetDevs}}{{if and $netdev.Hwaddr $netdev.Device}} ifname={{$netdev.Device}}:{{$netdev.Hwaddr}} {{end}}{{end}}
-set dracut_wwinit root=wwinit wwinit.uri=${uri} {{if ne .KernelOverride ""}}wwinit.KernelOverride={{ .KernelOverride }}{{end}} init=/init
+set dracut_wwinit root=wwinit wwinit.uri=${baseuri} {{if ne .KernelOverride ""}}wwinit.KernelOverride={{ .KernelOverride }}{{end}} init=/init
 
 echo Booting initramfs
 #echo Network KernelArgs: ${dracut_net}

--- a/etc/ipxe/dracut.ipxe
+++ b/etc/ipxe/dracut.ipxe
@@ -29,7 +29,7 @@ echo Downloading initramfs
 initrd --name initramfs ${uri}&stage=initramfs || goto reboot
 
 set dracut_net rd.neednet=1 {{range $devname, $netdev := .NetDevs}}{{if and $netdev.Hwaddr $netdev.Device}} ifname={{$netdev.Device}}:{{$netdev.Hwaddr}} {{end}}{{end}}
-set dracut_wwinit root=wwinit wwinit_uri={{.Ipaddr}}:{{.Port}} {{if ne .KernelOverride ""}}wwinit.KernelOverride={{ .KernelOverride }}{{end}} init=/init
+set dracut_wwinit root=wwinit wwinit.uri=${uri} {{if ne .KernelOverride ""}}wwinit.KernelOverride={{ .KernelOverride }}{{end}} init=/init
 
 echo Booting initramfs
 #echo Network KernelArgs: ${dracut_net}

--- a/etc/ipxe/dracut.ipxe
+++ b/etc/ipxe/dracut.ipxe
@@ -29,7 +29,7 @@ echo Downloading initramfs
 initrd --name initramfs ${uri}&stage=initramfs || goto reboot
 
 set dracut_net rd.neednet=1 {{range $devname, $netdev := .NetDevs}}{{if and $netdev.Hwaddr $netdev.Device}} ifname={{$netdev.Device}}:{{$netdev.Hwaddr}} {{end}}{{end}}
-set dracut_wwinit root=wwinit wwinit.container=${uri}&stage=container&compress=gz wwinit.system=${uri}&stage=system&compress=gz wwinit.runtime=${uri}&stage=runtime&compress=gz {{if ne .KernelOverride ""}}wwinit.kmods=${uri}&stage=kmods&compress=gz{{end}} init=/init
+set dracut_wwinit root=wwinit wwinit_uri={{.Ipaddr}}:{{.Port}} {{if ne .KernelOverride ""}}wwinit.kmods=true{{end}} init=/init
 
 echo Booting initramfs
 #echo Network KernelArgs: ${dracut_net}

--- a/etc/ipxe/dracut.ipxe
+++ b/etc/ipxe/dracut.ipxe
@@ -29,7 +29,7 @@ echo Downloading initramfs
 initrd --name initramfs ${uri}&stage=initramfs || goto reboot
 
 set dracut_net rd.neednet=1 {{range $devname, $netdev := .NetDevs}}{{if and $netdev.Hwaddr $netdev.Device}} ifname={{$netdev.Device}}:{{$netdev.Hwaddr}} {{end}}{{end}}
-set dracut_wwinit root=wwinit wwinit_uri={{.Ipaddr}}:{{.Port}} {{if ne .KernelOverride ""}}wwinit.kmods=true{{end}} init=/init
+set dracut_wwinit root=wwinit wwinit_uri={{.Ipaddr}}:{{.Port}} {{if ne .KernelOverride ""}}wwinit.KernelOverride={{ .KernelOverride }}{{end}} init=/init
 
 echo Booting initramfs
 #echo Network KernelArgs: ${dracut_net}

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -95,7 +95,6 @@ Requires: dracut-network
 %endif
 Requires: curl
 Requires: cpio
-Requires: dmidecode
 
 %description dracut
 Warewulf is a stateless and diskless container operating system provisioning
@@ -221,7 +220,7 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 
 %changelog
 * Tue Jun 18 2024 Josh Burks <jeburks2@asu.edu>
-- Add curl, cpio, dmidecode as requires for warewulf-dracut
+- Add curl, cpio as requires for warewulf-dracut
 
 * Thu Apr 18 2024 Jonathon Anderson <janderson@ciq.com>
 - New warewulf-dracut subpackage

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -95,6 +95,7 @@ Requires: dracut-network
 %endif
 Requires: curl
 Requires: cpio
+Requires: dmidecode
 
 %description dracut
 Warewulf is a stateless and diskless container operating system provisioning
@@ -220,7 +221,7 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 
 %changelog
 * Tue Jun 18 2024 Josh Burks <jeburks2@asu.edu>
-- Add curl, cpio as requires for warewulf-dracut
+- Add curl, cpio, and dracut as requires for warewulf-dracut
 
 * Thu Apr 18 2024 Jonathon Anderson <janderson@ciq.com>
 - New warewulf-dracut subpackage

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -93,6 +93,9 @@ Requires: dracut
 %else
 Requires: dracut-network
 %endif
+Requires: curl
+Requires: cpio
+Requires: dmidecode
 
 %description dracut
 Warewulf is a stateless and diskless container operating system provisioning
@@ -217,6 +220,9 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 
 
 %changelog
+* Tue Jun 18 2024 Josh Burks <jeburks2@asu.edu>
+- Add curl, cpio, dmidecode as requires for warewulf-dracut
+
 * Thu Apr 18 2024 Jonathon Anderson <janderson@ciq.com>
 - New warewulf-dracut subpackage
 


### PR DESCRIPTION
Alternative implementation for #1269. Also incorporates a fix from #1370.

The new dracut boot method bloated /proc/cmdline, and exposed asset-tag and uuid to unprivileged users. This PR moves the parsing of dracut URIs from iPXE to the dracut script pase-wwinit.sh, using dmidecode to obtain asset-tag and uuid, leaving only the IP and port of the warewulf server in /proc/cmdline.

Additionally, it forces runtime overlays to be pulled from a static local port (986) to allow dracut boot to be used with secure mode. Port 986 is used instead of 987 to prevent a race condition of the system releasing the port before wwclient starts and tries to bind to 987.

Lastly, add the required curl, cpio and now dmidecode packages to warewulf.spec for warewulf-dracut subpackage

## This fixes or addresses the following GitHub issues:

 - Fixes #1261 


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
