### PR TITLE
enhance the user syncing function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Added a link to an example SELinux-enabled node image in documentation. #1305
+- Added `--syncuser` flag to `shell` sub-command to enhance the user syncing function. #1344
 
 ## v4.5.6, 2024-08-05
 

--- a/internal/app/wwctl/container/exec/main.go
+++ b/internal/app/wwctl/container/exec/main.go
@@ -101,6 +101,10 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// getting syncuser from cmd, e.g., shell comamnd will call exec command and passing --syncuser
+	if syncUserFlag, err := cmd.Flags().GetBool("syncuser"); err == nil {
+		SyncUser = SyncUser || syncUserFlag
+	}
 	userdbChanged := false
 	if !beforePasswdTime.IsZero() {
 		afterPasswdTime := getTime(path.Join(containerPath, "/etc/passwd"))
@@ -143,7 +147,7 @@ func getTime(path string) time.Time {
 		return time.Time{}
 	} else {
 		unixStat := fileStat.Sys().(*syscall.Stat_t)
-		return time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec))
+		return time.Unix(int64(unixStat.Mtim.Sec), int64(unixStat.Mtim.Nsec))
 	}
 }
 

--- a/internal/app/wwctl/container/shell/root.go
+++ b/internal/app/wwctl/container/shell/root.go
@@ -25,11 +25,13 @@ var (
 	}
 	binds    []string
 	nodeName string
+	syncUser bool
 )
 
 func init() {
 	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, "Bind a local path into the container (must exist)")
 	baseCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Create a read only view of the container for the given node")
+	baseCmd.PersistentFlags().BoolVar(&syncUser, "syncuser", false, "Synchronize UIDs/GIDs from host to container")
 }
 
 // GetRootCommand returns the root cobra.Command for the application.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Added `--syncuser` flag to `shell` command to enhance the user sync function. `exec` command supports `--syncuser` command but to trigger it, it requires `userdbChanged && SyncUser flag set`. `shell` command can now pass `--syncuser` flag to `exec` command to trigger it. 


## This fixes or addresses the following GitHub issues:

 - Fixes #1344


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
