### PR TITLE
Remove defaults.conf from userdocs

### DIFF
--- a/userdocs/contents/configuration.rst
+++ b/userdocs/contents/configuration.rst
@@ -202,20 +202,6 @@ command.
    This also goes for ``warewulf.conf`` as well - any changes made also require ``warewulfd`` to be restarted.
    The restart should be done using the following command: ``systemctl restart warewulfd``
 
-defaults.conf
-=============
-
-The ``defaults.conf`` file configures default values used when none
-are specified in ``nodes.conf``. For example: if a node does not have
-a "runtime overlay" specified, the respective value from
-``defaultnode`` is used. If a network device does not specify a
-"device," the device value of the ``dummy`` device is used.
-
-If ``defaults.conf`` does not exist, compiled-in defaults are used.
-
-There should never be a need to change this file: all site-local
-parameters should be specified using either nodes or profiles.
-
 Directories
 ===========
 


### PR DESCRIPTION
This was missed during the NodeInfo refactor, which also removed nodes.conf.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
