### PR TITLE
Return non-zero exit code on overlay sub-commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Return non-zero exit code on profile sub-commands #1435
 - Fix issue that NetworkManager marks managed interfaces "unmanaged" if they do
   not have a device specified. #1154
+- Return non-zero exit code on overlay sub-commands #1423
 
 ## v4.5.8, 2024-10-01
 

--- a/internal/app/wwctl/overlay/build/main.go
+++ b/internal/app/wwctl/overlay/build/main.go
@@ -19,7 +19,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	controller := warewulfconf.Get()
 	nodeDB, err := node.New()
 	if err != nil {
-		return fmt.Errorf("couldn't open node configuration: %s", err)
+		return fmt.Errorf("could not open node configuration: %s", err)
 	}
 
 	db, err := nodeDB.FindAllNodes()
@@ -89,7 +89,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 
 		if err != nil {
-			return fmt.Errorf("Some overlays failed to be generated: %s", err)
+			return fmt.Errorf("some overlays failed to be generated: %s", err)
 		}
 	}
 	return nil

--- a/internal/app/wwctl/overlay/chmod/main.go
+++ b/internal/app/wwctl/overlay/chmod/main.go
@@ -1,6 +1,7 @@
 package chmod
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strconv"
@@ -8,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/warewulf/warewulf/internal/pkg/overlay"
 	"github.com/warewulf/warewulf/internal/pkg/util"
-	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
@@ -19,28 +19,24 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	permissionMode, err := strconv.ParseUint(args[2], 8, 32)
 	if err != nil {
-		wwlog.Error("Could not convert requested mode: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not convert requested mode: %s", err)
 	}
 
 	overlaySourceDir = overlay.OverlaySourceDir(overlayName)
 
 	if !util.IsDir(overlaySourceDir) {
-		wwlog.Error("Overlay does not exist: %s", overlayName)
-		os.Exit(1)
+		return fmt.Errorf("overlay does not exist: %s", overlayName)
 	}
 
 	overlayFile := path.Join(overlaySourceDir, fileName)
 
 	if !util.IsFile(overlayFile) && !util.IsDir(overlayFile) {
-		wwlog.Error("File does not exist within overlay: %s:%s", overlayName, fileName)
-		os.Exit(1)
+		return fmt.Errorf("file does not exist within overlay: %s:%s", overlayName, fileName)
 	}
 
 	err = os.Chmod(overlayFile, os.FileMode(permissionMode))
 	if err != nil {
-		wwlog.Error("Could not set permission: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not set permission: %s", err)
 	}
 
 	return nil

--- a/internal/app/wwctl/overlay/chown/main.go
+++ b/internal/app/wwctl/overlay/chown/main.go
@@ -1,13 +1,13 @@
 package chown
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strconv"
 
 	"github.com/warewulf/warewulf/internal/pkg/overlay"
 	"github.com/warewulf/warewulf/internal/pkg/util"
-	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 
 	"github.com/spf13/cobra"
 )
@@ -23,15 +23,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	uid, err = strconv.Atoi(args[2])
 	if err != nil {
-		wwlog.Error("UID is not an integer: %s", args[2])
-		os.Exit(1)
+		return fmt.Errorf("UID is not an integer: %s", args[2])
 	}
 
 	if len(args) > 3 {
 		gid, err = strconv.Atoi(args[3])
 		if err != nil {
-			wwlog.Error("GID is not an integer: %s", args[3])
-			os.Exit(1)
+			return fmt.Errorf("GID is not an integer: %s", args[3])
 		}
 	} else {
 		gid = -1
@@ -40,21 +38,18 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	overlaySourceDir = overlay.OverlaySourceDir(overlayName)
 
 	if !util.IsDir(overlaySourceDir) {
-		wwlog.Error("Overlay does not exist: %s", overlayName)
-		os.Exit(1)
+		return fmt.Errorf("overlay does not exist: %s", overlayName)
 	}
 
 	overlayFile := path.Join(overlaySourceDir, fileName)
 
 	if !util.IsFile(overlayFile) && !util.IsDir(overlayFile) {
-		wwlog.Error("File does not exist within overlay: %s:%s", overlayName, fileName)
-		os.Exit(1)
+		return fmt.Errorf("file does not exist within overlay: %s:%s", overlayName, fileName)
 	}
 
 	err = os.Chown(overlayFile, uid, gid)
 	if err != nil {
-		wwlog.Error("Could not set ownership: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not set ownership: %s", err)
 	}
 
 	return nil

--- a/internal/app/wwctl/overlay/create/main.go
+++ b/internal/app/wwctl/overlay/create/main.go
@@ -1,20 +1,11 @@
 package create
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 	"github.com/warewulf/warewulf/internal/pkg/overlay"
-	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
-func CobraRunE(cmd *cobra.Command, args []string) error {
-
-	err := overlay.OverlayInit(args[0])
-	if err != nil {
-		wwlog.Error("%s", err)
-		os.Exit(1)
-	}
-
-	return nil
+func CobraRunE(cmd *cobra.Command, args []string) (err error) {
+	err = overlay.OverlayInit(args[0])
+	return
 }

--- a/internal/app/wwctl/overlay/delete/main.go
+++ b/internal/app/wwctl/overlay/delete/main.go
@@ -25,13 +25,11 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	overlayPath = overlay.OverlaySourceDir(overlayName)
 
 	if overlayPath == "" {
-		wwlog.Error("Overlay name did not resolve: '%s'", overlayName)
-		os.Exit(1)
+		return fmt.Errorf("overlay name did not resolve: '%s'", overlayName)
 	}
 
 	if !util.IsDir(overlayPath) {
-		wwlog.Error("Overlay does not exist: %s", overlayName)
-		os.Exit(1)
+		return fmt.Errorf("overlay does not exist: %s", overlayName)
 	}
 
 	if fileName == "" {
@@ -49,29 +47,24 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				return errors.Wrap(err, "failed deleting overlay")
 			}
 		}
-		fmt.Printf("Deleted overlay: %s\n", args[0])
+		wwlog.Info("Deleted overlay: %s\n", args[0])
 
 	} else {
 		removePath := path.Join(overlayPath, fileName)
 
 		if !util.IsDir(removePath) && !util.IsFile(removePath) {
-			wwlog.Error("Path to remove doesn't exist in overlay: %s", removePath)
-			os.Exit(1)
+			return fmt.Errorf("path to remove doesn't exist in overlay: %s", removePath)
 		}
 
 		if Force {
 			err := os.RemoveAll(removePath)
 			if err != nil {
-				wwlog.Error("Failed deleting file from overlay: %s:%s", overlayName, overlayPath)
-				wwlog.Error("%s", err)
-				os.Exit(1)
+				return fmt.Errorf("failed deleting file from overlay: %s:%s", overlayName, overlayPath)
 			}
 		} else {
 			err := os.Remove(removePath)
 			if err != nil {
-				wwlog.Error("Failed deleting overlay: %s:%s", overlayName, overlayPath)
-				wwlog.Error("%s", err)
-				os.Exit(1)
+				return fmt.Errorf("failed deleting overlay: %s:%s", overlayName, overlayPath)
 			}
 		}
 

--- a/internal/app/wwctl/overlay/imprt/main.go
+++ b/internal/app/wwctl/overlay/imprt/main.go
@@ -1,6 +1,7 @@
 package imprt
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -30,8 +31,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	overlaySource = overlay.OverlaySourceDir(overlayName)
 
 	if !util.IsDir(overlaySource) {
-		wwlog.Error("Overlay does not exist: %s", overlayName)
-		os.Exit(1)
+		return fmt.Errorf("overlay does not exist: %s", overlayName)
 	}
 
 	if util.IsDir(path.Join(overlaySource, dest)) {
@@ -39,8 +39,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if util.IsFile(path.Join(overlaySource, dest)) {
-		wwlog.Error("A file with that name already exists in the overlay %s\n:", overlayName)
-		os.Exit(1)
+		return fmt.Errorf("a file with that name already exists in the overlay: %s", overlayName)
 	}
 
 	if CreateDirs {
@@ -49,13 +48,11 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 			wwlog.Debug("Create dir: %s", parent)
 			srcInfo, err := os.Stat(source)
 			if err != nil {
-				wwlog.Error("Could not retrieve the stat for file: %s", err)
-				return err
+				return fmt.Errorf("could not retrieve the stat for file: %s", err)
 			}
 			err = os.MkdirAll(parent, srcInfo.Mode())
 			if err != nil {
-				wwlog.Error("Could not create parent dif: %s: %v", parent, err)
-				return err
+				return fmt.Errorf("could not create parent dif: %s: %v", parent, err)
 			}
 		}
 	}
@@ -68,14 +65,12 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	if !NoOverlayUpdate {
 		n, err := node.New()
 		if err != nil {
-			wwlog.Error("Could not open node configuration: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("could not open node configuration: %s", err)
 		}
 
 		nodes, err := n.FindAllNodes()
 		if err != nil {
-			wwlog.Error("Could not get node list: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("could not get node list: %s", err)
 		}
 
 		var updateNodes []node.NodeConf

--- a/internal/app/wwctl/overlay/mkdir/main.go
+++ b/internal/app/wwctl/overlay/mkdir/main.go
@@ -1,6 +1,7 @@
 package mkdir
 
 import (
+	"fmt"
 	"os"
 	"path"
 
@@ -19,8 +20,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	overlaySourceDir = overlay.OverlaySourceDir(overlayName)
 
 	if !util.IsDir(overlaySourceDir) {
-		wwlog.Error("Overlay does not exist: %s", overlayName)
-		os.Exit(1)
+		return fmt.Errorf("overlay does not exist: %s", overlayName)
 	}
 
 	overlayDir := path.Join(overlaySourceDir, dirName)
@@ -29,8 +29,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	err := os.MkdirAll(overlayDir, os.FileMode(PermMode))
 	if err != nil {
-		wwlog.Error("Could not create directory: %s", path.Dir(overlayDir))
-		os.Exit(1)
+		return fmt.Errorf("could not create directory: %s", path.Dir(overlayDir))
 	}
 
 	return nil

--- a/internal/app/wwctl/overlay/show/main.go
+++ b/internal/app/wwctl/overlay/show/main.go
@@ -3,7 +3,7 @@ package show
 import (
 	"bufio"
 	"bytes"
-	"errors"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -25,15 +25,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	overlaySourceDir = overlay.OverlaySourceDir(overlayName)
 
 	if !util.IsDir(overlaySourceDir) {
-		err := errors.New("overlay does not exist")
-		return err
+		return fmt.Errorf("overlay dir: %s does not exist", overlaySourceDir)
 	}
 
 	overlayFile := path.Join(overlaySourceDir, fileName)
 
 	if !util.IsFile(overlayFile) {
-		err := errors.New("file does not exist within overlay")
-		return err
+		return fmt.Errorf("file: %s does not exist within overlay", overlayFile)
 	}
 
 	if NodeName == "" {
@@ -45,8 +43,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		wwlog.Output("%s", string(f))
 	} else {
 		if !util.IsFile(overlayFile) {
-			err := errors.New("not a file")
-			return err
+			return fmt.Errorf("%s is not a file", overlayFile)
 		}
 		if filepath.Ext(overlayFile) != ".ww" {
 			wwlog.Warn("%s lacks the '.ww' suffix, will not be rendered in an overlay", fileName)
@@ -59,7 +56,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		if err == node.ErrNotFound {
 			hostName, err := os.Hostname()
 			if err != nil {
-				wwlog.Error("Could not get host name: %s", err)
+				return fmt.Errorf("could not get host name: %s", err)
 			}
 			nodeConf = node.NewNode(hostName)
 			nodeConf.ClusterName = hostName


### PR DESCRIPTION
## Description of the Pull Request (PR):

Return non-zero exit code on overlay sub-commands

## This fixes or addresses the following GitHub issues:

- Fixes #1423


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
