### PR TITLE
Update default warewulfd port to match initial configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Return non-zero exit code on node sub-commands #1421
 - Fix panic when getting a long container list before building the container. #1391
 - Return non-zero exit code on power sub-commands #1439
+- Update default `warewulfd` port to match shipped configuration.
 
 ## v4.5.8, 2024-10-01
 

--- a/internal/pkg/config/buildconfig.go.in
+++ b/internal/pkg/config/buildconfig.go.in
@@ -33,7 +33,7 @@ type TFTPConf struct {
 // WarewulfConf adds additional Warewulf-specific configuration to
 // BaseConf.
 type WarewulfConf struct {
-	Port              int    `yaml:"port" default:"9983"`
+	Port              int    `yaml:"port" default:"9873"`
 	Secure            bool   `yaml:"secure" default:"true"`
 	UpdateInterval    int    `yaml:"update interval" default:"60"`
 	AutobuildOverlays bool   `yaml:"autobuild overlays" default:"true"`


### PR DESCRIPTION
## Description of the Pull Request (PR):

The default `warewulfd` port in the data structure didn't match what is in the default `warewulf.conf` and firewalld service that we ship. This PR updates the data structure to match.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
