### PR TITLE
Fix nightly build

### DIFF
--- a/.github/actions/generate/action.yml
+++ b/.github/actions/generate/action.yml
@@ -74,14 +74,14 @@ runs:
 
     - name: Upload warewulf.spec
       if: steps.should-continue.outputs.continue == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: warewulf.spec
         path: warewulf.spec
 
     - name: Upload DIST
       if: steps.should-continue.outputs.continue == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.DIST }}
         path: ${{ env.DIST }}

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
 
     - name: Setup go ${{ inputs.go-version }}
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.go-version }}
         cache: true

--- a/.github/actions/rpm/action.yml
+++ b/.github/actions/rpm/action.yml
@@ -68,19 +68,19 @@ runs:
       shell: bash
 
     - name: Upload RPM
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.RPM }}
         path: /var/lib/mock/${{ inputs.target }}/result/${{ env.RPM }}
 
     - name: Upload SRPM
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.SRPM }}
         path: /var/lib/mock/${{ inputs.target }}/result/${{ env.SRPM }}
 
     - name: Upload dracut RPM
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.DRACUT }}
         path: /var/lib/mock/${{ inputs.target }}/result/${{ env.DRACUT }}

--- a/.github/actions/rpm/action.yml
+++ b/.github/actions/rpm/action.yml
@@ -35,7 +35,7 @@ runs:
       shell: bash
 
     - name: Download spec
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: warewulf.spec
 
@@ -45,7 +45,7 @@ runs:
       shell: bash
 
     - name: Download dist
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: warewulf-${{ env.EXPECTED_VERSION }}.tar.gz
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -38,7 +38,7 @@ jobs:
           sudo apt-get install -f -y graphviz
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
 
       - name: Install Sphinx
         run: |

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -71,8 +71,9 @@ Requires: dhcp
 
 BuildRequires: git
 BuildRequires: make
+BuildRequires: gpgme-devel
 %if %{api}
-BuildRequires: libassuan-devel gpgme-devel
+BuildRequires: libassuan-devel
 %endif
 
 Recommends: logrotate


### PR DESCRIPTION
## Description of the Pull Request (PR):

The nightly build has been broken since the disabling of the API during RPM build. This due to gpgme-devel only being listed as required when the API was built.

This PR now lists gpgme-devel as required in all cases.

This PR also updates all workflow dependencies to their latest versions.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
