### PR TITLE
Return error code if overlay build fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `/sys/firmware/devicetree/base/serial-number`
 - Replace slice in templates with sprig substr. #1093
 - Fix an invalid format issue for the GitHub nightly build action. #1258
+- Return non-zero exit code on overlay build failure #1393
 
 ## v4.5.7, 2024-09-11
 

--- a/internal/app/wwctl/overlay/build/main.go
+++ b/internal/app/wwctl/overlay/build/main.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 
@@ -77,7 +78,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	if BuildHost && controller.Warewulf.EnableHostOverlay {
 		err := overlay.BuildHostOverlay()
 		if err != nil {
-			wwlog.Warn("host overlay could not be built: %s", err)
+			return errors.New(fmt.Sprintf("host overlay could not be built: %s", err))
 		}
 	}
 
@@ -89,7 +90,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 
 		if err != nil {
-			wwlog.Warn("Some overlays failed to be generated: %s", err)
+			return errors.New(fmt.Sprintf("Some overlays failed to be generated: %s", err))
 		}
 	}
 	return nil

--- a/internal/app/wwctl/overlay/build/main.go
+++ b/internal/app/wwctl/overlay/build/main.go
@@ -78,7 +78,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	if BuildHost && controller.Warewulf.EnableHostOverlay {
 		err := overlay.BuildHostOverlay()
 		if err != nil {
-			return errors.New(fmt.Sprintf("host overlay could not be built: %s", err))
+			return fmt.Errorf("host overlay could not be built: %s", err)
 		}
 	}
 
@@ -90,7 +90,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 
 		if err != nil {
-			return errors.New(fmt.Sprintf("Some overlays failed to be generated: %s", err))
+			return fmt.Errorf("Some overlays failed to be generated: %s", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

If `wwctl overlay build` fails, currently we only print a warning. This should be an error instead, to be used in scripts

## This fixes or addresses the following GitHub issues:

 - Partial fix for #1390 

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x]  Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
