### PR TITLE
Fix CHANGELOG for #1004

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add support for static routes to NetworkManager, wicked, ifcfg, debian.network_interfaces overlays. #1257
 - Add `wwctl upgrade <config|nodes>`. #230, #517
 - Better handling of InfiniBand udev net naming. #1227
+- use templating mechanism for power commands. #1004
 
 ### Changed
 
@@ -171,8 +172,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Refactor URL handling in wwclient to consistently escape arguments.
 
-## v4.5.6, unreleased
-
 ### Fixed
 
 - Ensure autobuilt overlays include contextual overlay contents. #1296
@@ -182,7 +181,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - `wwctl container list` only lists names by default. (`--long` shows all attributes.) #1117
-- use templating mechanism for power commands
 
 ## v4.5.5, 2024-07-05
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

- Move #1004 change to v4.6.0
- Remove redundant v4.5.6 header

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
