### PR TITLE
Use a sentinel file to determine container readonly state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Rename udev net naming file to 70-persistent-net.rules. #1227
 - Manage warewulfd template data as a pointer. #1548
 - Added test for sending grub.cfg.ww. #1548
+- Use a sentinel file to determine container readonly state. #1447
 
 ### Removed
 

--- a/internal/app/wwctl/container/exec/child/main.go
+++ b/internal/app/wwctl/container/exec/child/main.go
@@ -120,7 +120,7 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 		}
 		ps1Str = fmt.Sprintf("[%s|ro|%s] Warewulf> ", containerName, nodename)
 	}
-	if !util.IsWriteAble(containerPath) && nodename == "" {
+	if !container.IsWriteAble(containerName) && nodename == "" {
 		wwlog.Verbose("mounting %s ro", containerPath)
 		ps1Str = fmt.Sprintf("[%s|ro] Warewulf> ", containerName)
 		err = syscall.Mount(containerPath, containerPath, "", syscall.MS_BIND, "")

--- a/internal/pkg/container/util.go
+++ b/internal/pkg/container/util.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 
@@ -108,4 +109,8 @@ func DeleteImage(name string) error {
 		return nil
 	}
 	return errors.Errorf("Image %s of container %s doesn't exist\n", imageFile, name)
+}
+
+func IsWriteAble(name string) bool {
+	return !util.IsFile(filepath.Join(SourceDir(name), "readonly"))
 }

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -565,21 +565,3 @@ func ByteToString(b int64) string {
 	}
 	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
 }
-
-/*
-Check if the w-bit of a file/dir. unix.Access(file,unix.W_OK) will
-not show this.
-*/
-func IsWriteAble(path string) bool {
-	info, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-
-	// Check if the user bit is enabled in file permission
-	if info.Mode().Perm()&(1<<(uint(7))) == 0 {
-		wwlog.Debug("Write permission bit is not set for: %s", path)
-		return false
-	}
-	return true
-}

--- a/userdocs/contents/containers.rst
+++ b/userdocs/contents/containers.rst
@@ -464,3 +464,14 @@ tools 1.21 or newer. Below is an example for building wwclient for arm64:
    # cp wwclient /var/lib/warewulf/overlays/wwclient_arm64/rootfs/warewulf
 
 Then, apply the new "wwclient_arm64" system overlay to your arm64 node/profile
+
+Read-only containers
+====================
+
+A container may be marked "read-only" by creating a ``readonly`` file in its
+source directory, typically next to ``rootfs``.
+
+.. note::
+
+   Read-only containers are a preview feature primarily meant to enable future
+   support for container subscriptions and updates.


### PR DESCRIPTION
## Description of the Pull Request (PR):

The permissions on rootfs is part of the container image itself, and cannot reliably be used as configuration metadata by Warewulf. As such, this PR adjusts the determination of a container's readonly state to use a sentinel "readonly" file in the source dir.


## This fixes or addresses the following GitHub issues:

- Fixes #1447


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
