### PR TITLE
add cow option for binds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added option for wwclient port number. #1349
 - Additional helper directions during syncuser conflict. #1359
+- Add `:cow` suffix to `wwctl container exec --bind` to temporarily copy files into the node image. #1365
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added option for wwclient port number. #1349
 - Additional helper directions during syncuser conflict. #1359
 - Add `:cow` suffix to `wwctl container exec --bind` to temporarily copy files into the node image. #1365
+- Add `:copy` suffix to `wwctl container exec --bind` to temporarily copy files into the node image. #1365
 
 ### Changed
 

--- a/internal/app/wwctl/container/exec/child/main.go
+++ b/internal/app/wwctl/container/exec/child/main.go
@@ -142,7 +142,7 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	for _, mntPnt := range mountPts {
-		if mntPnt.Cow {
+		if mntPnt.Copy {
 			continue
 		}
 		wwlog.Debug("bind mounting: %s -> %s", mntPnt.Source, path.Join(containerPath, mntPnt.Dest))
@@ -199,7 +199,7 @@ the invalid mount points. Directories always have '/' as suffix
 func checkMountPoints(containerName string, binds []*warewulfconf.MountEntry) (overlayObjects []string) {
 	overlayObjects = []string{}
 	for _, b := range binds {
-		if b.Cow {
+		if b.Copy {
 			continue
 		}
 		_, err := os.Stat(b.Source)

--- a/internal/app/wwctl/container/exec/main.go
+++ b/internal/app/wwctl/container/exec/main.go
@@ -82,8 +82,10 @@ func runContainedCmd(cmd *cobra.Command, containerName string, args []string) (e
 	wwlog.Verbose("Running contained command: %s", childArgs)
 	retVal := childCommandFunc(cmd, childArgs)
 	for _, cpyFile := range filesToCpy {
-		if err := cpyFile.removeFromContainer(containerName); err != nil {
-			wwlog.Warn("couldn't remove file: %s", err)
+		if cpyFile.shouldRemoveFromContainer(containerName) {
+			if err := cpyFile.removeFromContainer(containerName); err != nil {
+				wwlog.Warn("couldn't remove file: %s", err)
+			}
 		}
 	}
 	return retVal
@@ -183,35 +185,47 @@ type copyFile struct {
 	modTime  time.Time
 }
 
+func (this *copyFile) containerDest(containerName string) string {
+	return path.Join(container.RootFsDir(containerName), this.fileName)
+}
+
 func (this *copyFile) copyToContainer(containerName string) error {
-	containerDest := path.Join(container.RootFsDir(containerName), this.fileName)
+	containerDest := this.containerDest(containerName)
 	if _, err := os.Stat(path.Dir(containerDest)); err != nil {
-		return fmt.Errorf("destination directory doesn't exist: %s", err)
+		return err
 	} else if _, err := os.Stat(containerDest); err == nil {
-		return fmt.Errorf("file already exists in container: %s", this.fileName)
+		return err
 	} else if _, err := os.Stat(this.src); err != nil {
-		return fmt.Errorf("source doesn't exist: %s", err)
+		return err
 	} else if err := util.CopyFile(this.src, containerDest); err != nil {
-		return fmt.Errorf("couldn't copy files into container: %w", err)
+		return err
+	} else if stat, err := os.Stat(containerDest); err != nil {
+		return err
 	} else {
-		// we can ignore error as the file was copied
-		stat, _ := os.Stat(containerDest)
 		this.modTime = stat.ModTime()
 		return nil
 	}
 }
 
-func (this *copyFile) removeFromContainer(containerName string) error {
-	containerDest := path.Join(container.RootFsDir(containerName), this.fileName)
+func (this *copyFile) shouldRemoveFromContainer(containerName string) bool {
+	containerDest := this.containerDest(containerName)
 	if this.modTime.IsZero() {
-		return fmt.Errorf("not previously copied: %s", this.fileName)
+		wwlog.Debug("file was not previously copied: %s", this.fileName)
+		return false
 	} else if destStat, err := os.Stat(containerDest); err != nil {
-		return fmt.Errorf("no longer present: %s", err)
+		wwlog.Verbose("file is no longer present: %s (%s)", this.fileName, err)
+		return false
 	} else if destStat.ModTime() == this.modTime {
-		return os.Remove(containerDest)
+		wwlog.Verbose("don't remove modified file:", this.fileName)
+		return false
 	} else {
-		return fmt.Errorf("modified since copy: %s", this.fileName)
+		return true
 	}
+}
+
+func (this *copyFile) removeFromContainer(containerName string) error {
+	containerDest := this.containerDest(containerName)
+	return os.Remove(containerDest)
 }
 
 /*

--- a/internal/app/wwctl/container/exec/root.go
+++ b/internal/app/wwctl/container/exec/root.go
@@ -32,7 +32,11 @@ var (
 
 func init() {
 	baseCmd.AddCommand(child.GetCommand())
-	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, "Bind a local path into the container (must exist)")
+	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, `Bind a local path which must exist into the container. Syntax is
+source[:destination[:{ro|cow}]] If destination is not set, 
+it will the same path as source.The additional parameter is 
+ro for read only and cow, which means the file is copied into 
+the container and removed if not modified.`)
 	baseCmd.PersistentFlags().BoolVar(&SyncUser, "syncuser", false, "Synchronize UIDs/GIDs from host to container")
 	baseCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Create a read only view of the container for the given node")
 }

--- a/internal/app/wwctl/container/exec/root.go
+++ b/internal/app/wwctl/container/exec/root.go
@@ -32,11 +32,10 @@ var (
 
 func init() {
 	baseCmd.AddCommand(child.GetCommand())
-	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, `Bind a local path which must exist into the container. Syntax is
-source[:destination[:{ro|cow}]] If destination is not set, 
-it will the same path as source.The additional parameter is 
-ro for read only and cow, which means the file is copied into 
-the container and removed if not modified.`)
+	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, `source[:destination[:{ro|cow}]]
+Bind a local path which must exist into the container. If destination is not
+set, uses the same path as source. "ro" binds read-only. "cow" temporarily
+copies the file into the container.`)
 	baseCmd.PersistentFlags().BoolVar(&SyncUser, "syncuser", false, "Synchronize UIDs/GIDs from host to container")
 	baseCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Create a read only view of the container for the given node")
 }

--- a/internal/app/wwctl/container/exec/root.go
+++ b/internal/app/wwctl/container/exec/root.go
@@ -32,9 +32,9 @@ var (
 
 func init() {
 	baseCmd.AddCommand(child.GetCommand())
-	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, `source[:destination[:{ro|cow}]]
+	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, `source[:destination[:{ro|copy}]]
 Bind a local path which must exist into the container. If destination is not
-set, uses the same path as source. "ro" binds read-only. "cow" temporarily
+set, uses the same path as source. "ro" binds read-only. "copy" temporarily
 copies the file into the container.`)
 	baseCmd.PersistentFlags().BoolVar(&SyncUser, "syncuser", false, "Synchronize UIDs/GIDs from host to container")
 	baseCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Create a read only view of the container for the given node")

--- a/internal/app/wwctl/container/shell/root.go
+++ b/internal/app/wwctl/container/shell/root.go
@@ -28,11 +28,10 @@ var (
 )
 
 func init() {
-	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, `Bind a local path which must exist into the container. Syntax is
-source[:destination[:{ro|cow}]] If destination is not set, 
-it will the same path as source.The additional parameter is 
-ro for read only and cow, which means the file is copied into 
-the container and removed if not modified.`)
+	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, `source[:destination[:{ro|cow}]]
+Bind a local path which must exist into the container. If destination is not
+set, uses the same path as source. "ro" binds read-only. "cow" temporarily
+copies the file into the container.`)
 	baseCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Create a read only view of the container for the given node")
 }
 

--- a/internal/app/wwctl/container/shell/root.go
+++ b/internal/app/wwctl/container/shell/root.go
@@ -28,9 +28,9 @@ var (
 )
 
 func init() {
-	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, `source[:destination[:{ro|cow}]]
+	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, `source[:destination[:{ro|copy}]]
 Bind a local path which must exist into the container. If destination is not
-set, uses the same path as source. "ro" binds read-only. "cow" temporarily
+set, uses the same path as source. "ro" binds read-only. "copy" temporarily
 copies the file into the container.`)
 	baseCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Create a read only view of the container for the given node")
 }

--- a/internal/app/wwctl/container/shell/root.go
+++ b/internal/app/wwctl/container/shell/root.go
@@ -28,7 +28,11 @@ var (
 )
 
 func init() {
-	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, "Bind a local path into the container (must exist)")
+	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, `Bind a local path which must exist into the container. Syntax is
+source[:destination[:{ro|cow}]] If destination is not set, 
+it will the same path as source.The additional parameter is 
+ro for read only and cow, which means the file is copied into 
+the container and removed if not modified.`)
 	baseCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Create a read only view of the container for the given node")
 }
 

--- a/internal/pkg/config/mounts.go
+++ b/internal/pkg/config/mounts.go
@@ -7,5 +7,5 @@ type MountEntry struct {
 	Dest     string `yaml:"dest,omitempty"`
 	ReadOnly bool   `yaml:"readonly,omitempty"`
 	Options  string `yaml:"options,omitempty"` // ignored at the moment
-	Cow      bool   `yaml:"cow,omitempty"`     // copy the file into the container and don't remove if modified
+	Copy     bool   `yaml:"copy,omitempty"`    // temporarily copy the file into the container
 }

--- a/internal/pkg/config/mounts.go
+++ b/internal/pkg/config/mounts.go
@@ -7,4 +7,5 @@ type MountEntry struct {
 	Dest     string `yaml:"dest,omitempty"`
 	ReadOnly bool   `yaml:"readonly,omitempty"`
 	Options  string `yaml:"options,omitempty"` // ignored at the moment
+	Cow      bool   `yaml:"cow,omitempty"`     // copy the file into the container and don't remove if modified
 }

--- a/internal/pkg/container/mountpoints.go
+++ b/internal/pkg/container/mountpoints.go
@@ -21,13 +21,19 @@ func InitMountPnts(binds []string) (mounts []*warewulfconf.MountEntry) {
 			dest = bind[1]
 		}
 		readonly := false
-		if len(bind) >= 3 && bind[2] == "ro" {
-			readonly = true
+		cow := false
+		if len(bind) >= 3 {
+			if bind[2] == "ro" {
+				readonly = true
+			} else if bind[2] == "cow" {
+				cow = true
+			}
 		}
 		mntPnt := warewulfconf.MountEntry{
 			Source:   bind[0],
 			Dest:     dest,
 			ReadOnly: readonly,
+			Cow:      cow,
 		}
 		mounts = append(mounts, &mntPnt)
 	}

--- a/internal/pkg/container/mountpoints.go
+++ b/internal/pkg/container/mountpoints.go
@@ -21,19 +21,19 @@ func InitMountPnts(binds []string) (mounts []*warewulfconf.MountEntry) {
 			dest = bind[1]
 		}
 		readonly := false
-		cow := false
+		copy_ := false
 		if len(bind) >= 3 {
 			if bind[2] == "ro" {
 				readonly = true
-			} else if bind[2] == "cow" {
-				cow = true
+			} else if bind[2] == "copy" {
+				copy_ = true
 			}
 		}
 		mntPnt := warewulfconf.MountEntry{
 			Source:   bind[0],
 			Dest:     dest,
 			ReadOnly: readonly,
-			Cow:      cow,
+			Copy:     copy_,
 		}
 		mounts = append(mounts, &mntPnt)
 	}

--- a/userdocs/contents/containers.rst
+++ b/userdocs/contents/containers.rst
@@ -214,7 +214,7 @@ when using the exec command. This works as follows:
    distribution (as prescribed by the LSB file hierarchy standard).
 
 Files which should always be present in a container image like ``resolv.conf``
-can be specified in ``warewulf.conf`` with following container_exit
+can be specified in ``warewulf.conf``:
 
 .. code-block:: yaml
    container mounts:
@@ -223,10 +223,9 @@ can be specified in ``warewulf.conf`` with following container_exit
      readonly: true
 
 .. note::
-   Instead of the ``readonly`` setting you can set ``cow``, which 
-   has the effect, that the source file is copied to the container
-   and removed if it was modified. This useful for file used for
-   registrations.
+   Instead of ``readonly: true`` you can set ``cow: true``. This causes the
+   source file to be copied to the container and removed if it was not
+   modified. This can be useful for files used for registrations.
 
 When the command completes, if anything within the container changed,
 the container will be rebuilt into a bootable static object

--- a/userdocs/contents/containers.rst
+++ b/userdocs/contents/containers.rst
@@ -223,7 +223,7 @@ can be specified in ``warewulf.conf``:
      readonly: true
 
 .. note::
-   Instead of ``readonly: true`` you can set ``cow: true``. This causes the
+   Instead of ``readonly: true`` you can set ``copy: true``. This causes the
    source file to be copied to the container and removed if it was not
    modified. This can be useful for files used for registrations.
 

--- a/userdocs/contents/containers.rst
+++ b/userdocs/contents/containers.rst
@@ -213,6 +213,21 @@ when using the exec command. This works as follows:
    location, as it is almost always present and empty in every Linux
    distribution (as prescribed by the LSB file hierarchy standard).
 
+Files which should always be present in a container image like ``resolv.conf``
+can be specified in ``warewulf.conf`` with following container_exit
+
+.. code-block:: yaml
+   container mounts:
+   - source: /etc/resolv.conf
+     dest: /etc/resolv.conf
+     readonly: true
+
+.. note::
+   Instead of the ``readonly`` setting you can set ``cow``, which 
+   has the effect, that the source file is copied to the container
+   and removed if it was modified. This useful for file used for
+   registrations.
+
 When the command completes, if anything within the container changed,
 the container will be rebuilt into a bootable static object
 automatically.


### PR DESCRIPTION
The option cow can now be set for files which are then
mounted during exec, but copied into the image and removed
if not modified.

Example:
```
wwctl container shell leap15.6 --bind /root/test:/root/test:cow
```