### PR TITLE
Update IgnitionJson to sort the list of file systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Bump github.com/coreos/ignition/v2 from 2.15.0 to 2.19.0 #1239
 - Disable building containers by default when calling `wwctl container copy`. #1378
 - Split wwinit and generic overlays into discrete functionality. #987
+- Updated IgnitionJson to sort filesystems. #1433
 
 ### Fixed
 

--- a/internal/pkg/node/ignition.go
+++ b/internal/pkg/node/ignition.go
@@ -47,6 +47,9 @@ func (node *NodeInfo) GetStorage() (stor types_3_4.Storage, err error, rep strin
 		wwlog.Debug("created file system struct: %v", myFs)
 		fileSystems = append(fileSystems, myFs)
 	}
+	sort.SliceStable(fileSystems, func(i int, j int) bool {
+		return fileSystems[i].Device < fileSystems[j].Device
+	})
 	var disks []types_3_4.Disk
 	for diskDev, disk := range node.Disks {
 		var partitions []types_3_4.Partition

--- a/overlays/ignition/internal/ignition_test.go
+++ b/overlays/ignition/internal/ignition_test.go
@@ -2,8 +2,6 @@ package ignition
 
 import (
 	"bytes"
-	"encoding/json"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,10 +59,7 @@ func Test_ignitionOverlay(t *testing.T) {
 			assert.Empty(t, stdout.String())
 			assert.Empty(t, stderr.String())
 			if tt.json {
-				var expected, actual interface{}
-				assert.NoError(t, json.Unmarshal([]byte(tt.log), &expected))
-				assert.NoError(t, json.Unmarshal(logbuf.Bytes(), &actual))
-				assert.True(t, reflect.DeepEqual(expected, actual), "expected: %v\nactual  : %v", expected, actual)
+				assert.JSONEq(t, tt.log, logbuf.String())
 			} else {
 				assert.Equal(t, tt.log, logbuf.String())
 			}
@@ -116,5 +111,44 @@ What=/dev/disk/by-partlabel/swap
 RequiredBy=swap.target
 `
 
-const ignition_json string = `{"ignition":{"version":"3.1.0"},"storage":{"disks":[{"device":"/dev/vda","partitions":[{"label":"scratch","shouldExist":true,"wipePartitionEntry":false},{"label":"swap","number":1,"shouldExist":false,"sizeMiB":1024,"wipePartitionEntry":false}],"wipeTable":true}],"filesystems":[{"device":"/dev/disk/by-partlabel/scratch","format":"btrfs","path":"/scratch","wipeFilesystem":true},{"device":"/dev/disk/by-partlabel/swap","format":"swap","path":"swap","wipeFilesystem":false}]}}
-`
+const ignition_json string = `{
+  "ignition": {
+    "version": "3.1.0"
+  },
+  "storage": {
+    "disks": [
+      {
+        "device": "/dev/vda",
+        "partitions": [
+          {
+            "label": "scratch",
+            "shouldExist": true,
+            "wipePartitionEntry": false
+          },
+          {
+            "label": "swap",
+            "number": 1,
+            "shouldExist": false,
+            "sizeMiB": 1024,
+            "wipePartitionEntry": false
+          }
+        ],
+        "wipeTable": true
+      }
+    ],
+    "filesystems": [
+      {
+        "device": "/dev/disk/by-partlabel/scratch",
+        "format": "btrfs",
+        "path": "/scratch",
+        "wipeFilesystem": true
+      },
+      {
+        "device": "/dev/disk/by-partlabel/swap",
+        "format": "swap",
+        "path": "swap",
+        "wipeFilesystem": false
+      }
+    ]
+  }
+}`


### PR DESCRIPTION
## Description of the Pull Request (PR):

Now that we're testing IgnitionJson, we exposed the fact that the file systems weren't being output in a consistent way. Since they're read from a map and output as a list, the order of that list was non-deterministic.

This PR sorts the file systems by device name.


## This fixes or addresses the following GitHub issues:

- Closes #1433


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
