### PR TITLE
Allow unauthenticated iPXE script download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Split wwinit and generic overlays into discrete functionality. #987
 - Updated IgnitionJson to sort filesystems. #1433
 - `wwctl node set` requires mandatory pattern input. #502
+- Fix asset tag support to allow unauthenticated iPXE script download #1455
 
 ### Fixed
 

--- a/internal/pkg/warewulfd/provision.go
+++ b/internal/pkg/warewulfd/provision.go
@@ -80,7 +80,8 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if node.AssetKey.Defined() && node.AssetKey.Get() != rinfo.assetkey {
+	// iPXE doesn't have access to the asset key yet
+	if rinfo.stage != "ipxe" && node.AssetKey.Defined() && node.AssetKey.Get() != rinfo.assetkey {
 		w.WriteHeader(http.StatusUnauthorized)
 		wwlog.Denied("Incorrect asset key for node: %s", node.Id.Get())
 		updateStatus(node.Id.Get(), status_stage, "BAD_ASSET", rinfo.ipaddr)


### PR DESCRIPTION
## Description of the Pull Request (PR):

The asset tag isn't available yet when pulling the iPXE script.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
