### PR TITLE
Format errors in logs as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix issue that initrd fails at downloading runtime overlay with permission denied error,
   when warewulf secure option in warewulf.conf is enabled. #806
 - Allow iPXE to continue booting without runtime overlay. #806
+- Format errors in logs as strings. #1563
 
 ## v4.5.8, 2024-10-01
 

--- a/internal/app/wwctl/container/exec/main.go
+++ b/internal/app/wwctl/container/exec/main.go
@@ -48,7 +48,7 @@ func runContainedCmd(cmd *cobra.Command, containerName string, args []string) (e
 	}
 	defer func() {
 		if err := os.RemoveAll(runDir); err != nil {
-			wwlog.Error("error removing run directory: %w", err)
+			wwlog.Error("error removing run directory: %s", err)
 		}
 	}()
 

--- a/internal/pkg/api/container/container.go
+++ b/internal/pkg/api/container/container.go
@@ -398,7 +398,7 @@ func ContainerRename(crp *wwapiv1.ContainerRenameParameter) (err error) {
 
 	err = container.DeleteImage(crp.ContainerName)
 	if err != nil {
-		wwlog.Warn("Could not remove image files for %s: %w", crp.ContainerName, err)
+		wwlog.Warn("Could not remove image files for %s: %s", crp.ContainerName, err)
 	}
 
 	if crp.Build {

--- a/internal/pkg/upgrade/node.go
+++ b/internal/pkg/upgrade/node.go
@@ -528,7 +528,7 @@ func (this *NetDev) Upgrade(addDefaults bool) (upgraded *node.NetDev) {
 	if this.IpCIDR != "" {
 		cidrIP, cidrIPNet, err := net.ParseCIDR(this.IpCIDR)
 		if err != nil {
-			wwlog.Error("%v is not a valid CIDR address: %w", this.IpCIDR, err)
+			wwlog.Error("%v is not a valid CIDR address: %s", this.IpCIDR, err)
 		} else {
 			if upgraded.Ipaddr == nil {
 				upgraded.Ipaddr = cidrIP


### PR DESCRIPTION
## Description of the Pull Request (PR):

Some error logs were being formatted with `%w`, which wraps errors programmatically but doesn't present errors in a straightforward format.

```
# wwctl container rename alpine alpine-newname
WARN   : Could not remove image files for alpine: %!w(*errors.fundamental=&{Image /var/lib/warewulf/provision/container/alpine.img of container alpine doesn't exist
 0x400011d6b0})
```


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
