### PR TITLE
docs: fix dracut build command in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added a link to an example SELinux-enabled node image in documentation. #1305
 - Refine error handling for `wwctl configure`. #1273
+- Updated dracut guidance for building initramfs. #1369
 
 ## v4.5.6, 2024-08-05
 

--- a/userdocs/contents/boot-management.rst
+++ b/userdocs/contents/boot-management.rst
@@ -161,7 +161,7 @@ initramfs inside the container.
 .. code-block:: shell
 
    dnf -y install warewulf-dracut
-   dracut --force --no-hostonly --add wwinit --kver $(ls /lib/modules | head -n1)
+   dracut --force --no-hostonly --add wwinit --regenerate-all
 
 Set the node's iPXE template to ``dracut`` to direct iPXE to fetch the
 node's initramfs image and boot with dracut semantics, rather than


### PR DESCRIPTION
The current command line works correctly only if one kernel is installed. It picks the oldest if there are multiple, which is rather unlikely to be correct. Using "tail" instead of "head" would work also, but `--regenerate-all` makes it briefer and safer.
