### PR TITLE
upgrade github actions from v3 to v4

### DIFF
--- a/.github/actions/generate/action.yml
+++ b/.github/actions/generate/action.yml
@@ -74,14 +74,14 @@ runs:
 
     - name: Upload warewulf.spec
       if: steps.should-continue.outputs.continue == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: warewulf.spec
         path: warewulf.spec
 
     - name: Upload DIST
       if: steps.should-continue.outputs.continue == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.DIST }}
         path: ${{ env.DIST }}

--- a/.github/actions/rpm/action.yml
+++ b/.github/actions/rpm/action.yml
@@ -35,7 +35,7 @@ runs:
       shell: bash
 
     - name: Download spec
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: warewulf.spec
 
@@ -45,7 +45,7 @@ runs:
       shell: bash
 
     - name: Download dist
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: warewulf-${{ env.EXPECTED_VERSION }}.tar.gz
 
@@ -68,19 +68,19 @@ runs:
       shell: bash
 
     - name: Upload RPM
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.RPM }}
         path: /var/lib/mock/${{ inputs.target }}/result/${{ env.RPM }}
 
     - name: Upload SRPM
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.SRPM }}
         path: /var/lib/mock/${{ inputs.target }}/result/${{ env.SRPM }}
 
     - name: Upload dracut RPM
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.DRACUT }}
         path: /var/lib/mock/${{ inputs.target }}/result/${{ env.DRACUT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove a 3-second sleep during iPXE boot. #1500
 - Don't package the API in RPM packages by default. #1493
 - Update default `warewulfd` port to match shipped configuration. #1448
+- Upgrade github actions/upload{download}-artifact from v3 to v4. #1529
+
 
 ### Removed
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

upgrade Github actions upload/download-artifact from v3 to v4.


## This fixes or addresses the following GitHub issues:

- Fixes #1529


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary

## Test
![image](https://github.com/user-attachments/assets/0eaa43ee-2159-47eb-9134-ccd3b4433d89)
![image](https://github.com/user-attachments/assets/8929ca61-1a5d-49d3-a0e4-0e89ecc1eaca)
