### PR TITLE
Remove an unnecessary 3s boot from iPXE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update `wwctl server` to always run in the foreground #508
 - Update `wwctl server` to log to stdout rather than a file #503
 - Changed `wwctl server` to use "INFO" for send and receive logs #725
+- Remove a 3-second sleep during iPXE boot. #1500
 
 
 ### Removed

--- a/etc/ipxe/default.ipxe
+++ b/etc/ipxe/default.ipxe
@@ -89,14 +89,11 @@ initrd --name kmods ${uri_base}&stage=kmods&compress=gz         || goto reboot
 
 :imoktogo
 
-echo Booting in 3s...
 {{if ne .KernelOverride "" -}}
 echo boot kernel initrd=container initrd=kmods initrd=system initrd=runtime wwid={{.Hwaddr}} {{.KernelArgs}}
-sleep 3
 boot kernel initrd=container initrd=kmods initrd=system initrd=runtime wwid={{.Hwaddr}} {{.KernelArgs}} ||  goto reboot
 {{- else -}}
 echo boot kernel initrd=container initrd=system initrd=runtime wwid={{.Hwaddr}} {{.KernelArgs}}
-sleep 3
 boot kernel initrd=container initrd=system initrd=runtime wwid={{.Hwaddr}} {{.KernelArgs}} ||  goto reboot
 {{- end}}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Remove an unnecessary 3s boot from iPXE.


## This fixes or addresses the following GitHub issues:

- Fixes #1500


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
