### PR TITLE
prefer profile overlay value over node one in node's SystemOverlay entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added a link to an example SELinux-enabled node image in documentation. #1305
 - Refine error handling for `wwctl configure`. #1273
 - Updated dracut guidance for building initramfs. #1369
+- Preferred profile overlay value over node one for node's `SystemOverlay` entry. #1259
 
 ## v4.5.6, 2024-08-05
 

--- a/internal/app/wwctl/node/list/main_test.go
+++ b/internal/app/wwctl/node/list/main_test.go
@@ -338,6 +338,32 @@ n01   Init            --          (/sbin/init)
 n01   Kernel.Args     --          (quiet crashkernel=no vga=791 net.naming-scheme=v238)  
 n01   Profiles        --          p1
 `},
+		{
+			inDb: `WW_INTERNAL: 45
+nodeprofiles:
+  p1:
+    system overlay:
+    - profileinit
+nodes:
+  n01:
+    profiles:
+    - p1
+    system overlay:
+    - nodeinit
+`,
+			name:    "prefer profile system overlay over node overlay",
+			args:    []string{"-a"},
+			wantErr: false,
+			stdout: `NODE  FIELD           PROFILE     VALUE
+n01   Id              --        n01        
+n01   Ipxe            --          (default)
+n01   RuntimeOverlay  --          (generic)
+n01   SystemOverlay   SUPERSEDED  profileinit, nodeinit  
+n01   Root            --          (initramfs)
+n01   Init            --          (/sbin/init)
+n01   Kernel.Args     --          (quiet crashkernel=no vga=791 net.naming-scheme=v238)  
+n01   Profiles        --          p1
+`},
 	}
 
 	conf_yml := `WW_INTERNAL: 0`

--- a/internal/pkg/node/list.go
+++ b/internal/pkg/node/list.go
@@ -32,11 +32,19 @@ func recursiveFields(obj interface{}, emptyFields bool, prefix string) (output [
 		if typeObj.Elem().Field(i).Type == reflect.TypeOf(Entry{}) {
 			myField := valObj.Elem().Field(i).Interface().(Entry)
 			if emptyFields || myField.Get() != "" {
-				output = append(output, NodeFields{
-					Field:  prefix + typeObj.Elem().Field(i).Name,
-					Source: myField.Source(),
-					Value:  myField.Print(),
-				})
+				if typeObj.Elem().Field(i).Name == "SystemOverlay" {
+					output = append(output, NodeFields{
+						Field:  prefix + typeObj.Elem().Field(i).Name,
+						Source: myField.Source(),
+						Value:  myField.PrintPreferAlt(),
+					})
+				} else {
+					output = append(output, NodeFields{
+						Field:  prefix + typeObj.Elem().Field(i).Name,
+						Source: myField.Source(),
+						Value:  myField.Print(),
+					})
+				}
 			}
 		} else if typeObj.Elem().Field(i).Type == reflect.TypeOf(map[string]*Entry{}) {
 			for key, val := range valObj.Elem().Field(i).Interface().(map[string]*Entry) {

--- a/internal/pkg/node/methods.go
+++ b/internal/pkg/node/methods.go
@@ -287,6 +287,17 @@ func (ent *Entry) GetSlice() []string {
 	return []string{}
 }
 
+func (ent *Entry) GetSlicePreferAlt() []string {
+	retval := append(ent.altvalue, ent.value...)
+	if len(retval) != 0 {
+		return cleanList(retval)
+	}
+	if len(ent.def) != 0 {
+		return ent.def
+	}
+	return []string{}
+}
+
 /*
 Get the real value, not the alternative of default one.
 */
@@ -371,6 +382,43 @@ func (ent *Entry) Print() string {
 		var ret string
 		if len(ent.value) != 0 || len(ent.altvalue) != 0 {
 			combList := append(ent.value, ent.altvalue...)
+			ret = strings.Join(cleanList(combList), ",")
+			if len(negList(combList)) > 0 {
+				ret += " ~{" + strings.Join(negList(combList), ",") + "}"
+			}
+
+		}
+		if ret != "" {
+			return ret
+		}
+		if len(ent.def) != 0 {
+			return "(" + strings.Join(ent.def, ",") + ")"
+		}
+
+	}
+	return "--"
+}
+
+/* Gets the the entry of the value in following order
+* profile value if set
+* node value if set
+* default value if set
+ */
+func (ent *Entry) PrintPreferAlt() string {
+	if !ent.isSlice {
+		if len(ent.altvalue) != 0 {
+			return ent.altvalue[0]
+		}
+		if len(ent.value) != 0 {
+			return ent.value[0]
+		}
+		if len(ent.def) != 0 {
+			return "(" + ent.def[0] + ")"
+		}
+	} else {
+		var ret string
+		if len(ent.value) != 0 || len(ent.altvalue) != 0 {
+			combList := append(ent.altvalue, ent.value...)
 			ret = strings.Join(cleanList(combList), ",")
 			if len(negList(combList)) > 0 {
 				ret += " ~{" + strings.Join(negList(combList), ",") + "}"

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -31,7 +31,7 @@ Build all overlays (runtime and generic) for a node
 func BuildAllOverlays(nodes []node.NodeInfo) error {
 	for _, n := range nodes {
 
-		sysOverlays := n.SystemOverlay.GetSlice()
+		sysOverlays := n.SystemOverlay.GetSlicePreferAlt()
 		wwlog.Info("Building system overlays for %s: [%s]", n.Id.Get(), strings.Join(sysOverlays, ", "))
 		err := BuildOverlay(n, "system", sysOverlays)
 		if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

prefer profile overlay value over node one in node's SystemOverlay entry


## This fixes or addresses the following GitHub issues:

 - Fixes #1259


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)

## Test
```
before:
[root@localhost warewulf]# wwctl node list -a n1
  NODE  FIELD           PROFILE     VALUE                                                             
  n1    Id              --          n1                                                                
  n1    Comment         SUPERSEDED  This profile is automatically included for each node hah? xxxxxx  
  n1    ContainerName   SUPERSEDED  rockylinux-9                                                      
  n1    Ipxe            --          (default)                                                         
  n1    RuntimeOverlay  --          (generic)                                                         
  n1    SystemOverlay   SUPERSEDED  nodeinit,profileinit                                              
  n1    Root            --          (initramfs)                                                       
  n1    Init            --          (/sbin/init)                                                      
  n1    Kernel.Args     --          (quiet crashkernel=no vga=791 net.naming-scheme=v238)             
  n1    Profiles        --          default                 

after:                                          
[root@localhost warewulf]# wwctl node list -a n1
  NODE  FIELD           PROFILE     VALUE                                                             
  n1    Id              --          n1                                                                
  n1    Comment         SUPERSEDED  This profile is automatically included for each node hah? xxxxxx  
  n1    ContainerName   SUPERSEDED  rockylinux-9                                                      
  n1    Ipxe            --          (default)                                                         
  n1    RuntimeOverlay  --          (generic)                                                         
  n1    SystemOverlay   SUPERSEDED  profileinit,nodeinit                                              
  n1    Root            --          (initramfs)                                                       
  n1    Init            --          (/sbin/init)                                                      
  n1    Kernel.Args     --          (quiet crashkernel=no vga=791 net.naming-scheme=v238)             
  n1    Profiles        --          default    
```