### PR TITLE
Prevent overlays from being improperly used as format strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed application of node overlays such that they override overlapping files from profile overlays. #1259
+- Prevent overlays from being improperly used as format strings during `wwctl overlay show --render`. #1363
 
 ## v4.5.6, 2024-08-05
 

--- a/internal/app/wwctl/overlay/show/main.go
+++ b/internal/app/wwctl/overlay/show/main.go
@@ -113,7 +113,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			wwlog.Info("backupFile: %v\nwriteFile: %v", backupFile, writeFile)
 			wwlog.Info("Filename: %s\n", destFileName)
 		}
-		wwlog.Info(outBuffer.String())
+		wwlog.Info("%s", outBuffer.String())
 	}
 	return nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

`wwctl overlay show --render` shows the rendered overlay with `wwlog.Info`, but that caused it to be processed as a format string. This passes an explicit format string first, and then includes the rendered overlay as a variable to the formatter.


## This fixes or addresses the following GitHub issues:

- Fixes #1363


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
