### PR TITLE
Apply #1454 to main: Set restrictive permissions on /root/.ssh in generic overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Return non-zero exit code on power sub-commands #1439
 - Fix issue that pattern matching broken on `node set` #964
 - Fix issue that domain globs not supported during wwctl node delete. #1449
+- Fix overlay permissions in /root/ and /root/.ssh/. #1452
 
 ## v4.5.8, 2024-10-01
 

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -212,6 +212,8 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %dir %{_sharedstatedir}/warewulf/overlays/wwinit
 %dir %{_sharedstatedir}/warewulf/overlays/wwclient
 %attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/*/rootfs
+%attr(700, root, root) %{_sharedstatedir}/warewulf/overlays/generic/rootfs/root
+%attr(700, root, root) %{_sharedstatedir}/warewulf/overlays/generic/rootfs/root/.ssh
 
 %attr(-, root, root) %{_bindir}/wwctl
 %attr(-, root, root) %{_prefix}/lib/firewalld/services/warewulf.xml


### PR DESCRIPTION
By default, these get 755 permissions set by git, which is too relaxed.
This fixes or addresses the following GitHub issues:

Fixes #1452


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
