### PR TITLE
fix issue that initrd fails at downloading runtime overlay with permission denied error, when warewulf secure option in warewulf.conf is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Don't update IPMI if password isn't set. #638
 - Fix issue that `--nettagdel` does not work properly. #1503
 - Fix test for dhcp static configuration #1536 #1537
+- Fix issue that initrd fails at downloading runtime overlay with permission denied error,
+  when warewulf secure option in warewulf.conf is enabled. #806
 
 ## v4.5.8, 2024-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix test for dhcp static configuration #1536 #1537
 - Fix issue that initrd fails at downloading runtime overlay with permission denied error,
   when warewulf secure option in warewulf.conf is enabled. #806
+- Allow iPXE to continue booting without runtime overlay. #806
 
 ## v4.5.8, 2024-10-01
 

--- a/etc/ipxe/default.ipxe
+++ b/etc/ipxe/default.ipxe
@@ -58,7 +58,7 @@ echo Downloading System Overlay:
 initrd --name system ${uri_base}&stage=system           || goto reboot
 
 echo Downloading Runtime Overlay:
-initrd --name runtime ${uri_base}&stage=runtime         || goto reboot
+initrd --name runtime ${uri_base}&stage=runtime         || echo Failed to download overlay runtime, but will continue...
 
 {{if ne .KernelOverride "" -}}
 echo Downloading Kernel Modules:
@@ -79,7 +79,7 @@ echo Downloading System Overlay:
 initrd --name system ${uri_base}&stage=system&compress=gz       || goto reboot
 
 echo Downloading Runtime Overlay:
-initrd --name runtime ${uri_base}&stage=runtime&compress=gz     || goto reboot
+initrd --name runtime ${uri_base}&stage=runtime&compress=gz     || echo Failed to download overlay runtime.gz, but will continue...
 
 {{if ne .KernelOverride "" -}}
 echo Downloading Kernel Modules:

--- a/etc/ipxe/default.ipxe
+++ b/etc/ipxe/default.ipxe
@@ -37,7 +37,7 @@ echo Downloading System Overlay:
 imgextract --name system ${uri_base}&stage=system&compress=gz       || goto reboot
 
 echo Downloading Runtime Overlay:
-imgextract --name runtime ${uri_base}&stage=runtime&compress=gz     || echo Failed downloading runtime overlay.
+imgextract --name runtime ${uri_base}&stage=runtime&compress=gz     && set runtime_initrd initrd=runtime || echo Failed downloading runtime overlay.
 
 {{if ne .KernelOverride "" -}}
 echo Downloading Kernel Modules:
@@ -58,7 +58,7 @@ echo Downloading System Overlay:
 initrd --name system ${uri_base}&stage=system           || goto reboot
 
 echo Downloading Runtime Overlay:
-initrd --name runtime ${uri_base}&stage=runtime         || echo Failed downloading runtime overlay.
+initrd --name runtime ${uri_base}&stage=runtime         && set runtime_initrd initrd=runtime || echo Failed downloading runtime overlay.
 
 {{if ne .KernelOverride "" -}}
 echo Downloading Kernel Modules:
@@ -79,7 +79,7 @@ echo Downloading System Overlay:
 initrd --name system ${uri_base}&stage=system&compress=gz       || goto reboot
 
 echo Downloading Runtime Overlay:
-initrd --name runtime ${uri_base}&stage=runtime&compress=gz     || echo Failed downloading runtime overlay.
+initrd --name runtime ${uri_base}&stage=runtime&compress=gz     && set runtime_initrd initrd=runtime || echo Failed downloading runtime overlay.
 
 {{if ne .KernelOverride "" -}}
 echo Downloading Kernel Modules:
@@ -90,11 +90,11 @@ initrd --name kmods ${uri_base}&stage=kmods&compress=gz         || goto reboot
 :imoktogo
 
 {{if ne .KernelOverride "" -}}
-echo boot kernel initrd=container initrd=kmods initrd=system initrd=runtime wwid={{.Hwaddr}} {{.KernelArgs}}
-boot kernel initrd=container initrd=kmods initrd=system initrd=runtime wwid={{.Hwaddr}} {{.KernelArgs}} ||  goto reboot
+echo boot kernel initrd=container initrd=kmods initrd=system ${runtime_initrd} wwid={{.Hwaddr}} {{.KernelArgs}}
+boot kernel initrd=container initrd=kmods initrd=system ${runtime_initrd} wwid={{.Hwaddr}} {{.KernelArgs}} ||  goto reboot
 {{- else -}}
-echo boot kernel initrd=container initrd=system initrd=runtime wwid={{.Hwaddr}} {{.KernelArgs}}
-boot kernel initrd=container initrd=system initrd=runtime wwid={{.Hwaddr}} {{.KernelArgs}} ||  goto reboot
+echo boot kernel initrd=container initrd=system ${runtime_initrd} wwid={{.Hwaddr}} {{.KernelArgs}}
+boot kernel initrd=container initrd=system ${runtime_initrd} wwid={{.Hwaddr}} {{.KernelArgs}} ||  goto reboot
 {{- end}}
 
 :reboot

--- a/etc/ipxe/default.ipxe
+++ b/etc/ipxe/default.ipxe
@@ -37,7 +37,7 @@ echo Downloading System Overlay:
 imgextract --name system ${uri_base}&stage=system&compress=gz       || goto reboot
 
 echo Downloading Runtime Overlay:
-imgextract --name runtime ${uri_base}&stage=runtime&compress=gz     || goto reboot
+imgextract --name runtime ${uri_base}&stage=runtime&compress=gz     || echo Failed downloading runtime overlay.
 
 {{if ne .KernelOverride "" -}}
 echo Downloading Kernel Modules:

--- a/etc/ipxe/default.ipxe
+++ b/etc/ipxe/default.ipxe
@@ -58,7 +58,7 @@ echo Downloading System Overlay:
 initrd --name system ${uri_base}&stage=system           || goto reboot
 
 echo Downloading Runtime Overlay:
-initrd --name runtime ${uri_base}&stage=runtime         || echo Failed to download overlay runtime, but will continue...
+initrd --name runtime ${uri_base}&stage=runtime         || echo Failed downloading runtime overlay.
 
 {{if ne .KernelOverride "" -}}
 echo Downloading Kernel Modules:
@@ -79,7 +79,7 @@ echo Downloading System Overlay:
 initrd --name system ${uri_base}&stage=system&compress=gz       || goto reboot
 
 echo Downloading Runtime Overlay:
-initrd --name runtime ${uri_base}&stage=runtime&compress=gz     || echo Failed to download overlay runtime.gz, but will continue...
+initrd --name runtime ${uri_base}&stage=runtime&compress=gz     || echo Failed downloading runtime overlay.
 
 {{if ne .KernelOverride "" -}}
 echo Downloading Kernel Modules:


### PR DESCRIPTION
## Description of the Pull Request (PR):

fix issue that initrd fails at downloading runtime overlay with permission denied error, when warewulf secure option in warewulf.conf is enabled


## This fixes or addresses the following GitHub issues:

- Fixes #806

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)

## Test
Before:

![2024-10-22_16-31](https://github.com/user-attachments/assets/951cf983-53f5-43fe-bbee-3a2d58788872)

After:

![2024-10-22_16-40](https://github.com/user-attachments/assets/2d14141a-04f5-49c1-957e-380ebeca7772)
