### PR TITLE
return non-zero exit code on container sub-commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix an invalid format issue for the GitHub nightly build action. #1258
 - Return non-zero exit code on overlay build failure #1393
 - Return non-zero exit code on container copy failure #1377
+- Return non-zero exit code on container sub-commands #1414
 
 ## v4.5.8, unreleased
 

--- a/internal/app/wwctl/container/exec/main.go
+++ b/internal/app/wwctl/container/exec/main.go
@@ -97,8 +97,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	containerName := args[0]
 	wwlog.Debug("CobraRunE:containerName: %v", containerName)
 	if !container.ValidSource(containerName) {
-		wwlog.Error("Unknown Warewulf container: %s", containerName)
-		os.Exit(1)
+		return fmt.Errorf("unknown Warewulf container: %s", containerName)
 	}
 	os.Setenv("WW_CONTAINER_SHELL", containerName)
 
@@ -111,16 +110,14 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	err := runContainedCmd(cmd, containerName, args[1:])
 	if err != nil {
-		wwlog.Error("Failed executing container command: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("failed executing container command: %s", err)
 	}
 
 	if util.IsFile(path.Join(containerPath, "/etc/warewulf/container_exit.sh")) {
 		wwlog.Verbose("Found clean script: /etc/warewulf/container_exit.sh")
 		err = runContainedCmd(cmd, containerName, []string{"/bin/sh", "/etc/warewulf/container_exit.sh"})
 		if err != nil {
-			wwlog.Error("Failed executing exit script: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("failed executing exit script: %s", err)
 		}
 	}
 
@@ -155,8 +152,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Rebuilding container...\n")
 	err = container.Build(containerName, false)
 	if err != nil {
-		wwlog.Error("Could not build container %s: %s", containerName, err)
-		os.Exit(1)
+		return fmt.Errorf("could not build container %s: %s", containerName, err)
 	}
 	return nil
 }

--- a/internal/app/wwctl/container/list/main.go
+++ b/internal/app/wwctl/container/list/main.go
@@ -9,7 +9,6 @@ import (
 	apicontainer "github.com/warewulf/warewulf/internal/pkg/api/container"
 	"github.com/warewulf/warewulf/internal/pkg/container"
 	"github.com/warewulf/warewulf/internal/pkg/util"
-	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
 var containerList = apicontainer.ContainerList
@@ -20,7 +19,6 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 		if showSize || vars.full || vars.kernel {
 			containerInfo, err := containerList()
 			if err != nil {
-				wwlog.Error("%s", err)
 				return err
 			}
 			if vars.full {

--- a/internal/app/wwctl/container/rename/main.go
+++ b/internal/app/wwctl/container/rename/main.go
@@ -30,8 +30,7 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	if !container.ValidName(crp.TargetName) {
-		wwlog.Error("Container name contains illegal characters : %s", crp.TargetName)
-		return
+		return fmt.Errorf("container name contains illegal characters : %s", crp.TargetName)
 	}
 
 	err = api.ContainerRename(crp)

--- a/internal/app/wwctl/container/shell/main.go
+++ b/internal/app/wwctl/container/shell/main.go
@@ -4,6 +4,7 @@
 package shell
 
 import (
+	"fmt"
 	"os"
 	"path"
 
@@ -19,13 +20,11 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	var allargs []string
 
 	if !container.ValidSource(containerName) {
-		wwlog.Error("Unknown Warewulf container: %s", containerName)
-		os.Exit(1)
+		return fmt.Errorf("unknown Warewulf container: %s", containerName)
 	}
 	shellName := os.Getenv("SHELL")
 	if !container.ValidSource(containerName) {
-		wwlog.Error("Unknown Warewulf container: %s", containerName)
-		os.Exit(1)
+		return fmt.Errorf("unknown Warewulf container: %s", containerName)
 	}
 	var shells []string
 	if shellName == "" {

--- a/internal/app/wwctl/container/syncuser/main.go
+++ b/internal/app/wwctl/container/syncuser/main.go
@@ -2,7 +2,6 @@ package syncuser
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	container_build "github.com/warewulf/warewulf/internal/pkg/api/container"
@@ -18,8 +17,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 	err := container.SyncUids(containerName, write)
 	if err != nil {
-		wwlog.Error("Error in synchronize: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("error in synchronize: %s", err)
 	}
 
 	if write && !build {
@@ -35,8 +33,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 		err := container_build.ContainerBuild(cbp)
 		if err != nil {
-			wwlog.Error("Error during container build: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("error during container build: %s", err)
 		}
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

return non-zero exit code on container sub-commands


## This fixes or addresses the following GitHub issues:

- Fixes #1414


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
