### PR TITLE
Update nodeconfig.rst

### DIFF
--- a/userdocs/contents/nodeconfig.rst
+++ b/userdocs/contents/nodeconfig.rst
@@ -289,3 +289,18 @@ And to unset this configuration attribute:
 
    # wwctl node list -a n001 | grep Cluster
    n001                Cluster            --           --
+
+Important Considerations When Editing nodes.conf and warewulf.conf
+=================================================================
+
+When ``nodes.conf`` is edited, ``warewulfd`` does not know that the container profile has been changed. Therefore the new changes to ``nodes.conf`` are not taken into account until ``warewulfd`` is restarted.
+
+Once you restart ``warewulfd``, the ``nodes.conf`` file is then successfully reloaded.
+
+This also goes for ``warewulf.conf`` as well - any changes made also require ``warewulfd`` to be restarted.
+
+The restart should be done using the following ``systemd`` command:
+
+.. code-block:: console
+
+  # systemctl restart warewulfd


### PR DESCRIPTION
Added additional information on restarting warewulfd, when editing nodes.conf or warewulf.conf

## Description of the Pull Request (PR):

This follows on from Jonathon's kind help to update the documentation, where a user was restarting Warewulf with `wwctl server restart`, however this was not required and the user only needs to run `systemctl restart warewulfd`, when either `nodes.conf` or `warewulf.conf` are edited.


## This fixes or addresses the following GitHub issues:

- Fixes # - N/A


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
