### PR TITLE
Fix issue that domain globs not supported during wwctl node delete.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix panic when getting a long container list before building the container. #1391
 - Return non-zero exit code on power sub-commands #1439
 - Fix issue that pattern matching broken on `node set` #964
+- Fix issue that domain globs not supported during wwctl node delete. #1449
 
 ## v4.5.8, 2024-10-01
 

--- a/internal/pkg/api/node/node.go
+++ b/internal/pkg/api/node/node.go
@@ -158,19 +158,7 @@ func NodeDeleteParameterCheck(ndp *wwapiv1.NodeDeleteParameter, console bool) (n
 
 	node_args := hostlist.Expand(ndp.NodeNames)
 
-	for _, r := range node_args {
-		var match bool
-		for _, n := range nodes {
-			if n.Id.Get() == r {
-				nodeList = append(nodeList, n)
-				match = true
-			}
-		}
-
-		if !match {
-			wwlog.Error("ERROR: No match for node: %s\n", r)
-		}
-	}
+	nodeList = node.FilterByName(nodes, node_args)
 
 	if len(nodeList) == 0 {
 		wwlog.Info("No nodes found")


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix issue that domain globs not supported during wwctl node delete.


## This fixes or addresses the following GitHub issues:

- Fixes #1449


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)


## Test
```
[root@localhost warewulf]# wwctl node list
  NODE NAME  PROFILES  NETWORK

[root@localhost warewulf]# wwctl node add n[1-9].cluster2
Added node: n1.cluster2
Added node: n2.cluster2
Added node: n3.cluster2
Added node: n4.cluster2
Added node: n5.cluster2
Added node: n6.cluster2
Added node: n7.cluster2
Added node: n8.cluster2
Added node: n9.cluster2

[root@localhost warewulf]# wwctl node list
  NODE NAME    PROFILES  NETWORK
  n1.cluster2  default
  n2.cluster2  default
  n3.cluster2  default
  n4.cluster2  default
  n5.cluster2  default
  n6.cluster2  default
  n7.cluster2  default
  n8.cluster2  default
  n9.cluster2  default

[root@localhost warewulf]# wwctl node delete n[1-2].cluster2
? Are you sure you want to delete 2 nodes(s)? [y/N] y█

[root@localhost warewulf]# wwctl node delete *.cluster2
Are you sure you want to delete 7 nodes(s): y

[root@localhost warewulf]# wwctl node list
  NODE NAME  PROFILES  NETWORK

[root@localhost warewulf]# wwctl node list
  NODE NAME        PROFILES  NETWORK
  n00.example.com  default
  n01.example.com  default
  n02.example.com  default
  n03.example.com  default
  n04.example.com  default
  n05.example.com  default
  n06.example.com  default
  n07.example.com  default
  n08.example.com  default
  n09.example.com  default
  n10.example.com  default
  n11.example.com  default
[root@localhost warewulf]# wwctl node delete n[00-11].example.com
✗ Are you sure you want to delete 12 nodes(s): 
[root@localhost warewulf]# wwctl node delete n[00-11].example.*
✗ Are you sure you want to delete 12 nodes(s): 
[root@localhost warewulf]# wwctl node delete n[00-11].*
✗ Are you sure you want to delete 12 nodes(s): 
[root@localhost warewulf]# wwctl node delete n[02-11].*
✗ Are you sure you want to delete 10 nodes(s): 
```
