### PR TITLE
Improve network interface documentation

### DIFF
--- a/userdocs/contents/nodeconfig.rst
+++ b/userdocs/contents/nodeconfig.rst
@@ -178,7 +178,7 @@ provide the network information as follows:
 
 .. code-block:: console
 
-  # wwctl node set --netdev eth0 --hwaddr 11:22:33:44:55:66 --ipaddr 10.0.2.1 --netmask 255.255.252.0 n001
+  # wwctl node set --netdev eno1 --hwaddr 11:22:33:44:55:66 --ipaddr 10.0.2.1 --netmask 255.255.252.0 n001
    Are you sure you want to modify 1 nodes(s): y
 
 You can now see that the node contains configuration attributes for
@@ -212,7 +212,7 @@ container, kernel, and network:
   n001                 profile            --           default
   n001                 default:type       --           (ethernet)
   n001                 default:onboot     --           --
-  n001                 default:netdev     --           eth0
+  n001                 default:netdev     --           eno1
   n001                 default:hwaddr     --           11:22:33:44:55:66
   n001                 default:ipaddr     --           10.0.2.1
   n001                 default:ipaddr6    --           --
@@ -227,8 +227,12 @@ container, kernel, and network:
   # wwctl node list -a n001 | grep cluster
   n001                 cluster            --           cluster01
 
+Note: Due to the way network interface names are assigned by the Linux kernel and overwritten by udev
+and systemd in the default warewulf configuration, the use of `eth0/1/...` as interface names can lead to issues.
+We recommend the use of the original predictable names assigned to the interfaces (`eno1, ...`),
+as otherwise an interface may remain unconfigured if its name conflicts with the name of an already existing interface during boot.
 
-To configure a bonded (link aggreagtion) network interface the following commands can be used:
+To configure a bonded (link aggregation) network interface the following commands can be used:
 
 .. code-block:: console
 

--- a/userdocs/contents/nodeconfig.rst
+++ b/userdocs/contents/nodeconfig.rst
@@ -227,10 +227,11 @@ container, kernel, and network:
   # wwctl node list -a n001 | grep cluster
   n001                 cluster            --           cluster01
 
-Note: Due to the way network interface names are assigned by the Linux kernel and overwritten by udev
-and systemd in the default warewulf configuration, the use of `eth0/1/...` as interface names can lead to issues.
-We recommend the use of the original predictable names assigned to the interfaces (`eno1, ...`),
-as otherwise an interface may remain unconfigured if its name conflicts with the name of an already existing interface during boot.
+.. note::
+  Due to the way network interface names are assigned by the Linux kernel and overwritten by udev
+  and systemd in the default warewulf configuration, the use of `eth0/1/...` as interface names can lead to issues.
+  We recommend the use of the original predictable names assigned to the interfaces (`eno1, ...`),
+  as otherwise an interface may remain unconfigured if its name conflicts with the name of an already existing interface during boot.
 
 To configure a bonded (link aggregation) network interface the following commands can be used:
 

--- a/userdocs/contents/overlays.rst
+++ b/userdocs/contents/overlays.rst
@@ -46,9 +46,9 @@ network configurations for
 * NetworkManager
 * EL legacy network scripts
 
-it also contains udev rules, which will set the interface name of the
-first network device to ``eth0``.  Before the ``systemd`` init is
-called, the overlay loops through the scripts in
+it also contains udev rules, which will set the interface names
+based on the hardware addresses configured for the node. 
+Before the ``systemd`` init is called, the overlay loops through the scripts in
 ``/wwinit/warwulf/init.d/*`` which will setup
 
 * Ipmi


### PR DESCRIPTION
## Description of the Pull Request (PR):

The default naming scheme suggested in the documentation (eth0) can cause issues due to race conditions in device enumeration. Their usage in `.link` systemd unit files is discouraged https://github.com/systemd/systemd/issues/16665 and I've observed network interfaces getting named incorrectly if their name is already in use during boot.

To avoid this issue, I want to add a note mentioning the preferred naming scheme (predictable naming based on what the OS would do anyways).

Ideally, I would prefer if we would not have to deal with interface names at all, and could just use MAC addresses to identify the interfaces, but that would probably be much harder to do correctly.

## This fixes or addresses the following GitHub issues:


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] ~~Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary~~
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
