### PR TITLE
Fix `wwctl upgrade config` description

### DIFF
--- a/internal/app/wwctl/upgrade/config/cobra.go
+++ b/internal/app/wwctl/upgrade/config/cobra.go
@@ -15,8 +15,8 @@ var (
 	Command = &cobra.Command{
 		DisableFlagsInUseLine: true,
 		Use:                   "config [OPTIONS]",
-		Short:                 "Upgrade an existing nodes.conf",
-		Long: `Upgrades nodes.conf from a previous version of Warewulf 4 to a format
+		Short:                 "Upgrade an existing warewulf.conf",
+		Long: `Upgrades warewulf.conf from a previous version of Warewulf 4 to a format
 supported by the current version.`,
 		RunE: UpgradeNodesConf,
 	}
@@ -26,8 +26,8 @@ supported by the current version.`,
 )
 
 func init() {
-	Command.Flags().StringVarP(&inputPath, "input-path", "i", config.ConfigFile, "Path to a legacy nodes.conf")
-	Command.Flags().StringVarP(&outputPath, "output-path", "o", config.ConfigFile, "Path to write the upgraded nodes.conf to")
+	Command.Flags().StringVarP(&inputPath, "input-path", "i", config.ConfigFile, "Path to a legacy warewulf.conf")
+	Command.Flags().StringVarP(&outputPath, "output-path", "o", config.ConfigFile, "Path to write the upgraded warewulf.conf to")
 }
 
 func UpgradeNodesConf(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Description of the Pull Request (PR):

`wwctl upgrade config` erroneously retained a description copied from `wwctl upgrade nodes`.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
