### PR TITLE
Set restrictive permissions on `/root/.ssh` in generic overlay

### DIFF
--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -196,6 +196,8 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %dir %{_sharedstatedir}/warewulf/overlays/host
 %dir %{_sharedstatedir}/warewulf/overlays/wwinit
 %attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/*/rootfs
+%attr(700, root, root) %{_sharedstatedir}/warewulf/overlays/generic/rootfs/root
+%attr(700, root, root) %{_sharedstatedir}/warewulf/overlays/generic/rootfs/root/.ssh
 
 %attr(-, root, root) %{_bindir}/wwctl
 %attr(-, root, root) %{_prefix}/lib/firewalld/services/warewulf.xml


### PR DESCRIPTION
## Description of the Pull Request (PR):

By default, these get `755` permissions set by git, which is too relaxed.

## This fixes or addresses the following GitHub issues:

- Fixes #1452 


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
