### PR TITLE
`wwctl node set` requires mandatory pattern input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Disable building containers by default when calling `wwctl container copy`. #1378
 - Split wwinit and generic overlays into discrete functionality. #987
 - Updated IgnitionJson to sort filesystems. #1433
+- `wwctl node set` requires mandatory pattern input. #502
 
 ### Fixed
 

--- a/internal/app/wwctl/node/set/root.go
+++ b/internal/app/wwctl/node/set/root.go
@@ -31,11 +31,11 @@ func GetCommand() *cobra.Command {
 	vars.nodeConf = node.NewConf()
 	baseCmd := &cobra.Command{
 		DisableFlagsInUseLine: true,
-		Use:                   "set [OPTIONS] PATTERN [PATTERN ...]",
+		Use:                   "set [OPTIONS] PATTERN",
 		Short:                 "Configure node properties",
 		Long:                  "This command sets configuration properties for nodes matching PATTERN.\n\nNote: use the string 'UNSET' to remove a configuration",
 		Aliases:               []string{"modify"},
-		Args:                  cobra.MinimumNArgs(0),
+		Args:                  cobra.MinimumNArgs(1), // require pattern as a mandatory arg
 		RunE:                  CobraRunE(&vars),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {


### PR DESCRIPTION
## Description of the Pull Request (PR):

`wwctl node set` requires mandatory pattern input

## This fixes or addresses the following GitHub issues:

- Fixes #502


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
