### PR TITLE
Fix a "wicked" ifcfg overlay regression

### DIFF
--- a/overlays/wwinit/rootfs/etc/wicked/ifconfig/ifcfg.xml.ww
+++ b/overlays/wwinit/rootfs/etc/wicked/ifconfig/ifcfg.xml.ww
@@ -1,6 +1,7 @@
 {{- $host := .BuildHost }}
 {{- $time := .BuildTime }}
 {{- $source := .BuildSource }}
+{{ $NetDevs := .NetDevs -}}{{/* FIX: 1413 */ -}}
 {{range $devname, $netdev := .ThisNode.NetDevs -}}
 {{- $filename := print "ifcfg-" $devname ".xml" }}
 {{- file $filename }}
@@ -29,7 +30,7 @@ Source: {{ $source }}
   </ipv4>
   <ipv4:static>
     <address>
-      <local>{{$netdev.IpCIDR.Get}}</local>
+      <local>{{ (index $NetDevs $devname).IpCIDR }}</local>
     </address>
 {{ if $netdev.Gateway.Get -}}
     <route>


### PR DESCRIPTION
## Description of the Pull Request (PR):

#1410 introduced a regression in the "wicked" template by switching from the local `.NetDevs` data to `.ThisNode.NetDevs` where `IpCIDR` isn't populated correctly. (See also #1413 for underlying issue.)

This PR returns to using `.NetDevs` for `IpCIDR` until the underlying issue is fixed (possibly by #1020).

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
