### PR TITLE
Update containers.rst to include QEMU multiarch

### DIFF
--- a/userdocs/contents/containers.rst
+++ b/userdocs/contents/containers.rst
@@ -379,3 +379,32 @@ It is possible to duplicate an installed image by using :
   # wwctl container copy CONTAINER_NAME DUPLICATED_CONTAINER_NAME
 
 This kind of duplication can be useful if you are looking for canary tests.
+
+Multi-arch container management
+============================
+It is possible to build, edit, and provision containers of different 
+architectures (i.e. aarch64) from an x86_64 host by using QEMU. Simply 
+run the appropriate command below based on your container management tools.
+
+.. code-block:: console
+
+   # sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+   # sudo podman run --rm --privileged multiarch/qemu-user-static --reset -p yes
+   # sudo singularity run docker://multiarch/qemu-user-static --reset -p yes
+
+Then, ``wwctl container exec`` will work regardless of the architecture of the container.
+For more information about QEMU, see their `GitHub <https://github.com/multiarch/qemu-user-static>`_
+
+To use wwclient on a booted container using a different architecture, 
+wwclient must be compiled for the specific architecture. This requires GOLang build
+tools 1.21 or newer. Below is an example for building wwclient for arm64:
+
+.. code-block:: console
+
+   # git clone https://github.com/warewulf/warewulf
+   # cd warewulf
+   # GOARCH=arm64 PREFIX=/ make wwclient
+   # mkdir -p /var/lib/warewulf/overlays/wwclient_arm64/rootfs/warewulf
+   # cp wwclient /var/lib/warewulf/overlays/wwclient_arm64/rootfs/warewulf
+
+Then, apply the new "wwclient_arm64" system overlay to your arm64 node/profile


### PR DESCRIPTION

## Description of the Pull Request (PR):

I added a subsection to user docs about using QEMU to work with containers of various architectures


## This fixes or addresses the following GitHub issues:

 - Addresses #1323


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
