### PR TITLE
Update SELinux documentation to address rootfstype=ramfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added `--syncuser` flag to `wwctl container shell`. #1358
 - Added a troubleshooting guide. #1234
+- Added documentation about `rootfstype=ramfs` for SELinux support. #1001
 
 ### Changed
 

--- a/userdocs/contents/security.rst
+++ b/userdocs/contents/security.rst
@@ -28,25 +28,24 @@ SELinux
 The Warewulf server itself was developed with SELinux enabled in
 "targeted" and "enforcing" mode and with the firewall active.
 
-Additionally, the provisioning process fully supports SELinux by
-default. In previous versions you had to enable a switch to support
-SELinux, but in Warewulf v4 and above, it is always enabled, but you
-do have to make some configuration changes.
+The provisioning process also fully supports booting SELinux-enabled
+containers, though nodes must be configured to use tmpfs for init. ("ramfs"
+(often used by default) does not support extended file attributes.)
 
-#. The first thing to do is to change the provision "Root" option. By
-   default this is ``initramfs`` which means, take whatever file
-   system the kernel hands us. By default this is a ``ramfs`` type
-   file system (however this may not always be the case) and this
-   format does not support extended file attributes which are required
-   for SELinux. Instead you must configure Warewulf to use ``tmpfs``
-   for the provisioning file system. That change is made like: ``$
-   sudo wwctl profile set --root tmpfs default``.
+.. code-block:: bash
 
-#. That is all you have to do to ensure that Warewulf will
-   support SELinux. Once that is done, you just need to enable SELinux
-   in ``/etc/sysconfig/selinux`` and install the appropriate profiles
-   into the container. `An example`_ of such a container is in the
-   warewulf-node-images repository.
+   wwctl profile set default --root tmpfs
+
+.. note::
+
+   Versions of Warewulf prior to v4.5.8 also required a kernel argument
+   "rootfstype=ramfs" in order for wwinit to copy the node image to tmpfs; but
+   this is no longer required.
+
+Once that is done, you just need to enable SELinux in
+``/etc/sysconfig/selinux`` and install the appropriate profiles into the
+container. `An example`_ of such a container is available in the
+warewulf-node-images repository.
 
 .. _An example: https://github.com/warewulf/warewulf-node-images/tree/main/examples/rockylinux-9-selinux
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Previous versions of Warewulf v4 required a kernel argument rootfstype=ramfs to be set, in addition to --root=tmpfs. This was fixed in #1401.


## This fixes or addresses the following GitHub issues:

- Closes #1001


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
