### PR TITLE
Return non-zero exit code on profile sub-commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix issue that domain globs not supported during wwctl node delete. #1449
 - Fix overlay permissions in /root/ and /root/.ssh/. #1452
 - Return non-zero exit code on container sub-commands #1437
+- Return non-zero exit code on profile sub-commands #1435
 
 ## v4.5.8, 2024-10-01
 

--- a/internal/app/wwctl/profile/add/main.go
+++ b/internal/app/wwctl/profile/add/main.go
@@ -6,7 +6,6 @@ import (
 
 	apiprofile "github.com/warewulf/warewulf/internal/pkg/api/profile"
 	"github.com/warewulf/warewulf/internal/pkg/node"
-	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 	"gopkg.in/yaml.v3"
 
 	"github.com/spf13/cobra"
@@ -47,8 +46,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 		delete(vars.profileConf.Disks, "UNDEF")
 		buffer, err := yaml.Marshal(vars.profileConf)
 		if err != nil {
-			wwlog.Error("Can't marshall nodeInfo", err)
-			return err
+			return fmt.Errorf("can not marshall nodeInfo: %w", err)
 		}
 		set := wwapiv1.NodeAddParameter{
 			NodeConfYaml: string(buffer[:]),

--- a/internal/app/wwctl/profile/delete/main.go
+++ b/internal/app/wwctl/profile/delete/main.go
@@ -2,7 +2,6 @@ package delete
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
@@ -20,22 +19,19 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Error("Failed to open node database: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to open node database: %s", err)
 	}
 
 	profiles, err := nodeDB.FindAllProfiles()
 	if err != nil {
-		wwlog.Error("Could not load all profiles: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not load all profiles: %s", err)
 	}
 	for _, r := range args {
 		for _, p := range profiles {
 			if p.Id() == r {
 				nodes, err := nodeDB.FindAllNodes()
 				if err != nil {
-					wwlog.Error("Could not load all nodes: %s", err)
-					os.Exit(1)
+					return fmt.Errorf("could not load all nodes: %s", err)
 				}
 				for _, n := range nodes {
 					for i, np := range n.Profiles {
@@ -67,13 +63,11 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 		if !found {
 			wwlog.Warn("Profile not found: %s", r)
-			return nil
 		}
 	}
 
 	if count == 0 {
-		wwlog.Warn("No profiles found")
-		return nil
+		return fmt.Errorf("no profiles found")
 	}
 
 	if SetYes {

--- a/internal/app/wwctl/profile/edit/main.go
+++ b/internal/app/wwctl/profile/edit/main.go
@@ -23,12 +23,10 @@ import (
 func CobraRunE(cmd *cobra.Command, args []string) error {
 	canWrite, err := apiutil.CanWriteConfig()
 	if err != nil {
-		wwlog.Error("While checking whether can write config, err: %w", err)
-		os.Exit(1)
+		return fmt.Errorf("while checking whether can write config, err: %s", err)
 	}
 	if !canWrite.CanWriteConfig {
-		wwlog.Error("Can't write to config exiting")
-		os.Exit(1)
+		return fmt.Errorf("can not write to config exiting")
 	}
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
@@ -65,8 +63,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		sum1 := hex.EncodeToString(hasher.Sum(nil))
 		err = util.ExecInteractive(editor, file.Name())
 		if err != nil {
-			wwlog.Error("Editor process existed with non-zero\n")
-			os.Exit(1)
+			return fmt.Errorf("editor process existed with non-zero: %s", err)
 		}
 		_, _ = file.Seek(0, 0)
 		hasher.Reset()
@@ -125,8 +122,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 					Hash:         newHash.Hash,
 				})
 				if err != nil {
-					wwlog.Error("Got following problem when writing back yaml: %s", err)
-					os.Exit(1)
+					return fmt.Errorf("got following problem when writing back yaml: %s", err)
 				}
 				break
 			}

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -2,7 +2,6 @@ package set
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -50,8 +49,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 		delete(vars.profileConf.Disks, "UNDEF")
 		buffer, err := yaml.Marshal(vars.profileConf)
 		if err != nil {
-			wwlog.Error("Cant marshall nodeInfo", err)
-			os.Exit(1)
+			return fmt.Errorf("can not marshall nodeInfo: %s", err)
 		}
 		wwlog.Debug("sending following values: %s", string(buffer))
 		set := wwapiv1.ConfSetParameter{


### PR DESCRIPTION
## Description of the Pull Request (PR):

Return non-zero exit code on profile sub-commands


## This fixes or addresses the following GitHub issues:

- Fixes #1435


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
