### PR TITLE
Resolve redundant file entries in warewulf.spec

### DIFF
--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -189,28 +189,27 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %dir %{_sharedstatedir}/warewulf
 %dir %{_sharedstatedir}/warewulf/chroots
 %dir %{_sharedstatedir}/warewulf/overlays
-%dir %{_sharedstatedir}/warewulf/overlays/NetworkManager
-%dir %{_sharedstatedir}/warewulf/overlays/debian.interfaces
-%dir %{_sharedstatedir}/warewulf/overlays/debug
-%dir %{_sharedstatedir}/warewulf/overlays/fstab
-%dir %{_sharedstatedir}/warewulf/overlays/host
-%dir %{_sharedstatedir}/warewulf/overlays/hostname
-%dir %{_sharedstatedir}/warewulf/overlays/hosts
-%dir %{_sharedstatedir}/warewulf/overlays/ifcfg
-%dir %{_sharedstatedir}/warewulf/overlays/ignition
-%dir %{_sharedstatedir}/warewulf/overlays/issue
-%dir %{_sharedstatedir}/warewulf/overlays/resolv
-%dir %{_sharedstatedir}/warewulf/overlays/ssh.authorized_keys
-%dir %{_sharedstatedir}/warewulf/overlays/ssh.host_keys
-%dir %{_sharedstatedir}/warewulf/overlays/syncuser
-%dir %{_sharedstatedir}/warewulf/overlays/systemd.netname
-%dir %{_sharedstatedir}/warewulf/overlays/udev.netname
-%dir %{_sharedstatedir}/warewulf/overlays/wicked
-%dir %{_sharedstatedir}/warewulf/overlays/wwinit
-%dir %{_sharedstatedir}/warewulf/overlays/wwclient
-%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/*/rootfs
-%attr(700, root, root) %{_sharedstatedir}/warewulf/overlays/ssh.authorized_keys/rootfs/root
-%attr(700, root, root) %{_sharedstatedir}/warewulf/overlays/ssh.authorized_keys/rootfs/root/.ssh
+%dir %{_sharedstatedir}/warewulf/overlays/*
+%dir %{_sharedstatedir}/warewulf/overlays/*/rootfs
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/NetworkManager/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/debian.interfaces/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/debug/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/fstab/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/host/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/hostname/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/hosts/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/ifcfg/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/ignition/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/issue/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/resolv/rootfs/*
+%attr(700, root, root) %{_sharedstatedir}/warewulf/overlays/ssh.authorized_keys/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/ssh.host_keys/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/syncuser/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/systemd.netname/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/udev.netname/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/wicked/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/wwclient/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/wwinit/rootfs/*
 
 %attr(-, root, root) %{_bindir}/wwctl
 %attr(-, root, root) %{_prefix}/lib/firewalld/services/warewulf.xml


### PR DESCRIPTION
## Description of the Pull Request (PR):

Resolve redundant file entries in `warewulf.spec`.


## This fixes or addresses the following GitHub issues:

- Closes #1526


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
