### PR TITLE
Updates from CIQ training prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Changed `wwctl server` to use "INFO" for send and receive logs #725
 - Remove a 3-second sleep during iPXE boot. #1500
 - Don't package the API in RPM packages by default. #1493
+- Update default `warewulfd` port to match shipped configuration. #1448
 
 ### Removed
 

--- a/docs/man/man5/warewulf.conf.5
+++ b/docs/man/man5/warewulf.conf.5
@@ -62,7 +62,7 @@ This is the port that the Warewulf web server will be listening on. It
 is recommended not to change this so there is no misalignment with
 node's expectations of how to contact the Warewulf service.
 
-Default: 9983
+Default: 9873
 .IP
 
 .TP

--- a/etc/warewulf.conf
+++ b/etc/warewulf.conf
@@ -1,7 +1,6 @@
 WW_INTERNAL: 45
 ipaddr: 10.0.0.1
 netmask: 255.255.252.0
-network: 10.0.0.0
 warewulf:
   secure: false
   update interval: 60

--- a/etc/warewulf.conf
+++ b/etc/warewulf.conf
@@ -3,7 +3,6 @@ ipaddr: 10.0.0.1
 netmask: 255.255.252.0
 network: 10.0.0.0
 warewulf:
-  port: 9873
   secure: false
   update interval: 60
   autobuild overlays: true

--- a/internal/pkg/config/buildconfig.go.in
+++ b/internal/pkg/config/buildconfig.go.in
@@ -38,7 +38,7 @@ type TFTPConf struct {
 // WarewulfConf adds additional Warewulf-specific configuration to
 // BaseConf.
 type WarewulfConf struct {
-	Port              int    `yaml:"port" default:"9983"`
+	Port              int    `yaml:"port" default:"9873"`
 	Secure            bool   `yaml:"secure" default:"true"`
 	UpdateInterval    int    `yaml:"update interval" default:"60"`
 	AutobuildOverlays bool   `yaml:"autobuild overlays" default:"true"`

--- a/internal/pkg/config/root.go
+++ b/internal/pkg/config/root.go
@@ -41,7 +41,7 @@ type RootConf struct {
 	SSH             *SSHConf      `yaml:"ssh,omitempty"`
 	MountsContainer []*MountEntry `yaml:"container mounts" default:"[{\"source\": \"/etc/resolv.conf\", \"dest\": \"/etc/resolv.conf\"}]"`
 	Paths           *BuildConfig  `yaml:"paths"`
-	WWClient        *WWClientConf `yaml:"wwclient"`
+	WWClient        *WWClientConf `yaml:"wwclient,omitempty"`
 
 	warewulfconf string
 }

--- a/internal/pkg/config/root_test.go
+++ b/internal/pkg/config/root_test.go
@@ -10,7 +10,7 @@ import (
 func TestDefaultRootConf(t *testing.T) {
 	conf := New()
 
-	assert.Equal(t, 9983, conf.Warewulf.Port)
+	assert.Equal(t, 9873, conf.Warewulf.Port)
 	assert.True(t, conf.Warewulf.Secure)
 	assert.Equal(t, 60, conf.Warewulf.UpdateInterval)
 	assert.True(t, conf.Warewulf.AutobuildOverlays)
@@ -155,8 +155,8 @@ func TestCache(t *testing.T) {
 	confOrig := New()
 	confCached := Get()
 
-	assert.Equal(t, 9983, confOrig.Warewulf.Port)
-	assert.Equal(t, 9983, confCached.Warewulf.Port)
+	assert.Equal(t, 9873, confOrig.Warewulf.Port)
+	assert.Equal(t, 9873, confCached.Warewulf.Port)
 
 	confOrig.Warewulf.Port = 9999
 	assert.Equal(t, 9999, confCached.Warewulf.Port)

--- a/overlays/debug/internal/debug_test.go
+++ b/overlays/debug/internal/debug_test.go
@@ -172,7 +172,7 @@ data from other structures.
 
 ### Warewulf
 
-- Port: 9983
+- Port: 9873
 - Secure: true
 - UpdateInterval: 60
 - AutobuildOverlays: true

--- a/userdocs/contents/configuration.rst
+++ b/userdocs/contents/configuration.rst
@@ -178,7 +178,7 @@ The first listed key type is used to generate authentication ssh keys.
 nodes.conf
 ==========
 
-The ``nodes.conf`` file is the primary database file for all compute
+The ``nodes.conf`` file is the primary registry for all compute
 nodes. It is a flat text YAML configuration file that is managed by
 the ``wwctl`` command, but some sites manage the compute nodes and
 infrastructure via configuration management. This file being flat text


### PR DESCRIPTION
CIQ is updating its training materials for Warewulf and, in so doing, we're recommending changes upstream to match. In most cases this is a filling-out of documentation to serve as reference material; but in some cases code behavior may be suggested.

## Changes

- Change the default warewulfd port to `9873` to match the `warewulf.conf` and Firewalld service we've been shipping.
- Refer to `nodes.conf` as a "registry" rather than "database" in the docs.
- Remove `network` from initial `warewulf.conf`.
- Omit the `wwclient` section from `warewulf.conf` if it is empty.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
