### PR TITLE
Updated configuration.rst, CONTRIBUTORS.md and CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added documentation on ensuring `systemctl restart warewulfd` is ran when editing `nodes.conf` or `warewulf.conf`
 - Add the ability to boot nodes with `wwid=[interface]`, which replaces
   `interface` with the interface MAC address
 - Added https://github.com/Masterminds/sprig functions to templates #1030

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,3 +40,4 @@
 * Elmar Pruesse <pruessee@njhealth.org> @epruesse
 * Adam Michel <elfurbe@furbism.com> [@elfurbe](https://github.com/elfurbe)
 * Brandon Biggs <brandonsbiggs@gmail.com>
+* Howard Van Der Wal <howard.a.vanderwal@protonmail.com> [@metalllinux](https://github.com/metalllinux)

--- a/userdocs/contents/configuration.rst
+++ b/userdocs/contents/configuration.rst
@@ -196,6 +196,13 @@ command.
    time you attempt to run ``wwctl``, this file will be generated if
    it does not exist already.
 
+.. note::
+   
+   When ``nodes.conf`` is edited directly, ``warewulfd`` does not know that the container profile has been changed. Therefore the changes to ``nodes.conf`` are not taken into account by ``warewulfd`` until it is restarted.
+   Once you restart ``warewulfd``, the ``nodes.conf`` file is then successfully reloaded.
+   This also goes for ``warewulf.conf`` as well - any changes made also require ``warewulfd`` to be restarted.
+   The restart should be done using the following command: ``systemctl restart warewulfd``
+
 defaults.conf
 =============
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Added a note to `configuration.rst`, so that when `nodes.conf` or `warewulfd.conf` are edited, `systemctl restart warewulfd` has to be enacted.

## This fixes or addresses the following GitHub issues:

- Fixes # - N/A

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
Observed the following when `git commit --signoff` was ran:
```
howard@ciq ~/g/warewulf (metalllinux)> git commit --signoff
On branch metalllinux
nothing to commit, working tree clean
```
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
