### PR TITLE
Additional help test when container.RunDir already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Correctly extract smbios asset key during Grub boot. #1291
 - Refactor of `wwinit/init` to more properly address rootfs options. #1098
 
+### Added
+
+- Additional help test when container.RunDir already exists. #1389
+
 ## v4.5.7, 2024-09-11
 
 ### Added

--- a/internal/app/wwctl/container/exec/main.go
+++ b/internal/app/wwctl/container/exec/main.go
@@ -4,7 +4,6 @@
 package exec
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -42,7 +41,7 @@ func runContainedCmd(cmd *cobra.Command, containerName string, args []string) (e
 	runDir := container.RunDir(containerName)
 	if err := os.Mkdir(runDir, 0750); err != nil {
 		if _, existerr := os.Stat(runDir); !os.IsNotExist(existerr) {
-			return errors.New("run directory already exists: another container command may already be running")
+			return fmt.Errorf("run directory already exists: another container command may already be running (otherwise, remove %s)", runDir)
 		} else {
 			return fmt.Errorf("unable to create run directory: %w", err)
 		}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Additional help test when container.RunDir already exists


## This fixes or addresses the following GitHub issues:

- Closes #1389


## Before submitting a PR, make sure you have done the following:

- [x] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [x] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [x] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [x] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
