### PR TITLE
wwctl should return non-zero exit code on wwctl power sub-commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix excessive line spacing issue when listing nodes. #1241
 - Return non-zero exit code on node sub-commands #1421
 - Fix panic when getting a long container list before building the container. #1391
+- Return non-zero exit code on power sub-commands #1439
 
 ## v4.5.8, unreleased
 

--- a/internal/app/wwctl/power/cycle/main.go
+++ b/internal/app/wwctl/power/cycle/main.go
@@ -1,4 +1,4 @@
-package powerreset
+package cycle
 
 import (
 	"fmt"
@@ -17,14 +17,12 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Error("Could not open node configuration: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not open node configuration: %s", err)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Error("Cloud not get nodeList: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not get node list: %s", err)
 	}
 
 	if len(args) > 0 {
@@ -36,8 +34,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(nodes) == 0 {
-		fmt.Printf("No nodes found\n")
-		os.Exit(1)
+		return fmt.Errorf("no nodes found")
 	}
 
 	batchpool := batch.New(50)
@@ -70,7 +67,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 		batchpool.Submit(func() {
 			//nolint:errcheck
-			ipmiCmd.PowerReset()
+			ipmiCmd.PowerCycle()
 			results <- ipmiCmd
 		})
 

--- a/internal/app/wwctl/power/cycle/root.go
+++ b/internal/app/wwctl/power/cycle/root.go
@@ -1,4 +1,4 @@
-package powercycle
+package cycle
 
 import (
 	"github.com/spf13/cobra"

--- a/internal/app/wwctl/power/off/main.go
+++ b/internal/app/wwctl/power/off/main.go
@@ -1,4 +1,4 @@
-package poweroff
+package off
 
 import (
 	"fmt"
@@ -17,14 +17,12 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Error("Could not open node configuration: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not open node configuration: %s", err)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Error("Could not get node list: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not get node list: %s", err)
 	}
 
 	if len(args) > 0 {
@@ -36,8 +34,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(nodes) == 0 {
-		fmt.Printf("No nodes found\n")
-		os.Exit(1)
+		return fmt.Errorf("no nodes found")
 	}
 
 	batchpool := batch.New(50)

--- a/internal/app/wwctl/power/off/root.go
+++ b/internal/app/wwctl/power/off/root.go
@@ -1,4 +1,4 @@
-package poweroff
+package off
 
 import (
 	"github.com/spf13/cobra"

--- a/internal/app/wwctl/power/on/main.go
+++ b/internal/app/wwctl/power/on/main.go
@@ -1,4 +1,4 @@
-package powersoft
+package on
 
 import (
 	"fmt"
@@ -17,14 +17,12 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Error("Could not open node configuration: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not open node configuration: %s", err)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Error("Cloud not get nodeList: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not get node list: %s", err)
 	}
 
 	if len(args) > 0 {
@@ -36,8 +34,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(nodes) == 0 {
-		fmt.Printf("No nodes found\n")
-		os.Exit(1)
+		return fmt.Errorf("no nodes found")
 	}
 
 	batchpool := batch.New(50)
@@ -70,7 +67,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 		batchpool.Submit(func() {
 			//nolint:errcheck
-			ipmiCmd.PowerSoft()
+			ipmiCmd.PowerOn()
 			results <- ipmiCmd
 		})
 

--- a/internal/app/wwctl/power/on/root.go
+++ b/internal/app/wwctl/power/on/root.go
@@ -1,4 +1,4 @@
-package poweron
+package on
 
 import (
 	"github.com/spf13/cobra"

--- a/internal/app/wwctl/power/reset/main.go
+++ b/internal/app/wwctl/power/reset/main.go
@@ -1,4 +1,4 @@
-package powerstatus
+package reset
 
 import (
 	"fmt"
@@ -17,14 +17,12 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Error("Could not open node configuration: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not open node configuration: %s", err)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Error("Could not get node list: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("cloud not get nodeList: %s", err)
 	}
 
 	if len(args) > 0 {
@@ -36,8 +34,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(nodes) == 0 {
-		fmt.Printf("No nodes found\n")
-		os.Exit(1)
+		return fmt.Errorf("no nodes found")
 	}
 
 	batchpool := batch.New(50)
@@ -70,7 +67,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 		batchpool.Submit(func() {
 			//nolint:errcheck
-			ipmiCmd.PowerStatus()
+			ipmiCmd.PowerReset()
 			results <- ipmiCmd
 		})
 

--- a/internal/app/wwctl/power/reset/root.go
+++ b/internal/app/wwctl/power/reset/root.go
@@ -1,4 +1,4 @@
-package powerreset
+package reset
 
 import (
 	"github.com/spf13/cobra"

--- a/internal/app/wwctl/power/soft/main.go
+++ b/internal/app/wwctl/power/soft/main.go
@@ -1,4 +1,4 @@
-package powercycle
+package soft
 
 import (
 	"fmt"
@@ -17,14 +17,12 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Error("Could not open node configuration: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not open node configuration: %s", err)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Error("Could not get node list: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not get nodeList: %s", err)
 	}
 
 	if len(args) > 0 {
@@ -36,8 +34,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(nodes) == 0 {
-		fmt.Printf("No nodes found\n")
-		os.Exit(1)
+		return fmt.Errorf("no nodes found")
 	}
 
 	batchpool := batch.New(50)
@@ -70,7 +67,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 		batchpool.Submit(func() {
 			//nolint:errcheck
-			ipmiCmd.PowerCycle()
+			ipmiCmd.PowerSoft()
 			results <- ipmiCmd
 		})
 

--- a/internal/app/wwctl/power/soft/root.go
+++ b/internal/app/wwctl/power/soft/root.go
@@ -1,4 +1,4 @@
-package powersoft
+package soft
 
 import (
 	"github.com/spf13/cobra"

--- a/internal/app/wwctl/power/status/main.go
+++ b/internal/app/wwctl/power/status/main.go
@@ -1,4 +1,4 @@
-package poweron
+package status
 
 import (
 	"fmt"
@@ -17,14 +17,12 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 	nodeDB, err := node.New()
 	if err != nil {
-		wwlog.Error("Could not open node configuration: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not open node configuration: %s", err)
 	}
 
 	nodes, err := nodeDB.FindAllNodes()
 	if err != nil {
-		wwlog.Error("Could not get node list: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("could not get node list: %s", err)
 	}
 
 	if len(args) > 0 {
@@ -36,8 +34,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(nodes) == 0 {
-		fmt.Printf("No nodes found\n")
-		os.Exit(1)
+		return fmt.Errorf("no nodes found")
 	}
 
 	batchpool := batch.New(50)
@@ -70,7 +67,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 
 		batchpool.Submit(func() {
 			//nolint:errcheck
-			ipmiCmd.PowerOn()
+			ipmiCmd.PowerStatus()
 			results <- ipmiCmd
 		})
 

--- a/internal/app/wwctl/power/status/root.go
+++ b/internal/app/wwctl/power/status/root.go
@@ -1,4 +1,4 @@
-package powerstatus
+package status
 
 import (
 	"github.com/spf13/cobra"


### PR DESCRIPTION
## Description of the Pull Request (PR):

wwctl should return non-zero exit code on wwctl power sub-commands


## This fixes or addresses the following GitHub issues:

- Fixes #1439


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
