### PR TITLE
Fix panic on container import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Correctly extract smbios asset key during Grub boot. #1291
 - Refactor of `wwinit/init` to more properly address rootfs options. #1098
 - Fix autodetected kernel sorting issue. #1332
+- Avoid panic on container import #1244
 
 ## v4.5.7, 2024-09-11
 

--- a/internal/pkg/container/imprt.go
+++ b/internal/pkg/container/imprt.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/drivers/copy"
+	"github.com/containers/storage/pkg/reexec"
 	"github.com/pkg/errors"
 
 	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
@@ -67,7 +68,9 @@ func ImportDirectory(uri string, name string) error {
 	if !util.IsFile(path.Join(uri, "/bin/sh")) {
 		return errors.New("Source directory has no /bin/sh: " + uri)
 	}
-
+	if reexec.Init() {
+		return errors.New("couldn't init reexec")
+	}
 	err = copy.DirCopy(uri, fullPath, copy.Content, true)
 	if err != nil {
 		return err


### PR DESCRIPTION
`copy.DirCopy` is internal and needs Init to be called

- Closes #1244 

Re-submission of #1246

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
