### PR TITLE
Enable nested profiles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add support for nesting prfiles in profiles.
 - Added documentation on ensuring `systemctl restart warewulfd` is ran when editing `nodes.conf` or `warewulf.conf`
 - Add the ability to boot nodes with `wwid=[interface]`, which replaces
   `interface` with the interface MAC address

--- a/internal/pkg/api/node/list.go
+++ b/internal/pkg/api/node/list.go
@@ -39,7 +39,7 @@ func NodeList(nodeGet *wwapiv1.GetNodeList) (nodeList wwapiv1.NodeList, err erro
 			}
 			sort.Strings(netNames)
 			nodeList.Output = append(nodeList.Output,
-				fmt.Sprintf("%s:=:%s:=:%s", n.Id(), n.Profiles, strings.Join(netNames, ", ")))
+				fmt.Sprintf("%s:=:%s:=:%s", n.Id(), n.ProfileConf.Profiles, strings.Join(netNames, ", ")))
 		}
 	} else if nodeGet.Type == wwapiv1.GetNodeList_Network {
 		nodeList.Output = append(nodeList.Output,

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -31,7 +31,6 @@ type NodeConf struct {
 	// exported values
 	Discoverable wwtype.WWbool     `yaml:"discoverable,omitempty" lopt:"discoverable" sopt:"e" comment:"Make discoverable in given network (true/false)"`
 	AssetKey     string            `yaml:"asset key,omitempty" lopt:"asset" comment:"Set the node's Asset tag (key)"`
-	Profiles     []string          `yaml:"profiles,omitempty" lopt:"profile" sopt:"P" comment:"Set the node's profile members (comma separated)"`
 	ProfileConf  `yaml:"-,inline"` // include all values set in the profile, but inline them in yaml output if these are part of NodeConf
 }
 
@@ -52,6 +51,7 @@ type ProfileConf struct {
 	Init           string                 `yaml:"init,omitempty" lopt:"init" sopt:"i" comment:"Define the init process to boot the container"`
 	Root           string                 `yaml:"root,omitempty" lopt:"root" comment:"Define the rootfs" `
 	NetDevs        map[string]*NetDevs    `yaml:"network devices,omitempty"`
+	Profiles       []string               `yaml:"profiles,omitempty" lopt:"profile" sopt:"P" comment:"Set the node's profile members (comma separated)"`
 	Tags           map[string]string      `yaml:"tags,omitempty"`
 	PrimaryNetDev  string                 `yaml:"primary network,omitempty" lopt:"primarynet" sopt:"p" comment:"Set the primary network interface"`
 	Disks          map[string]*Disk       `yaml:"disks,omitempty"`


### PR DESCRIPTION
- **Make Profiles a member of ProfileConf instead of NodeConf.**
- **Recursively build list of profiles.**
- **Update CHANGELOG.md**

## Description of the Pull Request (PR):

This PR adds support for nested profiles and:
- Builds a list of all profiles recursively, avoiding loops.
- Removes duplicates from the list of profiles.
- Sorts the profile list

I'm a little freaked out that this works? I thought naively changing the
location of `Profiles []string` from `NodeConf` to `ProfilesConf` would break
something. Before that Just Worked(tm) I was wondering why these are two
separate data structures since a nodeprofile is just a node under a different
top level key. Since this does seem to work now I'm really curious why there is
a split data structures for these.


## This fixes or addresses the following GitHub issues:

- Fixes #


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
