### PR TITLE
Fix an href in userdocs

### DIFF
--- a/userdocs/contents/disks.rst
+++ b/userdocs/contents/disks.rst
@@ -110,7 +110,9 @@ existing data on the disk.
 
 .. [#] With `wipefs` you have to remove the filesystem *and* parition information. E.g. use `wipefs -fa /dev/vda*` to remove all filesystem information and partition information.
 
-See also [ignition documentation](https://coreos.github.io/ignition/operator-notes/#filesystem-reuse-semantics) for additional information.
+See also `ignition documentation`_ for additional information.
+
+.. _ignition documentation: https://coreos.github.io/ignition/operator-notes/#filesystem-reuse-semantics
 
 Troubleshooting
 ===============


### PR DESCRIPTION
Was using markdown syntax rather than rst syntax.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
