### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM opensuse/tumbleweed:latest as builder
 
-RUN zypper  -n install --no-recommends git go1.18 libgpgme-devel &&\
+RUN zypper  -n install --no-recommends git go1.21 libgpgme-devel unzip &&\
   zypper -n install -t pattern devel_basis
 
 # now build the warewulf

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN zypper  -n install \
   container-scripts/config-warewulf \
   /container &&\
   mkdir -p /usr/share/bash_completion/completions/ &&\
-  cp /etc/warewulf/bash_completion.d/warewulf /usr/share/bash_completion/completions/warewulf &&\
+  cp /etc/warewulf/bash_completion.d/* /usr/share/bash_completion/completions/ &&\
   mv -v container-scripts/ww4-config.service /etc/systemd/system/ &&\
   mv -v container-scripts/warewulfd.service /etc/systemd/system/ &&\
   systemctl enable ww4-config &&\

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/warewulf/warewulf
 
 go 1.21.0
 
-toolchain go1.22.5
+toolchain go1.23.3
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR make the building of the Docker image possible again with current main branch.
Before it failed with:

```
level=error msg="Running error: context loading failed: failed to load packages: failed to load packages: failed to load with go/packages: err: exit status 1: stderr: go: errors parsing go.mod:\n/warewulf-src/go.mod:3: invalid go version '1.21.0': must match format 1.23\n/warewulf-src/go.mod:5: unknown directive: toolchain\n"
make: *** [Makefile:74: lint] Error 3
```
I therefore updated the go version and ran `go mod tidy` and `go mod vendors` and then built the image with `docker build -t warewulf .`

Also the bash completion seemed outdated, so I made the copy command generic.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
