### PR TITLE
Simplify passing of arguments through wwctl container exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix issue that NetworkManager marks managed interfaces "unmanaged" if they do
   not have a device specified. #1154
 - Return non-zero exit code on overlay sub-commands #1423
+- Simplify passing of arguments to commands through `wwctl container exec`. #253
 
 ## v4.5.8, 2024-10-01
 

--- a/internal/app/wwctl/container/exec/main.go
+++ b/internal/app/wwctl/container/exec/main.go
@@ -61,6 +61,7 @@ func runContainedCmd(cmd *cobra.Command, containerName string, args []string) (e
 	if nodeName != "" {
 		childArgs = append(childArgs, "--node", nodeName)
 	}
+	childArgs = append(childArgs, "--")
 	childArgs = append(childArgs, args...)
 	// copy the files into the container at this stage, es in __child the
 	// command syscall.Exec which replaces the __child process with the

--- a/internal/app/wwctl/container/exec/main_test.go
+++ b/internal/app/wwctl/container/exec/main_test.go
@@ -40,27 +40,27 @@ func Test_Exec(t *testing.T) {
 		{
 			name:   "plain test",
 			args:   []string{"test", "/bin/true"},
-			stdout: `--loglevel 20 container exec __child test /bin/true`,
+			stdout: `--loglevel 20 container exec __child test -- /bin/true`,
 		},
 		{
 			name:   "test with --bind",
 			args:   []string{"test", "--bind", "/tmp", "/bin/true"},
-			stdout: `--loglevel 20 container exec __child test --bind /tmp /bin/true`,
+			stdout: `--loglevel 20 container exec __child test --bind /tmp -- /bin/true`,
 		},
 		{
 			name:   "test with --node",
 			args:   []string{"test", "--node", "node1", "/bin/true"},
-			stdout: `--loglevel 20 container exec __child test --node node1 /bin/true`,
+			stdout: `--loglevel 20 container exec __child test --node node1 -- /bin/true`,
 		},
 		{
 			name:   "test with --node and --bind",
 			args:   []string{"test", "--bind", "/tmp", "--node", "node1", "/bin/true"},
-			stdout: `--loglevel 20 container exec __child test --bind /tmp --node node1 /bin/true`,
+			stdout: `--loglevel 20 container exec __child test --bind /tmp --node node1 -- /bin/true`,
 		},
 		{
 			name:   "test with complex command",
 			args:   []string{"test", "/bin/bash", "echo 'hello'"},
-			stdout: `--loglevel 20 container exec __child test /bin/bash echo 'hello'`,
+			stdout: `--loglevel 20 container exec __child test -- /bin/bash echo 'hello'`,
 		},
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Simplify passing of arguments through `wwctl container exec`. This removes the need to provide double-double dashes (e.g., `-- --`).


## This fixes or addresses the following GitHub issues:

- Fixes #253


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
