### PR TITLE
Don't package the API in RPM packages by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update `wwctl server` to log to stdout rather than a file #503
 - Changed `wwctl server` to use "INFO" for send and receive logs #725
 - Remove a 3-second sleep during iPXE boot. #1500
-
+- Don't package the API in RPM packages by default. #1493
 
 ### Removed
 

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -1,9 +1,6 @@
 %global debug_package %{nil}
 
-%global api 1
-%if 0%{?rhel} && 0%{?rhel} <= 7
 %global api 0
-%endif
 
 %if 0%{?suse_version}
 %global tftpdir /srv/tftpboot


### PR DESCRIPTION
## Description of the Pull Request (PR):

Don't package the API in RPM packages by default.


## This fixes or addresses the following GitHub issues:

- Fixes #1493


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
