### PR TITLE
Use "default" netname during add, set

### DIFF
--- a/internal/app/wwctl/node/add/main.go
+++ b/internal/app/wwctl/node/add/main.go
@@ -24,29 +24,29 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
 		// to this network
 		if !node.ObjectIsEmpty(vars.nodeConf.NetDevs["UNDEF"]) {
 			netDev := *vars.nodeConf.NetDevs["UNDEF"]
-			vars.nodeConf.NetDevs[vars.netName] = &netDev
+			vars.nodeConf.NetDevs[vars.nodeAdd.Net] = &netDev
 		}
 		delete(vars.nodeConf.NetDevs, "UNDEF")
-		if vars.fsName != "" {
-			if !strings.HasPrefix(vars.fsName, "/dev") {
-				if vars.fsName == vars.partName {
-					vars.fsName = "/dev/disk/by-partlabel/" + vars.partName
+		if vars.nodeAdd.FsName != "" {
+			if !strings.HasPrefix(vars.nodeAdd.FsName, "/dev") {
+				if vars.nodeAdd.FsName == vars.nodeAdd.PartName {
+					vars.nodeAdd.FsName = "/dev/disk/by-partlabel/" + vars.nodeAdd.PartName
 				} else {
 					return fmt.Errorf("filesystems need to have a underlying blockdev")
 				}
 			}
 			fs := *vars.nodeConf.FileSystems["UNDEF"]
-			vars.nodeConf.FileSystems[vars.fsName] = &fs
+			vars.nodeConf.FileSystems[vars.nodeAdd.FsName] = &fs
 		}
 		delete(vars.nodeConf.FileSystems, "UNDEF")
-		if vars.diskName != "" && vars.partName != "" {
+		if vars.nodeAdd.DiskName != "" && vars.nodeAdd.PartName != "" {
 			prt := *vars.nodeConf.Disks["UNDEF"].Partitions["UNDEF"]
-			vars.nodeConf.Disks["UNDEF"].Partitions[vars.partName] = &prt
+			vars.nodeConf.Disks["UNDEF"].Partitions[vars.nodeAdd.PartName] = &prt
 			delete(vars.nodeConf.Disks["UNDEF"].Partitions, "UNDEF")
 			dsk := *vars.nodeConf.Disks["UNDEF"]
-			vars.nodeConf.Disks[vars.diskName] = &dsk
+			vars.nodeConf.Disks[vars.nodeAdd.DiskName] = &dsk
 		}
-		if (vars.diskName != "") != (vars.partName != "") {
+		if (vars.nodeAdd.DiskName != "") != (vars.nodeAdd.PartName != "") {
 			return fmt.Errorf("partition and disk must be specified")
 		}
 		delete(vars.nodeConf.Disks, "UNDEF")

--- a/internal/app/wwctl/node/add/root.go
+++ b/internal/app/wwctl/node/add/root.go
@@ -12,11 +12,8 @@ import (
 
 // Holds the variables which are needed in CobraRunE
 type variables struct {
-	netName  string
-	fsName   string
-	partName string
-	diskName string
 	nodeConf node.NodeConf
+	nodeAdd  node.NodeConfAdd
 }
 
 // Returns the newly created command
@@ -33,10 +30,7 @@ func GetCommand() *cobra.Command {
 		Args:                  cobra.MinimumNArgs(1),
 	}
 	vars.nodeConf.CreateFlags(baseCmd)
-	baseCmd.PersistentFlags().StringVar(&vars.netName, "netname", "default", "Set network name for network options")
-	baseCmd.PersistentFlags().StringVar(&vars.fsName, "fsname", "", "set the file system name which must match a partition name")
-	baseCmd.PersistentFlags().StringVar(&vars.partName, "partname", "", "set the partition name so it can be used by a file system")
-	baseCmd.PersistentFlags().StringVar(&vars.diskName, "diskname", "", "set disk device name for the partition")
+	vars.nodeAdd.CreateAddFlags(baseCmd)
 	// register the command line completions
 	if err := baseCmd.RegisterFlagCompletionFunc("container", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		list, _ := container.ListSources()

--- a/internal/app/wwctl/profile/add/main.go
+++ b/internal/app/wwctl/profile/add/main.go
@@ -18,29 +18,29 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 		// to this network
 		if !node.ObjectIsEmpty(vars.profileConf.NetDevs["UNDEF"]) {
 			netDev := *vars.profileConf.NetDevs["UNDEF"]
-			vars.profileConf.NetDevs[vars.netName] = &netDev
+			vars.profileConf.NetDevs[vars.nodeAdd.Net] = &netDev
 		}
 		delete(vars.profileConf.NetDevs, "UNDEF")
-		if vars.fsName != "" {
-			if !strings.HasPrefix(vars.fsName, "/dev") {
-				if vars.fsName == vars.partName {
-					vars.fsName = "/dev/disk/by-partlabel/" + vars.partName
+		if vars.nodeAdd.FsName != "" {
+			if !strings.HasPrefix(vars.nodeAdd.FsName, "/dev") {
+				if vars.nodeAdd.FsName == vars.nodeAdd.PartName {
+					vars.nodeAdd.FsName = "/dev/disk/by-partlabel/" + vars.nodeAdd.PartName
 				} else {
 					return fmt.Errorf("filesystems need to have a underlying blockdev")
 				}
 			}
 			fs := *vars.profileConf.FileSystems["UNDEF"]
-			vars.profileConf.FileSystems[vars.fsName] = &fs
+			vars.profileConf.FileSystems[vars.nodeAdd.FsName] = &fs
 		}
 		delete(vars.profileConf.FileSystems, "UNDEF")
-		if vars.diskName != "" && vars.partName != "" {
+		if vars.nodeAdd.DiskName != "" && vars.nodeAdd.PartName != "" {
 			prt := *vars.profileConf.Disks["UNDEF"].Partitions["UNDEF"]
-			vars.profileConf.Disks["UNDEF"].Partitions[vars.partName] = &prt
+			vars.profileConf.Disks["UNDEF"].Partitions[vars.nodeAdd.PartName] = &prt
 			delete(vars.profileConf.Disks["UNDEF"].Partitions, "UNDEF")
 			dsk := *vars.profileConf.Disks["UNDEF"]
-			vars.profileConf.Disks[vars.diskName] = &dsk
+			vars.profileConf.Disks[vars.nodeAdd.DiskName] = &dsk
 		}
-		if (vars.diskName != "") != (vars.partName != "") {
+		if (vars.nodeAdd.DiskName != "") != (vars.nodeAdd.PartName != "") {
 			return fmt.Errorf("partition and disk must be specified")
 		}
 		delete(vars.profileConf.Disks, "UNDEF")

--- a/internal/app/wwctl/profile/add/root.go
+++ b/internal/app/wwctl/profile/add/root.go
@@ -11,15 +11,12 @@ import (
 )
 
 type variables struct {
-	netName      string
 	profileConf  node.ProfileConf
+	nodeAdd      node.NodeConfAdd
 	SetNetDevDel string
 	SetNodeAll   bool
 	SetYes       bool
 	SetForce     bool
-	fsName       string
-	partName     string
-	diskName     string
 }
 
 // GetRootCommand returns the root cobra.Command for the application.
@@ -36,10 +33,7 @@ func GetCommand() *cobra.Command {
 		Args:                  cobra.ExactArgs(1),
 	}
 	vars.profileConf.CreateFlags(baseCmd)
-	baseCmd.PersistentFlags().StringVar(&vars.netName, "netname", "", "Set network name for network options")
-	baseCmd.PersistentFlags().StringVar(&vars.fsName, "fsname", "", "set the file system name which must match a partition name")
-	baseCmd.PersistentFlags().StringVar(&vars.partName, "partname", "", "set the partition name so it can be used by a file system")
-	baseCmd.PersistentFlags().StringVar(&vars.diskName, "diskname", "", "set disk device name for the partition")
+	vars.nodeAdd.CreateAddFlags(baseCmd)
 	// register the command line completions
 	if err := baseCmd.RegisterFlagCompletionFunc("container", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		list, _ := container.ListSources()

--- a/internal/pkg/node/flags.go
+++ b/internal/pkg/node/flags.go
@@ -21,7 +21,7 @@ type NodeConfAdd struct {
 	TagsAdd     map[string]string `lopt:"tagadd" comment:"add tags"`
 	IpmiTagsAdd map[string]string `lopt:"ipmitagadd" comment:"add ipmi tags"`
 	NetTagsAdd  map[string]string `lopt:"nettagadd" comment:"add network tags"`
-	Net         string            `lopt:"netname" comment:"network which is modified"`
+	Net         string            `lopt:"netname" comment:"network which is modified" default:"default"`
 	DiskName    string            `lopt:"diskname" comment:"set diskdevice name"`
 	PartName    string            `lopt:"partname" comment:"set the partition name so it can be used by a file system"`
 	FsName      string            `lopt:"fsname" comment:"set the file system name which must match a partition name"`


### PR DESCRIPTION
## Description of the Pull Request (PR):

Use `--netname=default` by default during `wwctl <node|profile> <add|set>`.


## This fixes or addresses the following GitHub issues:

- Closes #1499


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
