### PR TITLE
Fix typo in "profile with name ... already exists" message

### DIFF
--- a/internal/pkg/api/profile/profile.go
+++ b/internal/pkg/api/profile/profile.go
@@ -169,7 +169,7 @@ func AddProfile(nsp *wwapiv1.ProfileSetParameter) error {
 	}
 
 	if util.InSlice(nodeDB.ListAllProfiles(), nsp.ProfileNames[0]) {
-		return errors.New(fmt.Sprintf("profile with name %s allready exists", nsp.ProfileNames[0]))
+		return errors.New(fmt.Sprintf("profile with name %s already exists", nsp.ProfileNames[0]))
 	}
 
 	var nodeConf node.NodeConf


### PR DESCRIPTION
## Description of the Pull Request (PR):

"allready" should be "already"

## Before submitting a PR, make sure you have done the following:

- [X] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [X] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [X] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
