### PR TITLE
Return an error indicating that name should not contain colon when im…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Replace slice in templates with sprig substr. #1093
 - Fix an invalid format issue for the GitHub nightly build action. #1258
 
+## v4.5.8, unreleased
+
+### Fixed
+
+- Return an error indicating that name should not contain colon when importing contianers. #1371
+
 ## v4.5.7, 2024-09-11
 
 ### Added

--- a/internal/pkg/oci/puller.go
+++ b/internal/pkg/oci/puller.go
@@ -83,7 +83,10 @@ func getReference(uri string) (types.ImageReference, error) {
 	case "docker-daemon":
 		return daemon.ParseReference(strings.TrimPrefix(s[1], "//"))
 	case "file":
-		return dockerarchive.ParseReference(strings.TrimPrefix(s[1], "/"))
+		if strings.Contains(s[1], ":") {
+			return nil, fmt.Errorf("%s should not contain colon", strings.TrimPrefix(s[1], "//"))
+		}
+		return dockerarchive.ParseReference(strings.TrimPrefix(s[1], "//"))
 	default:
 		return nil, fmt.Errorf("unknown uri scheme: %q", uri)
 	}

--- a/internal/pkg/oci/puller_test.go
+++ b/internal/pkg/oci/puller_test.go
@@ -1,0 +1,70 @@
+package oci
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetReference(t *testing.T) {
+	temp, err := os.MkdirTemp(os.TempDir(), "ww-archive-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(temp)
+
+	tests := []struct {
+		name string
+		uri  string
+		err  error
+	}{
+		{
+			name: "file archive ok case",
+			uri:  "test.tar",
+			err:  nil,
+		},
+		{
+			name: "file archive ko case, because having colon in file name",
+			uri:  "test:latest.tar",
+			err:  fmt.Errorf("/test:latest.tar should not contain colon"),
+		},
+		{
+			name: "file archive ko case, because having colon in path name",
+			uri:  "/test:/test.tar",
+			err:  fmt.Errorf("/test:/test.tar should not contain colon"),
+		},
+		{
+			name: "docker ok case",
+			uri:  "docker://test:latest",
+			err:  nil,
+		},
+		{
+			name: "docker daemon ok case",
+			uri:  "docker-daemon://test:latest",
+			err:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Logf("running test: %s", tt.name)
+		if !strings.HasPrefix(tt.uri, "docker") && !strings.HasPrefix(tt.uri, "docker-daemon") {
+			tt.uri = filepath.Join(temp, tt.uri)
+			parent := filepath.Dir(tt.uri)
+			err := os.MkdirAll(parent, 0o755)
+			assert.NoError(t, err)
+			f, err := os.Create(tt.uri)
+			assert.NoError(t, err)
+			assert.NoError(t, f.Close())
+		}
+
+		_, err := getReference(tt.uri)
+		if tt.err == nil {
+			assert.NoError(t, err)
+		} else {
+			assert.ErrorContains(t, err, tt.err.Error())
+		}
+	}
+
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Return an error indicating that name should not contain colon when importing containers


## This fixes or addresses the following GitHub issues:

 - Fixes #1371


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)

## Test
```
[root@localhost test]# wwctl container import rocky8\:8.x.tar rocky8\:8.x
ERROR  : could not import image: unable to parse uri: /home/vagrant/test/rocky8:8.x.tar should not contain colon
ERROR: could not import image: unable to parse uri: /home/vagrant/test/rocky8:8.x.tar should not contain colon
```
