### PR TITLE
Set mpol=interleave on dracut tmpfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## v4.5.8, unreleased
 
+### Changed
+
+- Interleave tmpfs across all available NUMA nodes. #1347, #1348
+
 ### Fixed
 
 - Return an error during `wwctl container import` if archive filename includes a colon. #1371

--- a/dracut/modules.d/90wwinit/load-wwinit.sh
+++ b/dracut/modules.d/90wwinit/load-wwinit.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 info "Mounting tmpfs at $NEWROOT"
-mount -t tmpfs ${wwinit_tmpfs_size_option} tmpfs "$NEWROOT"
+mount -t tmpfs -o mpol=interleave ${wwinit_tmpfs_size_option} tmpfs "$NEWROOT"
 
 for archive in "${wwinit_container}" "${wwinit_kmods}" "${wwinit_system}" "${wwinit_runtime}"
 do

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -39,7 +39,7 @@ elif test "$WWROOT" = "tmpfs"; then
     else
         echo "Setting up tmpfs root file system"
         mkdir /newroot
-        mount wwroot /newroot -t tmpfs
+        mount wwroot /newroot -t tmpfs -o mpol=interleave
         echo "Moving RAMFS to TMPFS"
         tar -cf - --exclude ./proc --exclude ./sys --exclude ./dev --exclude ./newroot . | tar -xf - -C /newroot
         mkdir /newroot/proc /newroot/dev /newroot/sys /newroot/run 2>/dev/null


### PR DESCRIPTION
## Description of the Pull Request (PR):

Configures Warewulf tmpfs to interleave across all available NUMA nodes.

## This fixes or addresses the following GitHub issues:

- Closes #1347

## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
