### PR TITLE
Init rootfs fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Return an error during `wwctl container import` if archive filename includes a colon. #1371
 - Correctly extract smbios asset key during Grub boot. #1291
+- Refactor of `wwinit/init` to more properly address rootfs options. #1098
 
 ## v4.5.7, 2024-09-11
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -38,3 +38,4 @@
 * Tobias Poschwatta <poschwatta@zib.de>
 * Josh Burks <jeburks2@asu.edu>
 * Elmar Pruesse <pruessee@njhealth.org> @epruesse
+* Adam Michel <elfurbe@furbism.com> [@elfurbe](https://github.com/elfurbe)

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -5,59 +5,49 @@
 #
 # Edit at your own risk! DANGER DANGER.
 
+echo -n "Mounting kernel file systems:"
+mkdir /proc /dev /sys /run 2>/dev/null
+mount -t proc proc /proc && echo -n " /proc"
+mount -t devtmpfs devtmpfs /dev && echo -n " /dev"
+mount -t sysfs sysfs /sys && echo -n " /sys"
+mount -t tmpfs tmpfs /run && echo -n " /run"
+echo
 
 if [ -f "/warewulf/config" ]; then
     . /warewulf/config
 else
-    echo "ERROR: Warewulf configuration file not found... rebooting in 1 minute"
+    echo "ERROR: Warewulf configuration file not found."
+    echo "Rebooting in 1 minute..."
     sleep 60
-    echo b > /proc/sysrq-trigger || /sbin/reboot
+    echo b > /proc/sysrq-trigger || /sbin/reboot -f
 fi
 
+echo
 echo "Warewulf v4 is now booting: ${WWHOSTNAME}"
 echo
 
-echo "Mounting up kernel file systems"
-mkdir /proc /dev /sys /run 2>/dev/null
-mount -t proc proc /proc
-mount -t devtmpfs devtmpfs /dev
-mount -t sysfs sysfs /sys
-mount -t tmpfs tmpfs /run
-
 chmod 755 /warewulf/wwinit
 
-echo -n "Checking Rootfs type..."
-ROOTFSTYPE=`stat -f -c "%T" /`
-echo "${ROOTFSTYPE}"
-
-
-if [ -n "${WWROOT}" ] && [ "${WWROOT}" != "${ROOTFSTYPE}" ]; then
-    echo "Requested rootfs type does not match current rootfs type. Pivoting to new rootfs..."
-    if [ "${WWROOT}" == "ramfs" ] || [ "${WWROOT}" == "tmpfs" ]; then
-        mkdir /newroot
-        mount wwroot /newroot -t ${WWROOT} -o mpol=interleave
-        tar cf - --exclude ./proc --exclude ./sys --exclude ./dev --exclude ./run --exclude ./newroot . | tar xf - -C /newroot
-        mkdir /newroot/proc /newroot/dev /newroot/sys /newroot/run 2>/dev/null
-        echo "Switching to new rootfs and invoking /warewulf/wwinit..."
-        exec /sbin/switch_root /newroot /warewulf/wwinit
-    elif [ "${WWROOT}" == "initramfs" ]; then
-        echo ">>> Deprecated option \"initramfs\" chosen."
-        echo ">>> The 'initramfs' can be either a ramfs or a tmpfs natively, depending on kernel configuration."
-        echo ">>> If you wish to use whatever this kernel chooses by default, remove the 'root' setting from your nodes/profiles."
-        echo "Invoking /warewulf/wwinit..."
-        exec /warewulf/wwinit
-    else
-        echo "Unrecognized rootfs type requested: ${WWROOT}"
-        echo "Rebooting in 1 minute..."
-        sleep 60
-        /sbin/reboot -f
-    fi
-else
-    echo "Invoking /warewulf/wwinit..."
+if [ -z "${WWROOT}" -o "${WWROOT}" == "initramfs" ]; then
+    echo "Retaining initramfs and invoking /warewulf/wwinit..."
     exec /warewulf/wwinit
+elif [ "${WWROOT}" == "ramfs" -o "${WWROOT}" == "tmpfs" ]; then
+    echo "Setting up new ${WWROOT} rootfs..."
+    mkdir /newroot
+    mount wwroot /newroot -t ${WWROOT} -o mpol=interleave # mpol ignored for ramfs
+    tar -cf - --exclude ./proc --exclude ./sys --exclude ./dev --exclude ./run --exclude ./newroot . | tar -xf - -C /newroot
+    mkdir /newroot/proc /newroot/dev /newroot/sys /newroot/run 2>/dev/null
+    echo "Switching to new rootfs and invoking /warewulf/wwinit..."
+    exec /sbin/switch_root /newroot /warewulf/wwinit
+else
+    echo "ERROR: Unrecognized rootfs type requested: ${WWROOT}"
+    echo "Rebooting in 1 minute..."
+    sleep 60
+    echo b > /proc/sysrq-trigger || /sbin/reboot -f
 fi
 
 echo
-echo "There was a problem with the initial provisioning process, rebooting in 1 minute..."
+echo "ERROR: There was a problem with the initial provisioning process.
+echo "Rebooting in 1 minute..."
 sleep 60
 echo b > /proc/sysrq-trigger || /sbin/reboot -f

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -6,7 +6,7 @@
 # Edit at your own risk! DANGER DANGER.
 
 
-if test -f "/warewulf/config"; then
+if [ -f "/warewulf/config" ]; then
     . /warewulf/config
 else
     echo "ERROR: Warewulf configuration file not found... rebooting in 1 minute"
@@ -14,7 +14,7 @@ else
     echo b > /proc/sysrq-trigger || /sbin/reboot
 fi
 
-echo "Warewulf v4 is now booting: $WWHOSTNAME"
+echo "Warewulf v4 is now booting: ${WWHOSTNAME}"
 echo
 
 echo "Mounting up kernel file systems"
@@ -26,31 +26,38 @@ mount -t tmpfs tmpfs /run
 
 chmod 755 /warewulf/wwinit
 
-echo "Checking Rootfs type"
+echo -n "Checking Rootfs type..."
 ROOTFSTYPE=`stat -f -c "%T" /`
+echo "${ROOTFSTYPE}"
 
-if test "$WWROOT" = "initramfs"; then
-    echo "Provisioned to default initramfs file system: $ROOTFSTYPE"
-    echo "Calling WW Init"
-    exec /warewulf/wwinit
-elif test "$WWROOT" = "tmpfs"; then
-    if test "$ROOTFSTYPE" = "tmpfs"; then
-        echo "ERROR: Switching the root file system requires the kernel argument: 'rootfstype=ramfs'"
-    else
-        echo "Setting up tmpfs root file system"
+
+if [ -n "${WWROOT}" ] && [ "${WWROOT}" != "${ROOTFSTYPE}" ]; then
+    echo "Requested rootfs type does not match current rootfs type. Pivoting to new rootfs..."
+    if [ "${WWROOT}" == "ramfs" ] || [ "${WWROOT}" == "tmpfs" ]; then
         mkdir /newroot
-        mount wwroot /newroot -t tmpfs -o mpol=interleave
-        echo "Moving RAMFS to TMPFS"
-        tar -cf - --exclude ./proc --exclude ./sys --exclude ./dev --exclude ./newroot . | tar -xf - -C /newroot
+        mount wwroot /newroot -t ${WWROOT} -o mpol=interleave
+        tar cf - --exclude ./proc --exclude ./sys --exclude ./dev --exclude ./run --exclude ./newroot . | tar xf - -C /newroot
         mkdir /newroot/proc /newroot/dev /newroot/sys /newroot/run 2>/dev/null
-        echo "Calling switch_root and invoking WW Init"
+        echo "Switching to new rootfs and invoking /warewulf/wwinit..."
         exec /sbin/switch_root /newroot /warewulf/wwinit
+    elif [ "${WWROOT}" == "initramfs" ]; then
+        echo ">>> Deprecated option \"initramfs\" chosen."
+        echo ">>> The 'initramfs' can be either a ramfs or a tmpfs natively, depending on kernel configuration."
+        echo ">>> If you wish to use whatever this kernel chooses by default, remove the 'root' setting from your nodes/profiles."
+        echo "Invoking /warewulf/wwinit..."
+        exec /warewulf/wwinit
+    else
+        echo "Unrecognized rootfs type requested: ${WWROOT}"
+        echo "Rebooting in 1 minute..."
+        sleep 60
+        /sbin/reboot -f
     fi
 else
-    echo "ERROR: Unknown Warewulf Root file system: $WWROOT"
+    echo "Invoking /warewulf/wwinit..."
+    exec /warewulf/wwinit
 fi
 
 echo
-echo "There was a problem with the provisioning process, rebooting in 1 minute..."
+echo "There was a problem with the initial provisioning process, rebooting in 1 minute..."
 sleep 60
-echo b > /proc/sysrq-trigger || /sbin/reboot
+echo b > /proc/sysrq-trigger || /sbin/reboot -f


### PR DESCRIPTION
## Description of the Pull Request (PR):

Extends and replaces #822, which removes any requirement that rootfstype be set, and permits a null "root" paramater, by further simplifying the script and un-deprecating the default "initramfs" value so as to avoid deprecation during a maintenance release.

Also squashes the commits from #822 to simplify the commit history.

## This fixes or addresses the following GitHub issues:

- Fixes #1093 
- Extends / replaces #822 

## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)