### PR TITLE
Fix warewulf.spec.in to use new overlay path

### DIFF
--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -212,8 +212,8 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %dir %{_sharedstatedir}/warewulf/overlays/wwinit
 %dir %{_sharedstatedir}/warewulf/overlays/wwclient
 %attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/*/rootfs
-%attr(700, root, root) %{_sharedstatedir}/warewulf/overlays/generic/rootfs/root
-%attr(700, root, root) %{_sharedstatedir}/warewulf/overlays/generic/rootfs/root/.ssh
+%attr(700, root, root) %{_sharedstatedir}/warewulf/overlays/ssh.authorized_keys/rootfs/root
+%attr(700, root, root) %{_sharedstatedir}/warewulf/overlays/ssh.authorized_keys/rootfs/root/.ssh
 
 %attr(-, root, root) %{_bindir}/wwctl
 %attr(-, root, root) %{_prefix}/lib/firewalld/services/warewulf.xml


### PR DESCRIPTION
Fixes a bug introduced in #1456

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
