### PR TITLE
Return non-zero exit code on container copy failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Replace slice in templates with sprig substr. #1093
 - Fix an invalid format issue for the GitHub nightly build action. #1258
 - Return non-zero exit code on overlay build failure #1393
+- Return non-zero exit code on container copy failure #1377
 
 ## v4.5.8, unreleased
 

--- a/internal/app/wwctl/container/copy/main.go
+++ b/internal/app/wwctl/container/copy/main.go
@@ -21,28 +21,22 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	if !container.DoesSourceExist(cdp.ContainerSource) {
-		wwlog.Error("Container's source doesn't exists: %s", cdp.ContainerSource)
-		return
+		return fmt.Errorf("container's source doesn't exists: %s", cdp.ContainerSource)
 	}
 
 	if !container.ValidName(cdp.ContainerDestination) {
-		wwlog.Error("Container name contains illegal characters : %s", cdp.ContainerDestination)
-		return
+		return fmt.Errorf("container name contains illegal characters : %s", cdp.ContainerDestination)
 	}
 
 	if container.DoesSourceExist(cdp.ContainerDestination) {
-		wwlog.Error("An other container with name: %s already exists in sources.", cdp.ContainerDestination)
-		return
+		return fmt.Errorf("an other container with name: %s already exists in sources", cdp.ContainerDestination)
 	}
 
 	err = container.Duplicate(cdp.ContainerSource, cdp.ContainerDestination)
 	if err != nil {
-		err = fmt.Errorf("could not duplicate image: %s", err.Error())
-		wwlog.Error(err.Error())
-		return
+		return fmt.Errorf("could not duplicate image: %s", err.Error())
 	}
 
 	wwlog.Info("Container %s successfully duplicated as %s", cdp.ContainerSource, cdp.ContainerDestination)
 	return
-
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Return non-zero exit code on container copy failure


## This fixes or addresses the following GitHub issues:

 - Fixes #1377


## Before submitting a PR, make sure you have done the following:

- [ ] Signed off on all commits (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] Read the [documentation for contributing to Warewulf](https://warewulf.org/docs/main/contributing/contributing.html)
- [ ] Added changes to the [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) if necessary
- [ ] Updated [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) if necessary
- [ ] Based this PR against the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] Added myself as a contributor to the [Contributors File](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)

## Test
```
[root@localhost test]# wwctl container copy rockylinux-9 rockylinux-9-tmp
ERROR: an other container with name: rockylinux-9-tmp already exists in sources
[root@localhost test]# echo $?
255
```
