### PR TITLE
Remove wwctl overlay build --host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `wwctl node list --fullall` has been removed
 - `wwctl profile list --fullall` has been removed
 - Remove `wwctl server <start,stop,status,restart,reload>` #508
+- Remove `wwctl overlay build --host` #1419
+- Remove `wwctl overlay build --nodes` #1419
 
 ### Fixed
 

--- a/internal/app/wwctl/overlay/build/root.go
+++ b/internal/app/wwctl/overlay/build/root.go
@@ -29,15 +29,11 @@ var (
 			return node_names, cobra.ShellCompDirectiveNoFileComp
 		},
 	}
-	BuildHost    bool
-	BuildNodes   bool
 	OverlayNames []string
 	OverlayDir   string
 )
 
 func init() {
-	baseCmd.PersistentFlags().BoolVarP(&BuildHost, "host", "H", false, "Build overlays only for the host")
-	baseCmd.PersistentFlags().BoolVarP(&BuildNodes, "nodes", "N", false, "Build overlays only for the nodes")
 	baseCmd.PersistentFlags().StringSliceVarP(&OverlayNames, "overlay", "O", []string{}, "Build only specific overlay(s)")
 
 	if err := baseCmd.RegisterFlagCompletionFunc("overlay", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -46,7 +42,7 @@ func init() {
 	}); err != nil {
 		log.Println(err)
 	}
-	baseCmd.PersistentFlags().StringVarP(&OverlayDir, "output", "o", "", `Do not create an overlay image, for distribution but write to
+	baseCmd.PersistentFlags().StringVarP(&OverlayDir, "output", "o", "", `Do not create an overlay image for distribution but write to
 	the given directory. An overlay must also be ge given to use this option.`)
 
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Remove the ability to "build" the host overlay with `wwctl overlay build`. This also obsoletes the `--nodes` flag, which is also removed.


## This fixes or addresses the following GitHub issues:

- Closes #1419


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
