### PR TITLE
Remove an erroneous colon suffix from a log message

### DIFF
--- a/internal/pkg/api/node/add.go
+++ b/internal/pkg/api/node/add.go
@@ -41,7 +41,7 @@ func NodeAdd(nap *wwapiv1.NodeAddParameter) (err error) {
 		if err != nil {
 			return errors.Wrap(err, "Failed to decode nodeConf")
 		}
-		wwlog.Info("Added node: %s:", a)
+		wwlog.Info("Added node: %s", a)
 		for _, dev := range n.NetDevs {
 			if !ipv4.IsUnspecified() && ipv4 != nil {
 				// if more nodes are added increment IPv4 address


### PR DESCRIPTION
Just removes an erroneous colon suffix in a log message.

> Added node: %s:

becomes

> Added node: %s

The previous format makes it seem like some extra output is missing.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
