### PR TITLE
wwctl should return non-zero exit code on wwctl kernel sub-commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix issue that pattern matching broken on `node set` #964
 - Fix issue that domain globs not supported during wwctl node delete. #1449
 - Fix overlay permissions in /root/ and /root/.ssh/. #1452
+- Return non-zero exit code on container sub-commands #1437
 
 ## v4.5.8, 2024-10-01
 

--- a/internal/app/wwctl/kernel/delete/main.go
+++ b/internal/app/wwctl/kernel/delete/main.go
@@ -2,7 +2,6 @@ package delete
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/warewulf/warewulf/internal/pkg/kernel"
@@ -14,8 +13,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Error("Could not open nodeDB: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not open nodeDB: %s", err)
 	}
 
 	nodes, _ := nodeDB.FindAllNodes()

--- a/internal/app/wwctl/kernel/imprt/main.go
+++ b/internal/app/wwctl/kernel/imprt/main.go
@@ -2,7 +2,6 @@ package imprt
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -15,20 +14,17 @@ import (
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 && !OptDetect {
-		wwlog.Error("the '--detect' flag is needed, if no kernel version is supplied")
-		os.Exit(1)
+		return fmt.Errorf("the '--detect' flag is needed, if no kernel version is suppiled")
 	}
 	if OptDetect && (OptRoot == "" || OptContainer == "") {
-		wwlog.Error("the '--detect flag needs the '--container' or '--root' flag")
-		os.Exit(1)
+		return fmt.Errorf("the '--detect flag needs the '--container' or '--root' flag")
 	}
 	// Checking if container flag was set, then overwriting OptRoot
 	if OptContainer != "" {
 		if container.ValidSource(OptContainer) {
 			OptRoot = container.RootFsDir(OptContainer)
 		} else {
-			wwlog.Error(" %s is not a valid container", OptContainer)
-			os.Exit(1)
+			return fmt.Errorf(" %s is not a valid container", OptContainer)
 		}
 	}
 
@@ -50,8 +46,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 	err = kernel.Build(kernelVersion, kernelName, OptRoot)
 	if err != nil {
-		wwlog.Error("Failed building kernel: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("failed building kernel: %s", err)
 	} else {
 		fmt.Printf("%s: %s\n", kernelName, "Finished kernel build")
 	}
@@ -60,8 +55,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 		nodeDB, err := node.New()
 		if err != nil {
-			wwlog.Error("Could not open node configuration: %s", err)
-			os.Exit(1)
+			return fmt.Errorf("could not open node configuration: %s", err)
 		}
 		//TODO: Don't loop through profiles, instead have a nodeDB function that goes directly to the map
 		profiles, _ := nodeDB.FindAllProfiles()

--- a/internal/app/wwctl/kernel/list/main.go
+++ b/internal/app/wwctl/kernel/list/main.go
@@ -2,20 +2,17 @@ package list
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/warewulf/warewulf/internal/pkg/kernel"
 	"github.com/warewulf/warewulf/internal/pkg/node"
-	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	kernels, err := kernel.ListKernels()
 	if err != nil {
-		wwlog.Error("%s", err)
-		os.Exit(1)
+		return err
 	}
 
 	nconfig, _ := node.New()


### PR DESCRIPTION
## Description of the Pull Request (PR):

wwctl should return non-zero exit code on wwctl kernel sub-commands


## This fixes or addresses the following GitHub issues:

- Fixes #1437


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)