### PR TITLE
Fixes  POSIX syntax for several scripts #1464 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Replace `defaults.conf` with settings on the default profile. #917
 - Switched from yaml.v2 to yaml.v3 #1462
 - Make OCIBlobCache a seperate path and point it to `/var/cache` #1459
+- Updated various shell scripts for POSIX compatibility. #1464
 
 
 ### Removed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -42,3 +42,4 @@
 * Brandon Biggs <brandonsbiggs@gmail.com>
 * Howard Van Der Wal <howard.a.vanderwal@protonmail.com> [@metalllinux](https://github.com/metalllinux)
 * Nicholas Porter <nap23@unm.edu>
+* Ian Kaufman [iankgt40](https://github.com/iankgt40)

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -28,10 +28,10 @@ echo
 
 chmod 755 /warewulf/wwinit
 
-if [ -z "${WWROOT}" -o "${WWROOT}" == "initramfs" ]; then
+if [ -z "${WWROOT}" -o "${WWROOT}" = "initramfs" ]; then
     echo "Retaining initramfs and invoking /warewulf/wwinit..."
     exec /warewulf/wwinit
-elif [ "${WWROOT}" == "ramfs" -o "${WWROOT}" == "tmpfs" ]; then
+elif [ "${WWROOT}" = "ramfs" -o "${WWROOT}" = "tmpfs" ]; then
     echo "Setting up new ${WWROOT} rootfs..."
     mkdir /newroot
     mount wwroot /newroot -t ${WWROOT} -o mpol=interleave # mpol ignored for ramfs

--- a/overlays/wwinit/rootfs/warewulf/wwinit
+++ b/overlays/wwinit/rootfs/warewulf/wwinit
@@ -5,21 +5,13 @@ echo "Hello from WWINIT"
 . /warewulf/config
 
 myPATH=/warewulf/init.d
-while read -r NAME; do
-#        if [ -x $myPATH/$NAME ]
-#        then
-               echo "Launching: $NAME"
-               sh "$myPATH/$NAME"
-
-#        fi
-done <<EOF
-# `ls $myPATH/*.sh`
-`ls $myPATH/`
-EOF
+ls -1 $myPATH/ | while read -r NAME; do
+    echo "Launching: $NAME"
+    sh "$myPATH/$NAME"
+done
 
 echo "Calling $WWINIT..."
 echo
 
 sleep 2
 exec $WWINIT
-

--- a/overlays/wwinit/rootfs/warewulf/wwinit
+++ b/overlays/wwinit/rootfs/warewulf/wwinit
@@ -4,14 +4,22 @@ echo "Hello from WWINIT"
 
 . /warewulf/config
 
-for i in /warewulf/init.d/*; do
-    NAME=`basename $i`
-    echo "Launching: $NAME"
-    sh "$i"
-done
+myPATH=/warewulf/init.d
+while read -r NAME; do
+#        if [ -x $myPATH/$NAME ]
+#        then
+               echo "Launching: $NAME"
+               sh "$myPATH/$NAME"
+
+#        fi
+done <<EOF
+# `ls $myPATH/*.sh`
+`ls $myPATH/`
+EOF
 
 echo "Calling $WWINIT..."
 echo
 
 sleep 2
 exec $WWINIT
+


### PR DESCRIPTION
## Description of the Pull Request (PR):
While building and testing WW4 under Ubuntu 22.04 LTS and 24.04 LTS, it was discovered that several scripts broke due to Ubuntu/Debian use of /bin/dash instead of /bin/bash for /bin/sh. The scripts are:

overlays/wwinit/rootfs/warewulf/wwinit
overlays/wwinit/rootfs/init
scripts/build-ipxe.sh

Since Ubuntu and Debian both use dash, POSIX compliance is warranted. A simple workaround would be to force the use of bash, however, POSIX compliance is preferred in the event that bash is not available on the system, or some other environment requires it.

I have added commented out logic in the wwinit script to facilitate testing for the .sh suffix and exec bit on the scripts launched should that become needed.

## This fixes or addresses the following GitHub issues:

- Fixes #1464 
[wwinit.txt](https://github.com/user-attachments/files/17576207/wwinit.txt)
[init.txt](https://github.com/user-attachments/files/17576208/init.txt)
[build-ipxe-with-read.sh.txt](https://github.com/user-attachments/files/17576209/build-ipxe-with-read.sh.txt)

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
