### PR TITLE
Remove dhcp template static condition around range and next-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - make sure that warewulfd has the permission 0755 at creation time #674
 - Fix "onboot" behavior for NetworkManager, Debian networking, and Suse wicked. #1278
 - Clarified missing steps in Enterprise Linux quickstart. #1179
+- Fix dhcpd.conf static template to include next-server and dhcp-range #1536
 
 ### Added
 

--- a/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
+++ b/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
@@ -51,10 +51,8 @@ if exists user-class and option user-class = "iPXE" {
 
 subnet {{$.Network}} netmask {{$.Netmask}} {
     max-lease-time 120;
-{{- if ne .Dhcp.Template "static" }}
     range {{$.Dhcp.RangeStart}} {{$.Dhcp.RangeEnd}};
     next-server {{.Ipaddr}};
-{{- end }}
 }
 
 {{- if eq .Dhcp.Template "static" }}


### PR DESCRIPTION
## Description of the Pull Request (PR):

When using a `template: static` in the `warewulf.conf` dhcp configuration, the `dhcpd.conf.ww` template produces a `dhcpd.conf` without  a `next-server` causing (some?) iPXE clients to fail to load.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
