### PR TITLE
Fix old links that pointed to warewulf-web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Update links on contributing page to point to warewulf repo.
 - Prevent Networkmanager from trying to optain IP address via DHCP
   on unused/unmanaged network interfaces.
 - Systems with no SMBIOS (Raspberry Pi) will create a UUID from

--- a/userdocs/contributing/documentation.rst
+++ b/userdocs/contributing/documentation.rst
@@ -9,9 +9,9 @@ reason for this: we want to share the love so nobody feels left out!
 
 You can contribute to the documentation by `raising an issue to
 suggest an improvement
-<https://github.com/warewulf/warewulf-web/issues/new>`_ or by sending a
-`pull request <https://github.com/warewulf/warewulf-web/compare>`_ on
-`our repository <https://github.com/warewulf/warewulf-web>`_.
+<https://github.com/warewulf/warewulf/issues/new>`_ or by sending a
+`pull request <https://github.com/warewulf/warewulf/compare>`_ on
+`our repository <https://github.com/warewulf/warewulf>`_.
 
 The current documentation is generated with `Sphinx
 <https://www.sphinx-doc.org/>`_.


### PR DESCRIPTION
- **Replace warewulf-web with warewulf in contributing links.**
- **Update CHANGELOG for PR.**
