### PR TITLE
Add --syncuser flag to wwctl shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Interleave tmpfs across all available NUMA nodes. #1347, #1348
+- Syncuser watches for changes in mtime rather than ctime. #1358
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## v4.5.8, unreleased
 
+### Added
+
+- Added `--syncuser` flag to `wwctl container shell`. #1358
+
 ### Changed
 
 - Interleave tmpfs across all available NUMA nodes. #1347, #1348

--- a/internal/app/wwctl/container/exec/main.go
+++ b/internal/app/wwctl/container/exec/main.go
@@ -124,6 +124,10 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// getting syncuser from cmd, e.g., shell comamnd will call exec command and passing --syncuser
+	if syncUserFlag, err := cmd.Flags().GetBool("syncuser"); err == nil {
+		SyncUser = SyncUser || syncUserFlag
+	}
 	userdbChanged := false
 	if !beforePasswdTime.IsZero() {
 		afterPasswdTime := getTime(path.Join(containerPath, "/etc/passwd"))
@@ -166,7 +170,7 @@ func getTime(path string) time.Time {
 		return time.Time{}
 	} else {
 		unixStat := fileStat.Sys().(*syscall.Stat_t)
-		return time.Unix(int64(unixStat.Ctim.Sec), int64(unixStat.Ctim.Nsec))
+		return time.Unix(int64(unixStat.Mtim.Sec), int64(unixStat.Mtim.Nsec))
 	}
 }
 

--- a/internal/app/wwctl/container/exec/main.go
+++ b/internal/app/wwctl/container/exec/main.go
@@ -124,10 +124,6 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// getting syncuser from cmd, e.g., shell comamnd will call exec command and passing --syncuser
-	if syncUserFlag, err := cmd.Flags().GetBool("syncuser"); err == nil {
-		SyncUser = SyncUser || syncUserFlag
-	}
 	userdbChanged := false
 	if !beforePasswdTime.IsZero() {
 		afterPasswdTime := getTime(path.Join(containerPath, "/etc/passwd"))

--- a/internal/app/wwctl/container/shell/main.go
+++ b/internal/app/wwctl/container/shell/main.go
@@ -22,11 +22,6 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		wwlog.Error("Unknown Warewulf container: %s", containerName)
 		os.Exit(1)
 	}
-	/*
-		for _, b := range binds {
-			allargs = append(allargs, "--bind", b)
-		}
-	*/
 	shellName := os.Getenv("SHELL")
 	if !container.ValidSource(containerName) {
 		wwlog.Error("Unknown Warewulf container: %s", containerName)
@@ -49,5 +44,6 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	wwlog.Debug("Calling exec with args: %s", allargs)
 	cntexec.SetBinds(binds)
 	cntexec.SetNode(nodeName)
+	cntexec.SyncUser = syncUser
 	return cntexec.CobraRunE(cmd, allargs)
 }

--- a/internal/app/wwctl/container/shell/root.go
+++ b/internal/app/wwctl/container/shell/root.go
@@ -25,6 +25,7 @@ var (
 	}
 	binds    []string
 	nodeName string
+	syncUser bool
 )
 
 func init() {
@@ -33,6 +34,7 @@ Bind a local path which must exist into the container. If destination is not
 set, uses the same path as source. "ro" binds read-only. "copy" temporarily
 copies the file into the container.`)
 	baseCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Create a read only view of the container for the given node")
+	baseCmd.PersistentFlags().BoolVar(&syncUser, "syncuser", false, "Synchronize UIDs/GIDs from host to container")
 }
 
 // GetRootCommand returns the root cobra.Command for the application.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Added --syncuser flag to shell command to enhance the user sync function. exec command supports --syncuser command but to trigger it, it requires userdbChanged && SyncUser flag set. shell command can now pass --syncuser flag to exec command to trigger it.

## This fixes or addresses the following GitHub issues:

 - Fixes #1344


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
