### PR TITLE
Return non-zero exit code on node sub-commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Return non-zero exit code on container copy failure #1377
 - Return non-zero exit code on container sub-commands #1414
 - Fix excessive line spacing issue when listing nodes. #1241
+- Return non-zero exit code on node sub-commands #1421
 
 ## v4.5.8, unreleased
 

--- a/internal/app/wwctl/node/console/main.go
+++ b/internal/app/wwctl/node/console/main.go
@@ -16,14 +16,12 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Error("Could not open node configuration: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not open node configuration: %s", err)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Error("Could not get node list: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not get node list: %s", err)
 	}
 
 	args = hostlist.Expand(args)
@@ -37,8 +35,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(nodes) == 0 {
-		fmt.Printf("No nodes found\n")
-		os.Exit(1)
+		return fmt.Errorf("no nodes found")
 	}
 
 	for _, node := range nodes {

--- a/internal/app/wwctl/node/edit/main.go
+++ b/internal/app/wwctl/node/edit/main.go
@@ -23,12 +23,10 @@ import (
 func CobraRunE(cmd *cobra.Command, args []string) error {
 	canWrite, err := apiutil.CanWriteConfig()
 	if err != nil {
-		wwlog.Error("While checking whether can write config, err: %w", err)
-		os.Exit(1)
+		return fmt.Errorf("while checking whether can write config, err: %w", err)
 	}
 	if !canWrite.CanWriteConfig {
-		wwlog.Error("Can't write to config exiting")
-		os.Exit(1)
+		return fmt.Errorf("can not write to config exiting")
 	}
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
@@ -46,7 +44,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	_ = yaml.Unmarshal([]byte(nodeListMsg.NodeConfMapYaml), nodeMap)
 	file, err := os.CreateTemp(os.TempDir(), "ww4NodeEdit*.yaml")
 	if err != nil {
-		wwlog.Error("Could not create temp file:%s \n", err)
+		return fmt.Errorf("could not create temp file: %s", err)
 	}
 	defer os.Remove(file.Name())
 	yamlTemplate := node.UnmarshalConf(node.NodeConf{}, []string{"tagsdel", "default", "profiles"})
@@ -65,8 +63,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		sum1 := hex.EncodeToString(hasher.Sum(nil))
 		err = util.ExecInteractive(editor, file.Name())
 		if err != nil {
-			wwlog.Error("Editor process existed with non-zero\n")
-			os.Exit(1)
+			return fmt.Errorf("editor process existed with non-zero")
 		}
 		_, _ = file.Seek(0, 0)
 		hasher.Reset()
@@ -125,8 +122,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 					Hash:            newHash.Hash,
 				})
 				if err != nil {
-					wwlog.Error("Got following problem when writing back yaml: %s", err)
-					os.Exit(1)
+					return fmt.Errorf("got following problem when writing back yaml: %s", err)
 				}
 				break
 			}

--- a/internal/app/wwctl/node/export/main.go
+++ b/internal/app/wwctl/node/export/main.go
@@ -1,11 +1,10 @@
 package export
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	apinode "github.com/warewulf/warewulf/internal/pkg/api/node"
 	"github.com/warewulf/warewulf/internal/pkg/api/routes/wwapiv1"
+	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
@@ -21,6 +20,6 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		// got proper yaml back
 		_ = yaml.Unmarshal([]byte(nodeListMsg.NodeConfMapYaml), nodeMap)
 	*/
-	fmt.Println(nodeListMsg.NodeConfMapYaml)
+	wwlog.Info(nodeListMsg.NodeConfMapYaml)
 	return nil
 }

--- a/internal/app/wwctl/node/sensors/main.go
+++ b/internal/app/wwctl/node/sensors/main.go
@@ -17,14 +17,12 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Error("Could not open node configuration: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not open node configuration: %s", err)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Error("Could not get node list: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not get node list: %s", err)
 	}
 
 	args = hostlist.Expand(args)
@@ -38,7 +36,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(nodes) == 0 {
-		fmt.Printf("No nodes found\n")
+		wwlog.Info("No nodes found")
 		os.Exit(1)
 	}
 

--- a/internal/app/wwctl/node/set/main.go
+++ b/internal/app/wwctl/node/set/main.go
@@ -2,7 +2,6 @@ package set
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -54,8 +53,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 		delete(vars.nodeConf.Disks, "UNDEF")
 		buffer, err := yaml.Marshal(vars.nodeConf)
 		if err != nil {
-			wwlog.Error("Can't marshall nodeInfo", err)
-			os.Exit(1)
+			return fmt.Errorf("can not marshall nodeInfo: %s", err)
 		}
 		wwlog.Debug("sending following values: %s", string(buffer))
 		set := wwapiv1.NodeSetParameter{

--- a/internal/pkg/api/node/node.go
+++ b/internal/pkg/api/node/node.go
@@ -102,8 +102,7 @@ func NodeDelete(ndp *wwapiv1.NodeDeleteParameter) (err error) {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Error("Failed to open node database: %s", err)
-		return
+		return fmt.Errorf("failed to open node database: %s", err)
 	}
 	dbHash := nodeDB.Hash()
 	if hex.EncodeToString(dbHash[:]) != ndp.Hash && !ndp.Force {
@@ -138,27 +137,23 @@ func NodeDelete(ndp *wwapiv1.NodeDeleteParameter) (err error) {
 func NodeDeleteParameterCheck(ndp *wwapiv1.NodeDeleteParameter, console bool) (nodeList []node.NodeInfo, err error) {
 
 	if ndp == nil {
-		err = fmt.Errorf("NodeDeleteParameter is nil")
-		return
+		return nodeList, fmt.Errorf("NodeDeleteParameter is nil")
 	}
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Error("Failed to open node database: %s", err)
-		return
+		return nodeList, fmt.Errorf("failed to open node database: %s", err)
 	}
 	dbHash := nodeDB.Hash()
 	if hex.EncodeToString(dbHash[:]) != ndp.Hash && !ndp.Force {
 		wwlog.Debug("got hash: %s", ndp.Hash)
 		wwlog.Debug("actual hash: %s", hex.EncodeToString(dbHash[:]))
-		err = fmt.Errorf("got wrong hash, not modifying node database")
-		return
+		return nodeList, fmt.Errorf("got wrong hash, not modifying node database")
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Error("Could not get node list: %s", err)
-		return
+		return nodeList, fmt.Errorf("could not get node list: %s", err)
 	}
 
 	node_args := hostlist.Expand(ndp.NodeNames)
@@ -173,12 +168,12 @@ func NodeDeleteParameterCheck(ndp *wwapiv1.NodeDeleteParameter, console bool) (n
 		}
 
 		if !match {
-			fmt.Fprintf(os.Stderr, "ERROR: No match for node: %s\n", r)
+			wwlog.Error("ERROR: No match for node: %s\n", r)
 		}
 	}
 
 	if len(nodeList) == 0 {
-		fmt.Printf("No nodes found\n")
+		wwlog.Info("No nodes found")
 	}
 	return
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Return non-zero exit code on node sub-commands


## This fixes or addresses the following GitHub issues:

- Fixes #1421


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
