### PR TITLE
Port next-server changes to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Make sure that tftp files have unmasked permissions at creation time. #674
 - Fix "onboot" behavior for NetworkManager, Debian networking, and Suse wicked. #1278
 - Clarified missing steps in Enterprise Linux quickstart. #1179
+- Fix dhcpd.conf static template to include next-server and dhcp-range #1536
 
 
 ## v4.5.7, 2024-09-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Simplify passing of arguments to commands through `wwctl container exec`. #253
 - Don't update IPMI if password isn't set. #638
 - Fix issue that `--nettagdel` does not work properly. #1503
+- Fix test for dhcp static configuration #1536 #1537
 
 ## v4.5.8, 2024-10-01
 

--- a/overlays/host/internal/host_test.go
+++ b/overlays/host/internal/host_test.go
@@ -218,6 +218,8 @@ if exists user-class and option user-class = "iPXE" {
 
 subnet 192.168.0.0 netmask 255.255.255.0 {
     max-lease-time 120;
+    range 192.168.0.100 192.168.0.199;
+    next-server 192.168.0.1;
 }
 host node1-default
 {

--- a/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
+++ b/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
@@ -48,10 +48,8 @@ if exists user-class and option user-class = "iPXE" {
 
 subnet {{$.Network}} netmask {{$.Netmask}} {
     max-lease-time 120;
-{{- if ne .Dhcp.Template "static" }}
     range {{$.Dhcp.RangeStart}} {{$.Dhcp.RangeEnd}};
     next-server {{.Ipaddr}};
-{{- end }}
 }
 
 {{- if eq .Dhcp.Template "static" }}


### PR DESCRIPTION
## Description of the Pull Request (PR):

 * Cherry-pick dhcp static template fix for next server #1536
 * Added test for template fix

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
