### PR TITLE
Change the permission of overlay dir to `0750` and generated overlays to `0660`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Interleave tmpfs across all available NUMA nodes. #1347, #1348
 - Syncuser watches for changes in mtime rather than ctime. #1358
+- Change the default permissions for provisioned overlay images to `0750` (dirs) and `0660` (files). #1388
 
 ### Fixed
 

--- a/internal/app/wwctl/overlay/build/main.go
+++ b/internal/app/wwctl/overlay/build/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
 
 	"github.com/spf13/cobra"
 	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
@@ -83,6 +84,9 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if BuildNodes || (!BuildHost && !BuildNodes) {
+		oldMask := syscall.Umask(007)
+		defer syscall.Umask(oldMask)
+
 		if len(OverlayNames) > 0 {
 			err = overlay.BuildSpecificOverlays(nodes, OverlayNames)
 		} else {

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -136,7 +136,7 @@ func BuildOverlay(nodeInfo node.NodeInfo, context string, overlayNames []string)
 	overlayImage := OverlayImage(nodeInfo.Id.Get(), context, overlayNames)
 	overlayImageDir := path.Dir(overlayImage)
 
-	err := os.MkdirAll(overlayImageDir, 0755)
+	err := os.MkdirAll(overlayImageDir, 0750)
 	if err != nil {
 		return errors.Wrapf(err, "Failed to create directory for %s: %s", name, overlayImageDir)
 	}

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -543,9 +543,6 @@ func CpioCreate(
 
 	args = append(args, cpio_args...)
 
-	oldMask := syscall.Umask(007)
-	defer syscall.Umask(oldMask)
-
 	proc := exec.Command("cpio", args...)
 
 	stdin, err := proc.StdinPipe()

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -543,6 +543,9 @@ func CpioCreate(
 
 	args = append(args, cpio_args...)
 
+	oldMask := syscall.Umask(007)
+	defer syscall.Umask(oldMask)
+
 	proc := exec.Command("cpio", args...)
 
 	stdin, err := proc.StdinPipe()


### PR DESCRIPTION
## Description of the Pull Request (PR):

Change the permission of overlay dir to `0750` and generated overlays to `0660`


## This fixes or addresses the following GitHub issues:

- Fixes #1388


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)

### Test

```
[root@localhost warewulf]# wwctl overlay build --nodes -O host
Building overlay for n1: [host]
Created image for overlay n1/[host]: /var/local/warewulf/provision/overlays/n1/host.img
Compressed image for overlay n1/[host]: /var/local/warewulf/provision/overlays/n1/host.img.gz
[root@localhost warewulf]# ls -al /var/local/warewulf/provision/overlays/
total 0
drwxr-x---. 3 root root 16 Sep 27 06:21 .
drwxr-xr-x. 5 root root 53 Sep 27 06:21 ..
drwxr-x---. 2 root root 41 Sep 27 06:21 n1
[root@localhost warewulf]# ls -al /var/local/warewulf/provision/overlays/n1/
total 12
drwxr-x---. 2 root root   41 Sep 27 06:21 .
drwxr-x---. 3 root root   16 Sep 27 06:21 ..
-rw-rw----. 1 root root 7168 Sep 27 06:21 host.img
-rw-rw----. 1 root root 2080 Sep 27 06:21 host.img.gz
[root@localhost warewulf]# wwctl overlay build --nodes -O generic
Building overlay for n1: [generic]
Created image for overlay n1/[generic]: /var/local/warewulf/provision/overlays/n1/generic.img
Compressed image for overlay n1/[generic]: /var/local/warewulf/provision/overlays/n1/generic.img.gz
[root@localhost warewulf]# ls -al /var/local/warewulf/provision/overlays/n1/
total 24
drwxr-x---. 2 root root   82 Sep 27 06:27 .
drwxr-x---. 3 root root   16 Sep 27 06:21 ..
-rw-rw----. 1 root root 7680 Sep 27 06:27 generic.img
-rw-rw----. 1 root root 2008 Sep 27 06:27 generic.img.gz
-rw-rw----. 1 root root 7168 Sep 27 06:21 host.img
-rw-rw----. 1 root root 2080 Sep 27 06:21 host.img.gz
```
