### PR TITLE
InfoErr function for wwctl overlay show -r

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added command line parameters for credentials of a container registry
 - Add flag `--build` to `wwctl container copy`. #1378
 - Add `wwctl clean` to remove OCI cache and overlays from deleted nodes
+- Add an InfoErr loglevel for sending INFO level logs to stderr instead of stdout
+- Use new InfoErr loglevel to send INFO output from `wwctl overlay show -r ...`
+  to stderr making it simpler to capture rendered template files.
 
 ### Changed
 

--- a/internal/app/wwctl/overlay/show/main.go
+++ b/internal/app/wwctl/overlay/show/main.go
@@ -87,9 +87,9 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				wwlog.Debug("Found multifile comment, new filename %s", filenameFromTemplate[0][1])
 				if foundFileComment {
 					if !Quiet {
-						wwlog.Info("backupFile: %v", backupFile)
-						wwlog.Info("writeFile: %v", writeFile)
-						wwlog.Info("Filename: %s", destFileName)
+						wwlog.InfoErr("backupFile: %v", backupFile)
+						wwlog.InfoErr("writeFile: %v", writeFile)
+						wwlog.InfoErr("Filename: %s\n", destFileName)
 					}
 					wwlog.Output("%s", outBuffer.String())
 					outBuffer.Reset()
@@ -101,9 +101,9 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			}
 		}
 		if !Quiet {
-			wwlog.Info("backupFile: %v", backupFile)
-			wwlog.Info("writeFile: %v", writeFile)
-			wwlog.Info("Filename: %s", destFileName)
+			wwlog.InfoErr("backupFile: %v", backupFile)
+			wwlog.InfoErr("writeFile: %v", writeFile)
+			wwlog.InfoErr("Filename: %s", destFileName)
 		}
 		wwlog.Output("%s", outBuffer.String())
 	}

--- a/internal/pkg/wwlog/wwlog.go
+++ b/internal/pkg/wwlog/wwlog.go
@@ -43,6 +43,7 @@ var (
 	OUT         = SetLevelName(22, "OUT")
 	SECINFO     = SetLevelName(21, "SECINFO")
 	INFO        = SetLevelName(20, "INFO")
+	INFOERR     = SetLevelName(23, "INFOERR")
 	SECVERBOSE  = SetLevelName(16, "SECVERBOSE")
 	VERBOSE     = SetLevelName(15, "VERBOSE")
 	SECDEBUG    = SetLevelName(11, "SECDEBUG")
@@ -117,7 +118,7 @@ func DefaultFormatter(logLevel int, rec *LogRecord) string {
 		}
 	}
 
-	if (rec.Level == INFO || rec.Level == OUT) && logLevel == INFO {
+	if (rec.Level == INFO || rec.Level == OUT || rec.Level == INFOERR) && logLevel == INFO {
 		// NOTE: this is a bit strange, but for user-friendliness it makes sense
 		// to not pollute the messages unless something bad happens (by default).
 		// if logLevel > INFO, then level == INFO messages should not be printed anyway,
@@ -253,6 +254,10 @@ func SecVerbose(message string, a ...interface{}) {
 
 func Info(message string, a ...interface{}) {
 	LogCaller(INFO, 1, nil, message, a...)
+}
+
+func InfoErr(message string, a ...interface{}) {
+	LogCaller(INFOERR, 1, nil, message, a...)
 }
 
 func Output(message string, a ...interface{}) {


### PR DESCRIPTION
- **Add INFOERR to wwlog**
- **Use InofErr to send info to stderr**
- **Updated CHANGELOG.md.**

## Description of the Pull Request (PR):

It's useful to be able to capture the output of a rendered template for testing
and debugging, for instance when a template produces a script that has no other
dependencies and can be easily tested without needing to build/deploy the
entire overlay or if an overlay is being used to manage host configs outside of
the exiting `host` overlay framework. 

This commit adds and InfoErr level which allows sending INFO level output to
stderr instead of stdout. This function is then used in the `overlay show -r`
command to send the informational output to stderr allowing the rendered
template to easily be captured by simply redirection the output to a file. 



