### PR TITLE
fix issue that --nettagdel does not work properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Return non-zero exit code on overlay sub-commands #1423
 - Simplify passing of arguments to commands through `wwctl container exec`. #253
 - Don't update IPMI if password isn't set. #638
+- Fix issue that `--nettagdel` does not work properly. #1503
 
 ## v4.5.8, 2024-10-01
 

--- a/internal/app/wwctl/node/list/main_test.go
+++ b/internal/app/wwctl/node/list/main_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"os"
 	"strings"
-
 	"testing"
 
 	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
@@ -157,7 +156,8 @@ nodes:
   n01:
     profiles:
     - default
-`},
+`,
+		},
 		{
 			name:    "node list profile with comment",
 			args:    []string{"-a"},
@@ -176,7 +176,8 @@ nodes:
   n01:
     profiles:
     - default
-`},
+`,
+		},
 		{
 			name:    "node list profile with comment superseded",
 			args:    []string{"-a"},
@@ -196,7 +197,8 @@ nodes:
     comment: nodecomment
     profiles:
     - default
-`},
+`,
+		},
 		{
 			name:    "node list profile with ipmi user",
 			args:    []string{"-i"},
@@ -215,7 +217,8 @@ nodes:
   n01:
     profiles:
     - default
-`},
+`,
+		},
 		{
 			name:    "node list profile with ipmi user superseded",
 			args:    []string{"-i"},
@@ -236,7 +239,8 @@ nodes:
       username: user
     profiles:
     - default
-`},
+`,
+		},
 		{
 			name:    "multiple profiles list",
 			args:    []string{},
@@ -255,7 +259,8 @@ nodes:
     profiles:
     - p1
     - p2
-`},
+`,
+		},
 		{
 			name:    "multiple profiles list all",
 			args:    []string{"-a"},
@@ -274,7 +279,8 @@ nodes:
     profiles:
     - p1
     - p2
-`},
+`,
+		},
 		{
 			name:    "multiple overlays list long with negation",
 			args:    []string{"-l"},
@@ -294,7 +300,8 @@ nodes:
   n01:
     profiles:
     - p1
-`},
+`,
+		},
 		{
 			name:    "multiple overlays list long",
 			args:    []string{"-l"},
@@ -319,7 +326,8 @@ nodes:
     runtime overlay:
     - nop1
     - ~rop1
-`},
+`,
+		},
 		{
 			name:    "multiple overlays list all with negation",
 			args:    []string{"-a"},
@@ -346,7 +354,8 @@ nodes:
     runtime overlay:
     - nop1
     - ~rop1
-`},
+`,
+		},
 		{
 			name:    "multiple overlays list all",
 			args:    []string{"-a"},
@@ -369,7 +378,8 @@ nodes:
     - p1
     runtime overlay:
     - nop1
-`},
+`,
+		},
 		{
 			name:    "network onboot",
 			args:    []string{"-a"},
@@ -385,7 +395,8 @@ nodes:
     network devices:
       default:
         onboot: true
-`},
+`,
+		},
 		{
 			name:    "empty network device",
 			args:    []string{"-a"},
@@ -399,7 +410,8 @@ nodes:
   wwnode1:
     network devices:
       default: {}
-`},
+`,
+		},
 	}
 
 	conf_yml := `WW_INTERNAL: 0`
@@ -437,7 +449,6 @@ nodes:
 			err := baseCmd.Execute()
 			assert.NoError(t, err)
 			assert.Equal(t, strings.TrimSpace(tt.stdout), strings.TrimSpace(buf.String()))
-
 		})
 	}
 }
@@ -496,6 +507,7 @@ nodes:
       "Interface": "",
       "EscapeChar": "",
       "Write": "",
+      "Template": "",
       "Tags": {}
     },
     "Init": "",
@@ -545,6 +557,7 @@ nodes:
       "Interface": "",
       "EscapeChar": "",
       "Write": "",
+      "Template": "",
       "Tags": {}
     },
     "Init": "",
@@ -578,6 +591,7 @@ nodes:
       "Interface": "",
       "EscapeChar": "",
       "Write": "",
+      "Template": "",
       "Tags": {}
     },
     "Init": "",

--- a/internal/app/wwctl/node/set/main.go
+++ b/internal/app/wwctl/node/set/main.go
@@ -66,6 +66,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 			NetTagDel:        vars.nodeDel.NetTagsDel,
 			IpmiTagAdd:       vars.nodeAdd.IpmiTagsAdd,
 			IpmiTagDel:       vars.nodeDel.IpmiTagsDel,
+			Netdev:           vars.nodeAdd.Net,
 			AllConfs:         vars.setNodeAll,
 			Force:            vars.setForce,
 			ConfList:         args,

--- a/internal/app/wwctl/node/set/main_test.go
+++ b/internal/app/wwctl/node/set/main_test.go
@@ -72,7 +72,8 @@ nodes:
   n01:
     profiles:
     - foo
-`}
+`,
+	}
 	run_test(t, test)
 }
 
@@ -94,7 +95,8 @@ nodes:
   n01:
     profiles:
     - default
-`}
+`,
+	}
 	run_test(t, test)
 }
 
@@ -114,9 +116,11 @@ nodes:
   n01:
     ipmi:
       write: "true"
-`}
+`,
+	}
 	run_test(t, test)
 }
+
 func Test_Set_Ipmi_Write_Implicit(t *testing.T) {
 	test := test_description{
 		args:    []string{"--ipmiwrite", "n01"},
@@ -133,7 +137,8 @@ nodes:
   n01:
     ipmi:
       write: "true"
-`}
+`,
+	}
 	run_test(t, test)
 }
 
@@ -153,9 +158,11 @@ nodes:
 nodeprofiles: {}
 nodes:
   n01: {}
-`}
+`,
+	}
 	run_test(t, test)
 }
+
 func Test_Unset_Ipmi_Write_False(t *testing.T) {
 	test := test_description{
 		args:    []string{"--ipmiwrite=UNDEF", "n01"},
@@ -172,9 +179,11 @@ nodes:
 nodeprofiles: {}
 nodes:
   n01: {}
-`}
+`,
+	}
 	run_test(t, test)
 }
+
 func Test_Ipmi_Hidden_False(t *testing.T) {
 	test := test_description{
 		args:    []string{"--ipmiwrite=false", "n01"},
@@ -201,13 +210,62 @@ nodes:
     - default
     ipmi:
       write: "false"
-`}
+`,
+	}
+	run_test(t, test)
+}
+
+func Test_Add_NetTags(t *testing.T) {
+	test := test_description{
+		args:    []string{"--nettagadd=dns=1.1.1.1", "n01"},
+		wantErr: false,
+		stdout:  "",
+		inDB: `WW_INTERNAL: 43
+nodeprofiles: {}
+nodes:
+  n01: {}
+`,
+		outDb: `WW_INTERNAL: 43
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        tags:
+          dns: 1.1.1.1
+`,
+	}
+	run_test(t, test)
+}
+
+func Test_Del_NetTags(t *testing.T) {
+	test := test_description{
+		args:    []string{"--netname=default", "--nettagdel=dns1,dns2", "n01"},
+		wantErr: false,
+		stdout:  "",
+		inDB: `WW_INTERNAL: 43
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        tags:
+          dns1: 1.1.1.1
+          dns2: 2.2.2.2
+`,
+		outDb: `WW_INTERNAL: 43
+nodeprofiles: {}
+nodes:
+  n01: {}
+`,
+	}
 	run_test(t, test)
 }
 
 func Test_Multiple_Set_Tests(t *testing.T) {
 	tests := []test_description{
-		{name: "single node change profile",
+		{
+			name:    "single node change profile",
 			args:    []string{"--profile=foo", "n01"},
 			wantErr: false,
 			stdout:  "",
@@ -227,8 +285,10 @@ nodes:
   n01:
     profiles:
     - foo
-`},
-		{name: "multiple nodes change profile",
+`,
+		},
+		{
+			name:    "multiple nodes change profile",
 			args:    []string{"--profile=foo", "n0[1-2]"},
 			wantErr: false,
 			stdout:  "",
@@ -254,8 +314,10 @@ nodes:
   n02:
     profiles:
     - foo
-`},
-		{name: "single node set ipmitag",
+`,
+		},
+		{
+			name:    "single node set ipmitag",
 			args:    []string{"--ipmitagadd", "foo=baar", "n01"},
 			wantErr: false,
 			stdout:  "",
@@ -278,8 +340,10 @@ nodes:
     ipmi:
       tags:
         foo: baar
-`},
-		{name: "single node delete tag",
+`,
+		},
+		{
+			name:    "single node delete tag",
 			args:    []string{"--tagdel", "tag1", "n01"},
 			wantErr: false,
 			stdout:  "",
@@ -304,8 +368,10 @@ nodes:
     - default
     tags:
       tag2: value2
-`},
-		{name: "single node set fs,part and disk",
+`,
+		},
+		{
+			name:    "single node set fs,part and disk",
 			args:    []string{"--fsname=var", "--fspath=/var", "--fsformat=btrfs", "--partname=var", "--partnumber=1", "--diskname=/dev/vda", "n01"},
 			wantErr: false,
 			stdout:  "",
@@ -335,8 +401,10 @@ nodes:
       /dev/disk/by-partlabel/var:
         format: btrfs
         path: /var
-`},
-		{name: "single delete not existing fs",
+`,
+		},
+		{
+			name:    "single delete not existing fs",
 			args:    []string{"--fsdel=foo", "n01"},
 			wantErr: true,
 			stdout:  "",
@@ -376,8 +444,10 @@ nodes:
       /dev/disk/by-partlabel/var:
         format: btrfs
         path: /var
-`},
-		{name: "single node delete existing fs",
+`,
+		},
+		{
+			name:    "single node delete existing fs",
 			args:    []string{"--fsdel=/dev/disk/by-partlabel/var", "n01"},
 			wantErr: false,
 			stdout:  "",
@@ -413,8 +483,10 @@ nodes:
         partitions:
           var:
             number: "1"
-`},
-		{name: "single node delete existing partition",
+`,
+		},
+		{
+			name:    "single node delete existing partition",
 			args:    []string{"--partdel=var", "n01"},
 			wantErr: false,
 			stdout:  "",
@@ -449,8 +521,10 @@ nodes:
       /dev/disk/by-partlabel/var:
         format: btrfs
         path: /var
-`},
-		{name: "single node delete existing disk",
+`,
+		},
+		{
+			name:    "single node delete existing disk",
 			args:    []string{"--diskdel=/dev/vda", "n01"},
 			wantErr: false,
 			stdout:  "",
@@ -484,8 +558,10 @@ nodes:
       /dev/disk/by-partlabel/var:
         format: btrfs
         path: /var
-`},
-		{name: "single node set mtu",
+`,
+		},
+		{
+			name:    "single node set mtu",
 			args:    []string{"--mtu", "1234", "--netname=mynet", "n01"},
 			wantErr: false,
 			stdout:  "",
@@ -508,8 +584,10 @@ nodes:
     network devices:
       mynet:
         mtu: "1234"
-`},
-		{name: "single node set ipmitag",
+`,
+		},
+		{
+			name:    "single node set ipmitag",
 			args:    []string{"--tagadd", "nodetag1=nodevalue1", "n01"},
 			wantErr: false,
 			stdout:  "",
@@ -545,8 +623,10 @@ nodes:
     - p2
     tags:
       nodetag1: nodevalue1
-`},
-		{name: "single node set comma in comment",
+`,
+		},
+		{
+			name:    "single node set comma in comment",
 			args:    []string{"n01", "--comment", "This is a , comment"},
 			wantErr: false,
 			stdout:  "",
@@ -560,7 +640,8 @@ nodeprofiles: {}
 nodes:
   n01:
     comment: This is a , comment
-`},
+`,
+		},
 	}
 
 	conf_yml := `WW_INTERNAL: 0`
@@ -610,7 +691,8 @@ nodes:
     - default
     tags:
       email: node
-`},
+`,
+		},
 		{
 			args:    []string{"--tagadd=newtag=newval", "n01"},
 			wantErr: false,
@@ -640,7 +722,8 @@ nodes:
     tags:
       email: node
       newtag: newval
-`},
+`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description of the Pull Request (PR):

fix issue that --nettagdel does not work properly


## This fixes or addresses the following GitHub issues:

- Fixes #1503


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary


## Test
```
[root@warewulf warewulf]# wwctl node list n2 --all
NODE  FIELD                        PROFILE  VALUE
----  -----                        -------  -----
n2    Comment                      default  This profile is automatically included for each node
n2    ContainerName                default  rocky-9
n2    Init                         default  /sbin/init
n2    Ipxe                         default  default
n2    Kernel.Args                  default  quiet crashkernel=no
n2    NetDevs[default].Device      --       default
n2    NetDevs[default].Tags[dns1]  --       1.1.1.1
n2    NetDevs[default].Tags[dns2]  --       2.2.2.2
n2    NetDevs[eth1].Gateway        default  192.168.200.211
n2    NetDevs[eth1].Netmask        default  255.255.255.0
n2    Profiles                     --       default
n2    Root                         default  initramfs
n2    RuntimeOverlay               default  hosts,ssh.authorized_keys,syncuser
n2    SystemOverlay                default  wwinit,wwclient,fstab,hostname,ssh.host_keys,issue,resolv,udev.netname,systemd.netname,ifcfg,NetworkManager,debian.interfaces,wicked,ignition

[root@warewulf warewulf]# wwctl node set n2 --nettagdel=dns1,dns2
? Are you sure you want to modify 1 nodes(s)? [y/N] y█
[root@warewulf warewulf]# wwctl node list n2 --all
NODE  FIELD                    PROFILE  VALUE
----  -----                    -------  -----
n2    Comment                  default  This profile is automatically included for each node
n2    ContainerName            default  rocky-9
n2    Init                     default  /sbin/init
n2    Ipxe                     default  default
n2    Kernel.Args              default  quiet crashkernel=no
n2    NetDevs[default].Device  --       default
n2    NetDevs[eth1].Gateway    default  192.168.200.211
n2    NetDevs[eth1].Netmask    default  255.255.255.0
n2    Profiles                 --       default
n2    Root                     default  initramfs
n2    RuntimeOverlay           default  hosts,ssh.authorized_keys,syncuser
n2    SystemOverlay            default  wwinit,wwclient,fstab,hostname,ssh.host_keys,issue,resolv,udev.netname,systemd.netname,ifcfg,NetworkManager,debian.interfaces,wicked,ignition
```
