### PR TITLE
Add test for sending grub.cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - replaced deprecated errors.Wrapf with fmr.Errorf. #1534
 - Rename udev net naming file to 70-persistent-net.rules. #1227
 - Manage warewulfd template data as a pointer. #1548
+- Added test for sending grub.cfg.ww. #1548
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Replace `olekukonko/tablewriter` with `cheynewallace/tabby`. #1497, #1498
 - replaced deprecated errors.Wrapf with fmr.Errorf. #1534
 - Rename udev net naming file to 70-persistent-net.rules. #1227
+- Manage warewulfd template data as a pointer. #1548
 
 ### Removed
 

--- a/internal/pkg/warewulfd/provision.go
+++ b/internal/pkg/warewulfd/provision.go
@@ -71,7 +71,7 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 	var stage_file string
 
 	// TODO: when module version is upgraded to go1.18, should be 'any' type
-	var tmpl_data interface{}
+	var tmpl_data *templateVars
 
 	remoteNode, err := GetNodeOrSetDiscoverable(rinfo.hwaddr)
 	if err != nil && err != node.ErrNoUnconfigured {
@@ -91,13 +91,13 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 		wwlog.Error("%s (unknown/unconfigured node)", rinfo.hwaddr)
 		if rinfo.stage == "ipxe" {
 			stage_file = path.Join(conf.Paths.Sysconfdir, "/warewulf/ipxe/unconfigured.ipxe")
-			tmpl_data = templateVars{
+			tmpl_data = &templateVars{
 				Hwaddr: rinfo.hwaddr}
 		}
 
 	} else if rinfo.stage == "ipxe" {
 		stage_file = path.Join(conf.Paths.Sysconfdir, "warewulf/ipxe/"+remoteNode.Ipxe+".ipxe")
-		tmpl_data = templateVars{
+		tmpl_data = &templateVars{
 			Id:             remoteNode.Id(),
 			Cluster:        remoteNode.ClusterName,
 			Fqdn:           remoteNode.Id(),
@@ -181,7 +181,7 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 			}
 		case "grub.cfg":
 			stage_file = path.Join(conf.Paths.Sysconfdir, "warewulf/grub/grub.cfg.ww")
-			tmpl_data = templateVars{
+			tmpl_data = &templateVars{
 				Id:             remoteNode.Id(),
 				Cluster:        remoteNode.ClusterName,
 				Fqdn:           remoteNode.Id(),

--- a/internal/pkg/warewulfd/provision_test.go
+++ b/internal/pkg/warewulfd/provision_test.go
@@ -32,6 +32,7 @@ var provisionSendTests = []struct {
 	{"find grub", "/efiboot/grub.efi", "", 404, "10.10.10.11:9873"},
 	{"find initramfs", "/provision/00:00:00:ff:ff:ff?stage=initramfs", "", 200, "10.10.10.10:9873"},
 	{"ipxe test with NetDevs and KernelOverrides", "/provision/00:00:00:00:00:ff?stage=ipxe", "1.1.1 ifname=net:00:00:00:00:00:ff ", 200, "10.10.10.12:9873"},
+	{"find grub.cfg", "/efiboot/grub.cfg", "dracut", 200, "10.10.10.11:9873"},
 }
 
 func Test_ProvisionSend(t *testing.T) {
@@ -52,6 +53,8 @@ nodes:
       default:
         hwaddr: 00:00:00:00:ff:ff
     container name: none
+    tags:
+      GrubMenuEntry: dracut
   n3:
     network devices:
       default:
@@ -96,6 +99,10 @@ nodes:
 	assert.NoError(t, os.MkdirAll(path.Join(conf.Paths.Sysconfdir, "warewulf/ipxe"), 0700))
 	{
 		assert.NoError(t, os.WriteFile(path.Join(conf.Paths.Sysconfdir, "warewulf/ipxe", "test.ipxe"), []byte("{{.KernelOverride}}{{range $devname, $netdev := .NetDevs}}{{if and $netdev.Hwaddr $netdev.Device}} ifname={{$netdev.Device}}:{{$netdev.Hwaddr}} {{end}}{{end}}"), 0600))
+	}
+	assert.NoError(t, os.MkdirAll(path.Join(conf.Paths.Sysconfdir, "warewulf/grub"), 0700))
+	{
+		assert.NoError(t, os.WriteFile(path.Join(conf.Paths.Sysconfdir, "warewulf/grub", "grub.cfg.ww"), []byte("{{ .Tags.GrubMenuEntry }}"), 0600))
 	}
 
 	dbErr := LoadNodeDB()


### PR DESCRIPTION
Although I can't reproduce the this with test, Tags are not 
awlays included in the template for e,g, grub.cfg.ww
Using a pointer to templateConfig fixes this.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
