### PR TITLE
Remove the node.ConfigFile initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove `wwctl overlay build --nodes` #1419
 - Remove `wwctl kernel` #1556
 - Remove `wwctl <node|profile> <add|set> --kerneloverride` #1556
+- Removed the nodeDB.Configfile initialization from init
 
 ### Fixed
 

--- a/internal/app/wwctl/clean/main_test.go
+++ b/internal/app/wwctl/clean/main_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -11,7 +12,7 @@ import (
 func Test_Clean(t *testing.T) {
 	wwlog.SetLogLevel(wwlog.DEBUG)
 	env := testenv.New(t)
-	env.WriteFile(t, "etc/warewulf/nodes.conf",
+	env.WriteFile(t, node.GetNodesConf("etc"),
 		`nodeprofiles: {}
 nodes:
   node1: {}

--- a/internal/app/wwctl/container/list/main_test.go
+++ b/internal/app/wwctl/container/list/main_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/pkg/api/routes/wwapiv1"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -57,7 +58,7 @@ nodes:
 	for _, tt := range tests {
 		env := testenv.New(t)
 		defer env.RemoveAll(t)
-		env.WriteFile(t, "etc/warewulf/nodes.conf", tt.inDb)
+		env.WriteFile(t, node.GetNodesConf("etc"), tt.inDb)
 
 		t.Logf("Running test: %s\n", tt.name)
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/app/wwctl/node/add/main_test.go
+++ b/internal/app/wwctl/node/add/main_test.go
@@ -281,7 +281,7 @@ nodes:
 	warewulfd.SetNoDaemon()
 	for _, tt := range tests {
 		env := testenv.New(t)
-		env.WriteFile(t, "etc/warewulf/nodes.conf", ``)
+		env.WriteFile(t, node.GetNodesConf("etc"), ``)
 		var err error
 		t.Run(tt.name, func(t *testing.T) {
 			baseCmd := GetCommand()

--- a/internal/app/wwctl/node/list/main_test.go
+++ b/internal/app/wwctl/node/list/main_test.go
@@ -2,14 +2,10 @@ package list
 
 import (
 	"bytes"
-	"os"
 	"strings"
 	"testing"
 
-	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
-
 	"github.com/stretchr/testify/assert"
-	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -395,30 +391,11 @@ NODE  FIELD  PROFILE  VALUE
 `,
 		},
 	}
-
-	conf_yml := ``
-	tempWarewulfConf, warewulfConfErr := os.CreateTemp("", "warewulf.conf-")
-	assert.NoError(t, warewulfConfErr)
-	defer os.Remove(tempWarewulfConf.Name())
-	_, warewulfConfErr = tempWarewulfConf.Write([]byte(conf_yml))
-	assert.NoError(t, warewulfConfErr)
-	assert.NoError(t, tempWarewulfConf.Sync())
-	assert.NoError(t, warewulfconf.New().Read(tempWarewulfConf.Name()))
-
-	tempNodeConf, nodesConfErr := os.CreateTemp("", "nodes.conf-")
-	assert.NoError(t, nodesConfErr)
-	defer os.Remove(tempNodeConf.Name())
-	node.ConfigFile = tempNodeConf.Name()
+	env := testenv.New(t)
+	defer env.RemoveAll(t)
 	warewulfd.SetNoDaemon()
 	for _, tt := range tests {
-		var err error
-		_, err = tempNodeConf.Seek(0, 0)
-		assert.NoError(t, err)
-		assert.NoError(t, tempNodeConf.Truncate(0))
-		_, err = tempNodeConf.Write([]byte(tt.inDb))
-		assert.NoError(t, err)
-		assert.NoError(t, tempNodeConf.Sync())
-
+		env.WriteFile(t, "etc/warewulf/nodes.conf", tt.inDb)
 		t.Run(tt.name, func(t *testing.T) {
 			baseCmd := GetCommand()
 			baseCmd.SetArgs(tt.args)

--- a/internal/app/wwctl/node/list/main_test.go
+++ b/internal/app/wwctl/node/list/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -395,7 +396,7 @@ NODE  FIELD  PROFILE  VALUE
 	defer env.RemoveAll(t)
 	warewulfd.SetNoDaemon()
 	for _, tt := range tests {
-		env.WriteFile(t, "etc/warewulf/nodes.conf", tt.inDb)
+		env.WriteFile(t, node.GetNodesConf("etc"), tt.inDb)
 		t.Run(tt.name, func(t *testing.T) {
 			baseCmd := GetCommand()
 			baseCmd.SetArgs(tt.args)
@@ -605,7 +606,7 @@ nodes:
 	warewulfd.SetNoDaemon()
 	for _, tt := range tests {
 		env := testenv.New(t)
-		env.WriteFile(t, "etc/warewulf/nodes.conf", tt.inDb)
+		env.WriteFile(t, node.GetNodesConf("etc"), tt.inDb)
 		var err error
 		t.Run(tt.name, func(t *testing.T) {
 			buf := new(bytes.Buffer)

--- a/internal/app/wwctl/node/sensors/root_test.go
+++ b/internal/app/wwctl/node/sensors/root_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -15,7 +16,7 @@ func Test_Sensors(t *testing.T) {
 	warewulfd.SetNoDaemon()
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.WriteFile(t, "etc/warewulf/nodes.conf", `
+	env.WriteFile(t, node.GetNodesConf("etc"), `
 nodeprofiles:
   default:
     ipmi:

--- a/internal/app/wwctl/node/set/main_test.go
+++ b/internal/app/wwctl/node/set/main_test.go
@@ -2,12 +2,9 @@ package set
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
-	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -645,20 +642,6 @@ nodes:
 `,
 		},
 	}
-
-	conf_yml := ``
-	tempWarewulfConf, warewulfConfErr := os.CreateTemp("", "warewulf.conf-")
-	assert.NoError(t, warewulfConfErr)
-	defer os.Remove(tempWarewulfConf.Name())
-	_, warewulfConfErr = tempWarewulfConf.Write([]byte(conf_yml))
-	assert.NoError(t, warewulfConfErr)
-	assert.NoError(t, tempWarewulfConf.Sync())
-	assert.NoError(t, warewulfconf.New().Read(tempWarewulfConf.Name()))
-
-	tempNodeConf, nodesConfErr := os.CreateTemp("", "nodes.conf-")
-	assert.NoError(t, nodesConfErr)
-	defer os.Remove(tempNodeConf.Name())
-	node.ConfigFile = tempNodeConf.Name()
 	warewulfd.SetNoDaemon()
 	for _, tt := range tests {
 		run_test(t, tt)

--- a/internal/app/wwctl/node/set/main_test.go
+++ b/internal/app/wwctl/node/set/main_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -23,7 +24,7 @@ func run_test(t *testing.T, test test_description) {
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
 	wwlog.SetLogLevel(wwlog.DEBUG)
-	env.WriteFile(t, "etc/warewulf/nodes.conf", test.inDB)
+	env.WriteFile(t, node.GetNodesConf("etc"), test.inDB)
 	warewulfd.SetNoDaemon()
 	name := test.name
 	if name == "" {
@@ -42,7 +43,7 @@ func run_test(t *testing.T, test test_description) {
 		} else {
 			assert.NoError(t, err)
 			assert.Equal(t, buf.String(), test.stdout)
-			content := env.ReadFile(t, "etc/warewulf/nodes.conf")
+			content := env.ReadFile(t, node.GetNodesConf("etc"))
 			assert.YAMLEq(t, test.outDb, content)
 		}
 	})

--- a/internal/app/wwctl/overlay/show/main_test.go
+++ b/internal/app/wwctl/overlay/show/main_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -51,7 +52,7 @@ nfs:
     mount options: defaults
     mount: false`)
 
-	env.WriteFile(t, "etc/warewulf/nodes.conf",
+	env.WriteFile(t, node.GetNodesConf("etc"),
 		`nodeprofiles:
   default:
     tags:
@@ -138,7 +139,7 @@ func TestShowServerTemplate(t *testing.T) {
 	`
 
 	env := testenv.New(t)
-	env.WriteFile(t, "etc/warewulf/nodes.conf",
+	env.WriteFile(t, node.GetNodesConf("etc"),
 		`nodeprofiles:
   default:
     tags:

--- a/internal/app/wwctl/power/cycle/root_test.go
+++ b/internal/app/wwctl/power/cycle/root_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -15,7 +16,7 @@ func Test_PowerCycle(t *testing.T) {
 	warewulfd.SetNoDaemon()
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.WriteFile(t, "etc/warewulf/nodes.conf", `
+	env.WriteFile(t, node.GetNodesConf("etc"), `
 nodeprofiles:
   default:
     ipmi:

--- a/internal/app/wwctl/power/off/root_test.go
+++ b/internal/app/wwctl/power/off/root_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -15,7 +16,7 @@ func Test_Power_Status(t *testing.T) {
 	warewulfd.SetNoDaemon()
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.WriteFile(t, "etc/warewulf/nodes.conf", `
+	env.WriteFile(t, node.GetNodesConf("etc"), `
 nodeprofiles:
   default:
     ipmi:

--- a/internal/app/wwctl/power/on/root_test.go
+++ b/internal/app/wwctl/power/on/root_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -15,7 +16,7 @@ func Test_Power_Status(t *testing.T) {
 	warewulfd.SetNoDaemon()
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.WriteFile(t, "etc/warewulf/nodes.conf", `
+	env.WriteFile(t, node.GetNodesConf("etc"), `
 nodeprofiles:
   default:
     ipmi:

--- a/internal/app/wwctl/power/reset/root_test.go
+++ b/internal/app/wwctl/power/reset/root_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -15,7 +16,7 @@ func Test_Power_Status(t *testing.T) {
 	warewulfd.SetNoDaemon()
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.WriteFile(t, "etc/warewulf/nodes.conf", `
+	env.WriteFile(t, node.GetNodesConf("etc"), `
 nodeprofiles:
   default:
     ipmi:

--- a/internal/app/wwctl/power/soft/root_test.go
+++ b/internal/app/wwctl/power/soft/root_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -15,7 +16,7 @@ func Test_Power_Status(t *testing.T) {
 	warewulfd.SetNoDaemon()
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.WriteFile(t, "etc/warewulf/nodes.conf", `
+	env.WriteFile(t, node.GetNodesConf("etc"), `
 nodeprofiles:
   default:
     ipmi:

--- a/internal/app/wwctl/power/status/root_test.go
+++ b/internal/app/wwctl/power/status/root_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -15,7 +16,7 @@ func Test_Power_Status(t *testing.T) {
 	warewulfd.SetNoDaemon()
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.WriteFile(t, "etc/warewulf/nodes.conf", `
+	env.WriteFile(t, node.GetNodesConf("etc"), `
 nodeprofiles:
   default:
     ipmi:

--- a/internal/app/wwctl/profile/add/main_test.go
+++ b/internal/app/wwctl/profile/add/main_test.go
@@ -46,7 +46,7 @@ nodes: {}
 	warewulfd.SetNoDaemon()
 	for _, tt := range tests {
 		env := testenv.New(t)
-		env.WriteFile(t, "etc/warewulf/nodes.conf", ``)
+		env.WriteFile(t, node.GetNodesConf("etc"), ``)
 		var err error
 		t.Run(tt.name, func(t *testing.T) {
 			baseCmd := GetCommand()

--- a/internal/app/wwctl/profile/list/main_test.go
+++ b/internal/app/wwctl/profile/list/main_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -97,7 +98,7 @@ nodes:
 	env := testenv.New(t)
 	warewulfd.SetNoDaemon()
 	for _, tt := range tests {
-		env.WriteFile(t, "etc/warewulf/nodes.conf", tt.inDb)
+		env.WriteFile(t, node.GetNodesConf("etc"), tt.inDb)
 		t.Run(tt.name, func(t *testing.T) {
 			baseCmd := GetCommand()
 			baseCmd.SetArgs(tt.args)
@@ -251,7 +252,7 @@ nodes:
 	env := testenv.New(t)
 	warewulfd.SetNoDaemon()
 	for _, tt := range tests {
-		env.WriteFile(t, "etc/warewulf/nodes.conf", tt.inDb)
+		env.WriteFile(t, node.GetNodesConf("etc"), tt.inDb)
 
 		t.Run(tt.name, func(t *testing.T) {
 			baseCmd := GetCommand()

--- a/internal/app/wwctl/profile/list/main_test.go
+++ b/internal/app/wwctl/profile/list/main_test.go
@@ -8,8 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
-	"github.com/warewulf/warewulf/internal/pkg/node"
+	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -95,31 +94,10 @@ nodes:
 `,
 		},
 	}
-
-	conf_yml := ``
-	tempWarewulfConf, warewulfConfErr := os.CreateTemp("", "warewulf.conf-")
-	assert.NoError(t, warewulfConfErr)
-	defer os.Remove(tempWarewulfConf.Name())
-	_, warewulfConfErr = tempWarewulfConf.Write([]byte(conf_yml))
-	assert.NoError(t, warewulfConfErr)
-	assert.NoError(t, tempWarewulfConf.Sync())
-	assert.NoError(t, warewulfconf.New().Read(tempWarewulfConf.Name()))
-
-	tempNodeConf, nodesConfErr := os.CreateTemp("", "nodes.conf-")
-	assert.NoError(t, nodesConfErr)
-	defer os.Remove(tempNodeConf.Name())
-	node.ConfigFile = tempNodeConf.Name()
+	env := testenv.New(t)
 	warewulfd.SetNoDaemon()
 	for _, tt := range tests {
-		var err error
-		_, err = tempNodeConf.Seek(0, 0)
-		assert.NoError(t, err)
-		assert.NoError(t, tempNodeConf.Truncate(0))
-		_, err = tempNodeConf.Write([]byte(tt.inDb))
-		assert.NoError(t, err)
-		assert.NoError(t, tempNodeConf.Sync())
-		assert.NoError(t, err)
-
+		env.WriteFile(t, "etc/warewulf/nodes.conf", tt.inDb)
 		t.Run(tt.name, func(t *testing.T) {
 			baseCmd := GetCommand()
 			baseCmd.SetArgs(tt.args)
@@ -270,28 +248,10 @@ nodes:
 		},
 	}
 
-	conf_yml := ``
-	tempWarewulfConf, warewulfConfErr := os.CreateTemp("", "warewulf.conf-")
-	assert.NoError(t, warewulfConfErr)
-	defer os.Remove(tempWarewulfConf.Name())
-	_, warewulfConfErr = tempWarewulfConf.Write([]byte(conf_yml))
-	assert.NoError(t, warewulfConfErr)
-	assert.NoError(t, tempWarewulfConf.Sync())
-	assert.NoError(t, warewulfconf.New().Read(tempWarewulfConf.Name()))
-
-	tempNodeConf, nodesConfErr := os.CreateTemp("", "nodes.conf-")
-	assert.NoError(t, nodesConfErr)
-	defer os.Remove(tempNodeConf.Name())
-	node.ConfigFile = tempNodeConf.Name()
+	env := testenv.New(t)
 	warewulfd.SetNoDaemon()
 	for _, tt := range tests {
-		var err error
-		_, err = tempNodeConf.Seek(0, 0)
-		assert.NoError(t, err)
-		assert.NoError(t, tempNodeConf.Truncate(0))
-		_, err = tempNodeConf.Write([]byte(tt.inDb))
-		assert.NoError(t, err)
-		assert.NoError(t, tempNodeConf.Sync())
+		env.WriteFile(t, "etc/warewulf/nodes.conf", tt.inDb)
 
 		t.Run(tt.name, func(t *testing.T) {
 			baseCmd := GetCommand()

--- a/internal/app/wwctl/profile/set/main_test.go
+++ b/internal/app/wwctl/profile/set/main_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -24,7 +25,7 @@ func run_test(t *testing.T, test test_description) {
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
 	wwlog.SetLogLevel(wwlog.DEBUG)
-	env.WriteFile(t, "etc/warewulf/nodes.conf", test.inDB)
+	env.WriteFile(t, node.GetNodesConf("etc"), test.inDB)
 	warewulfd.SetNoDaemon()
 	name := test.name
 	if name == "" {
@@ -43,7 +44,7 @@ func run_test(t *testing.T, test test_description) {
 		} else {
 			assert.NoError(t, err)
 			assert.Equal(t, buf.String(), test.stdout)
-			content := env.ReadFile(t, "etc/warewulf/nodes.conf")
+			content := env.ReadFile(t, node.GetNodesConf("etc"))
 			assert.YAMLEq(t, test.outDb, content)
 		}
 	})

--- a/internal/app/wwctl/upgrade/nodes/cobra.go
+++ b/internal/app/wwctl/upgrade/nodes/cobra.go
@@ -3,10 +3,9 @@ package nodes
 import (
 	"fmt"
 	"os"
-	"path"
 
 	"github.com/spf13/cobra"
-	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	libupgrade "github.com/warewulf/warewulf/internal/pkg/upgrade"
 	"github.com/warewulf/warewulf/internal/pkg/util"
 )
@@ -28,11 +27,10 @@ supported by the current version.`,
 )
 
 func init() {
-	controller := warewulfconf.Get()
 	Command.Flags().BoolVar(&addDefaults, "add-defaults", false, "Configure a default profile and set default node values")
 	Command.Flags().BoolVar(&replaceOverlays, "replace-overlays", false, "Replace 'wwinit' and 'generic' overlays with their split replacements")
-	Command.Flags().StringVarP(&inputPath, "input-path", "i", path.Join(controller.Paths.Sysconfdir, "warewulf/nodes.conf"), "Path to a legacy nodes.conf")
-	Command.Flags().StringVarP(&outputPath, "output-path", "o", path.Join(controller.Paths.Sysconfdir, "warewulf/nodes.conf"), "Path to write the upgraded nodes.conf to")
+	Command.Flags().StringVarP(&inputPath, "input-path", "i", node.GetNodesConf(), "Path to a legacy nodes.conf")
+	Command.Flags().StringVarP(&outputPath, "output-path", "o", node.GetNodesConf(), "Path to write the upgraded nodes.conf to")
 	if err := Command.MarkFlagRequired("add-defaults"); err != nil {
 		panic(err)
 	}

--- a/internal/app/wwctl/upgrade/nodes/cobra.go
+++ b/internal/app/wwctl/upgrade/nodes/cobra.go
@@ -3,10 +3,10 @@ package nodes
 import (
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/spf13/cobra"
-
-	"github.com/warewulf/warewulf/internal/pkg/node"
+	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
 	libupgrade "github.com/warewulf/warewulf/internal/pkg/upgrade"
 	"github.com/warewulf/warewulf/internal/pkg/util"
 )
@@ -28,10 +28,11 @@ supported by the current version.`,
 )
 
 func init() {
+	controller := warewulfconf.Get()
 	Command.Flags().BoolVar(&addDefaults, "add-defaults", false, "Configure a default profile and set default node values")
 	Command.Flags().BoolVar(&replaceOverlays, "replace-overlays", false, "Replace 'wwinit' and 'generic' overlays with their split replacements")
-	Command.Flags().StringVarP(&inputPath, "input-path", "i", node.ConfigFile, "Path to a legacy nodes.conf")
-	Command.Flags().StringVarP(&outputPath, "output-path", "o", node.ConfigFile, "Path to write the upgraded nodes.conf to")
+	Command.Flags().StringVarP(&inputPath, "input-path", "i", path.Join(controller.Paths.Sysconfdir, "warewulf/nodes.conf"), "Path to a legacy nodes.conf")
+	Command.Flags().StringVarP(&outputPath, "output-path", "o", path.Join(controller.Paths.Sysconfdir, "warewulf/nodes.conf"), "Path to write the upgraded nodes.conf to")
 	if err := Command.MarkFlagRequired("add-defaults"); err != nil {
 		panic(err)
 	}

--- a/internal/pkg/api/util/util.go
+++ b/internal/pkg/api/util/util.go
@@ -1,12 +1,11 @@
 package util
 
 import (
-	"path"
 	"syscall"
 
 	"github.com/manifoldco/promptui"
 	"github.com/warewulf/warewulf/internal/pkg/api/routes/wwapiv1"
-	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
@@ -32,8 +31,7 @@ Simple check if the config can be written in case wwctl isn't run as root
 func CanWriteConfig() (canwrite *wwapiv1.CanWriteConfig, err error) {
 	canwrite = new(wwapiv1.CanWriteConfig)
 	// node is not initialized yet
-	controller := warewulfconf.Get()
-	err = syscall.Access(path.Join(controller.Paths.Sysconfdir, "warewulf/nodes.conf"), syscall.O_RDWR)
+	err = syscall.Access(node.GetNodesConf(), syscall.O_RDWR)
 	if err != nil {
 		wwlog.Warn("Couldn't open: %w", err)
 		canwrite.CanWriteConfig = false

--- a/internal/pkg/api/util/util.go
+++ b/internal/pkg/api/util/util.go
@@ -1,12 +1,12 @@
 package util
 
 import (
-	"fmt"
+	"path"
 	"syscall"
 
 	"github.com/manifoldco/promptui"
 	"github.com/warewulf/warewulf/internal/pkg/api/routes/wwapiv1"
-	"github.com/warewulf/warewulf/internal/pkg/node"
+	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
@@ -32,16 +32,10 @@ Simple check if the config can be written in case wwctl isn't run as root
 func CanWriteConfig() (canwrite *wwapiv1.CanWriteConfig, err error) {
 	canwrite = new(wwapiv1.CanWriteConfig)
 	// node is not initialized yet
-	if node.ConfigFile == "" {
-		_, err := node.New()
-		if err != nil {
-			canwrite.CanWriteConfig = false
-			return canwrite, fmt.Errorf("unable to initialize the node %w", err)
-		}
-	}
-	err = syscall.Access(node.ConfigFile, syscall.O_RDWR)
+	controller := warewulfconf.Get()
+	err = syscall.Access(path.Join(controller.Paths.Sysconfdir, "warewulf/nodes.conf"), syscall.O_RDWR)
 	if err != nil {
-		wwlog.Warn("Couldn't open %s:%s", node.ConfigFile, err)
+		wwlog.Warn("Couldn't open: %w", err)
 		canwrite.CanWriteConfig = false
 	} else {
 		canwrite.CanWriteConfig = true

--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -14,13 +14,29 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const NodesConfPath = "warewulf/nodes.conf"
+
+/*
+Get the actual path of nodes.conf, with the possibility to prefix
+*/
+func GetNodesConf(prefix ...string) string {
+	var myPath []string
+	if len(prefix) == 0 {
+		controller := warewulfconf.Get()
+		myPath = append(myPath, controller.Paths.Sysconfdir)
+	} else {
+		myPath = append(myPath, prefix...)
+	}
+	myPath = append(myPath, NodesConfPath)
+	return path.Join(myPath...)
+}
+
 /*
 Creates a new nodeDb object from the on-disk configuration
 */
 func New() (NodesYaml, error) {
-	controller := warewulfconf.Get()
-	wwlog.Verbose("Opening node configuration file: %s", path.Join(controller.Paths.Sysconfdir, "warewulf/nodes.conf"))
-	data, err := os.ReadFile(path.Join(controller.Paths.Sysconfdir, "warewulf/nodes.conf"))
+	wwlog.Verbose("Opening node configuration file: %s", GetNodesConf())
+	data, err := os.ReadFile(GetNodesConf())
 	if err != nil {
 		return NodesYaml{}, err
 	}

--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -14,23 +14,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var (
-	ConfigFile string
-)
-
-func init() {
-	conf := warewulfconf.Get()
-	if ConfigFile == "" {
-		ConfigFile = path.Join(conf.Paths.Sysconfdir, "warewulf/nodes.conf")
-	}
-}
-
 /*
 Creates a new nodeDb object from the on-disk configuration
 */
 func New() (NodesYaml, error) {
-	wwlog.Verbose("Opening node configuration file: %s", ConfigFile)
-	data, err := os.ReadFile(ConfigFile)
+	controller := warewulfconf.Get()
+	wwlog.Verbose("Opening node configuration file: %s", path.Join(controller.Paths.Sysconfdir, "warewulf/nodes.conf"))
+	data, err := os.ReadFile(path.Join(controller.Paths.Sysconfdir, "warewulf/nodes.conf"))
 	if err != nil {
 		return NodesYaml{}, err
 	}

--- a/internal/pkg/node/modifiers.go
+++ b/internal/pkg/node/modifiers.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"encoding/gob"
 	"os"
-	"path"
 
 	"github.com/pkg/errors"
-	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 	"gopkg.in/yaml.v3"
 )
@@ -110,8 +108,7 @@ func (config *NodesYaml) DelProfile(nodeID string) error {
 Write the the NodeYaml to disk.
 */
 func (config *NodesYaml) Persist() error {
-	controller := warewulfconf.Get()
-	return config.PersistToFile(path.Join(controller.Paths.Sysconfdir, "warewulf/nodes.conf"))
+	return config.PersistToFile(GetNodesConf())
 }
 
 func (config *NodesYaml) PersistToFile(configFile string) error {

--- a/internal/pkg/node/modifiers.go
+++ b/internal/pkg/node/modifiers.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/gob"
 	"os"
+	"path"
 
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v3"
-
+	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
+	"gopkg.in/yaml.v3"
 )
 
 /*
@@ -109,12 +110,13 @@ func (config *NodesYaml) DelProfile(nodeID string) error {
 Write the the NodeYaml to disk.
 */
 func (config *NodesYaml) Persist() error {
-	return config.PersistToFile(ConfigFile)
+	controller := warewulfconf.Get()
+	return config.PersistToFile(path.Join(controller.Paths.Sysconfdir, "warewulf/nodes.conf"))
 }
 
 func (config *NodesYaml) PersistToFile(configFile string) error {
 	if configFile == "" {
-		configFile = ConfigFile
+		return errors.New("PersistToFile: configuration can't be empty")
 	}
 	out, dumpErr := config.Dump()
 	if dumpErr != nil {

--- a/internal/pkg/testenv/testenv.go
+++ b/internal/pkg/testenv/testenv.go
@@ -94,9 +94,6 @@ func New(t *testing.T) (env *TestEnv) {
 		env.MkdirAll(t, confPath)
 	}
 
-	// node.init() has already run, so set the config path again
-	// node.ConfigFile = env.GetPath(path.Join(Sysconfdir, "warewulf/nodes.conf"))
-
 	return
 }
 

--- a/internal/pkg/testenv/testenv.go
+++ b/internal/pkg/testenv/testenv.go
@@ -15,7 +15,6 @@ import (
 	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/warewulf/warewulf/internal/pkg/node"
 )
 
 const initWarewulfConf = ``
@@ -96,7 +95,7 @@ func New(t *testing.T) (env *TestEnv) {
 	}
 
 	// node.init() has already run, so set the config path again
-	node.ConfigFile = env.GetPath(path.Join(Sysconfdir, "warewulf/nodes.conf"))
+	// node.ConfigFile = env.GetPath(path.Join(Sysconfdir, "warewulf/nodes.conf"))
 
 	return
 }

--- a/internal/pkg/testenv/testenv.go
+++ b/internal/pkg/testenv/testenv.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
-	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
-
 	"github.com/stretchr/testify/assert"
+	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 )
 
 const initWarewulfConf = ``
@@ -56,7 +56,7 @@ func New(t *testing.T) (env *TestEnv) {
 	assert.NoError(t, err)
 	env.BaseDir = tmpDir
 
-	env.WriteFile(t, path.Join(Sysconfdir, "warewulf/nodes.conf"), initNodesConf)
+	env.WriteFile(t, node.GetNodesConf(Sysconfdir), initNodesConf)
 	env.WriteFile(t, path.Join(Sysconfdir, "warewulf/warewulf.conf"), initWarewulfConf)
 
 	// re-read warewulf.conf

--- a/internal/pkg/testenv/testenv_test.go
+++ b/internal/pkg/testenv/testenv_test.go
@@ -19,7 +19,7 @@ func Test_Basic(t *testing.T) {
 
 func Test_two_nodes(t *testing.T) {
 	env := New(t)
-	env.WriteFile(t, "etc/warewulf/nodes.conf", `nodeprofiles:
+	env.WriteFile(t, node.GetNodesConf("etc"), `nodeprofiles:
   default: {}
 nodes:
   node1: {}

--- a/internal/pkg/warewulfd/provision_test.go
+++ b/internal/pkg/warewulfd/provision_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 )
 
@@ -35,7 +36,7 @@ var provisionSendTests = []struct {
 func Test_ProvisionSend(t *testing.T) {
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.WriteFile(t, "etc/warewulf/nodes.conf", `nodeprofiles:
+	env.WriteFile(t, node.GetNodesConf("etc"), `nodeprofiles:
   default:
     container name: suse
 nodes:

--- a/internal/pkg/warewulfd/util.go
+++ b/internal/pkg/warewulfd/util.go
@@ -4,10 +4,8 @@ import (
 	"bufio"
 	"net/http"
 	"os"
-	"path"
 	"strings"
 
-	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/overlay"
 	"github.com/warewulf/warewulf/internal/pkg/util"
@@ -52,8 +50,7 @@ func getOverlayFile(n node.Node, context string, stage_overlays []string, autobu
 	build := !util.IsFile(stage_file)
 	wwlog.Verbose("stage file: %s", stage_file)
 	if !build && autobuild {
-		controller := warewulfconf.Get()
-		build = util.PathIsNewer(stage_file, path.Join(controller.Paths.Sysconfdir, "warewulf/nodes.conf"))
+		build = util.PathIsNewer(stage_file, node.GetNodesConf())
 
 		for _, overlayname := range stage_overlays {
 			build = build || util.PathIsNewer(stage_file, overlay.OverlaySourceDir(overlayname))

--- a/internal/pkg/warewulfd/util.go
+++ b/internal/pkg/warewulfd/util.go
@@ -4,10 +4,11 @@ import (
 	"bufio"
 	"net/http"
 	"os"
+	"path"
 	"strings"
 
+	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/node"
-	nodepkg "github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/overlay"
 	"github.com/warewulf/warewulf/internal/pkg/util"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -51,7 +52,8 @@ func getOverlayFile(n node.Node, context string, stage_overlays []string, autobu
 	build := !util.IsFile(stage_file)
 	wwlog.Verbose("stage file: %s", stage_file)
 	if !build && autobuild {
-		build = util.PathIsNewer(stage_file, nodepkg.ConfigFile)
+		controller := warewulfconf.Get()
+		build = util.PathIsNewer(stage_file, path.Join(controller.Paths.Sysconfdir, "warewulf/nodes.conf"))
 
 		for _, overlayname := range stage_overlays {
 			build = build || util.PathIsNewer(stage_file, overlay.OverlaySourceDir(overlayname))

--- a/internal/pkg/warewulfd/util_test.go
+++ b/internal/pkg/warewulfd/util_test.go
@@ -78,7 +78,7 @@ var getOverlayFileTests = []struct {
 
 func Test_getOverlayFile(t *testing.T) {
 	env := testenv.New(t)
-	env.WriteFile(t, "etc/warewulf/nodes.conf", `
+	env.WriteFile(t, node.GetNodesConf("etc"), `
 nodes:
   node1: {} `)
 	conf := warewulfconf.Get()

--- a/overlays/NetworkManager/internal/networkmanager_test.go
+++ b/overlays/NetworkManager/internal/networkmanager_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -50,7 +51,7 @@ func Test_networkmanagerOverlay(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env.ImportFile(t, "etc/warewulf/nodes.conf", tt.nodes_conf)
+			env.ImportFile(t, node.GetNodesConf("etc"), tt.nodes_conf)
 			cmd := show.GetCommand()
 			cmd.SetArgs(tt.args)
 			stdout := bytes.NewBufferString("")

--- a/overlays/debian.interfaces/internal/debian_interfaces_test.go
+++ b/overlays/debian.interfaces/internal/debian_interfaces_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -31,7 +32,7 @@ func Test_wickedOverlay(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env.ImportFile(t, "etc/warewulf/nodes.conf", tt.nodes_conf)
+			env.ImportFile(t, node.GetNodesConf("etc"), tt.nodes_conf)
 			cmd := show.GetCommand()
 			cmd.SetArgs(tt.args)
 			stdout := bytes.NewBufferString("")

--- a/overlays/debug/internal/debug_test.go
+++ b/overlays/debug/internal/debug_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -19,7 +20,7 @@ func Test_debugOverlay(t *testing.T) {
 
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "var/lib/warewulf/overlays/debug/rootfs/warewulf/template-variables.md.ww", "../rootfs/warewulf/template-variables.md.ww")
 
 	tests := []struct {

--- a/overlays/fstab/internal/fstab_test.go
+++ b/overlays/fstab/internal/fstab_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
 	"github.com/warewulf/warewulf/internal/pkg/config"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -14,7 +15,7 @@ import (
 func Test_fstabOverlay(t *testing.T) {
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "etc/warewulf/warewulf.conf", "warewulf.conf")
 	assert.NoError(t, config.Get().Read(env.GetPath("etc/warewulf/warewulf.conf")))
 	env.ImportFile(t, "var/lib/warewulf/overlays/fstab/rootfs/etc/fstab.ww", "../rootfs/etc/fstab.ww")

--- a/overlays/host/internal/host_test.go
+++ b/overlays/host/internal/host_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
 	"github.com/warewulf/warewulf/internal/pkg/config"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -17,7 +18,7 @@ func Test_hostOverlay(t *testing.T) {
 	hostname, _ := os.Hostname()
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "var/lib/warewulf/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww", "../rootfs/etc/dhcp/dhcpd.conf.ww")
 	env.ImportFile(t, "var/lib/warewulf/overlays/host/rootfs/etc/dnsmasq.d/ww4-hosts.conf.ww", "../rootfs/etc/dnsmasq.d/ww4-hosts.conf.ww")
 	env.ImportFile(t, "var/lib/warewulf/overlays/host/rootfs/etc/exports.ww", "../rootfs/etc/exports.ww")

--- a/overlays/hostname/internal/hostname_test.go
+++ b/overlays/hostname/internal/hostname_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -13,7 +14,7 @@ import (
 func Test_hostnameOverlay(t *testing.T) {
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "var/lib/warewulf/overlays/hostname/rootfs/etc/hostname.ww", "../rootfs/etc/hostname.ww")
 
 	tests := []struct {

--- a/overlays/hosts/internal/hosts_test.go
+++ b/overlays/hosts/internal/hosts_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
 	"github.com/warewulf/warewulf/internal/pkg/config"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -20,7 +21,7 @@ func Test_hostsOverlay(t *testing.T) {
 	defer env.RemoveAll(t)
 	env.ImportFile(t, "etc/warewulf/warewulf.conf", "warewulf.conf")
 	assert.NoError(t, config.Get().Read(env.GetPath("etc/warewulf/warewulf.conf")))
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "var/lib/warewulf/overlays/hosts/rootfs/etc/hosts.ww", "../rootfs/etc/hosts.ww")
 
 	tests := []struct {

--- a/overlays/ifcfg/internal/ifcfg_test.go
+++ b/overlays/ifcfg/internal/ifcfg_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -51,7 +52,7 @@ func Test_ifcfgOverlay(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env.ImportFile(t, "etc/warewulf/nodes.conf", tt.nodes_conf)
+			env.ImportFile(t, node.GetNodesConf("etc"), tt.nodes_conf)
 			cmd := show.GetCommand()
 			cmd.SetArgs(tt.args)
 			stdout := bytes.NewBufferString("")

--- a/overlays/ignition/internal/ignition_test.go
+++ b/overlays/ignition/internal/ignition_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -13,7 +14,7 @@ import (
 func Test_ignitionOverlay(t *testing.T) {
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "var/lib/warewulf/overlays/ignition/rootfs/etc/systemd/system/ww4-disks.target.ww", "../rootfs/etc/systemd/system/ww4-disks.target.ww")
 	env.ImportFile(t, "var/lib/warewulf/overlays/ignition/rootfs/etc/systemd/system/ww4-mounts.ww", "../rootfs/etc/systemd/system/ww4-mounts.ww")
 	env.ImportFile(t, "var/lib/warewulf/overlays/ignition/rootfs/warewulf/ignition.json.ww", "../rootfs/warewulf/ignition.json.ww")

--- a/overlays/issue/internal/issue_test.go
+++ b/overlays/issue/internal/issue_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -13,7 +14,7 @@ import (
 func Test_issueOverlay(t *testing.T) {
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "var/lib/warewulf/overlays/issue/rootfs/etc/issue.ww", "../rootfs/etc/issue.ww")
 
 	tests := []struct {

--- a/overlays/netplan/internal/netplan_test.go
+++ b/overlays/netplan/internal/netplan_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -13,7 +14,7 @@ import (
 func Test_netplanOverlay(t *testing.T) {
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "var/lib/warewulf/overlays/netplan/rootfs/etc/netplan/01-netcfg.yaml.ww", "../rootfs/etc/netplan/01-netcfg.yaml.ww")
 
 	tests := []struct {

--- a/overlays/resolv/internal/resolv_test.go
+++ b/overlays/resolv/internal/resolv_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -13,7 +14,7 @@ import (
 func Test_resolvOverlay(t *testing.T) {
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "var/lib/warewulf/overlays/resolv/rootfs/etc/resolv.conf.ww", "../rootfs/etc/resolv.conf.ww")
 
 	tests := []struct {

--- a/overlays/ssh.authorized_keys/internal/ssh_authorized_keys_test.go
+++ b/overlays/ssh.authorized_keys/internal/ssh_authorized_keys_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -15,7 +16,7 @@ func Test_ssh_authorized_keysOverlay(t *testing.T) {
 
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "var/lib/warewulf/overlays/ssh.authorized_keys/rootfs/root/.ssh/authorized_keys.ww", "../rootfs/root/.ssh/authorized_keys.ww")
 
 	tests := []struct {

--- a/overlays/ssh.host_keys/internal/ssh_host_keys_test.go
+++ b/overlays/ssh.host_keys/internal/ssh_host_keys_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -13,7 +14,7 @@ import (
 func Test_ssh_host_keysOverlay(t *testing.T) {
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "var/lib/warewulf/overlays/ssh.host_keys/rootfs/etc/ssh/ssh_host_dsa_key.pub.ww", "../rootfs/etc/ssh/ssh_host_dsa_key.pub.ww")
 	env.ImportFile(t, "var/lib/warewulf/overlays/ssh.host_keys/rootfs/etc/ssh/ssh_host_dsa_key.ww", "../rootfs/etc/ssh/ssh_host_dsa_key.ww")
 	env.ImportFile(t, "var/lib/warewulf/overlays/ssh.host_keys/rootfs/etc/ssh/ssh_host_ecdsa_key.pub.ww", "../rootfs/etc/ssh/ssh_host_ecdsa_key.pub.ww")

--- a/overlays/syncuser/internal/syncuser_test.go
+++ b/overlays/syncuser/internal/syncuser_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -15,7 +16,7 @@ func Test_syncuserOverlay(t *testing.T) {
 
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "var/lib/warewulf/overlays/syncuser/rootfs/etc/passwd.ww", "../../../../../overlays/syncuser/rootfs/etc/passwd.ww")
 	env.ImportFile(t, "var/lib/warewulf/overlays/syncuser/rootfs/etc/group.ww", "../../../../../overlays/syncuser/rootfs/etc/group.ww")
 	env.WriteFile(t, "var/lib/warewulf/chroots/rockylinux-9/rootfs/etc/passwd", `root:x:0:0:root:/root:/bin/bash`)

--- a/overlays/systemd.netname/internal/systemd_netname_test.go
+++ b/overlays/systemd.netname/internal/systemd_netname_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -13,7 +14,7 @@ import (
 func Test_udev_netnameOverlay(t *testing.T) {
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "var/lib/warewulf/overlays/systemd.netname/rootfs/etc/systemd/network/10-ww4-netname.link.ww", "../rootfs/etc/systemd/network/10-ww4-netname.link.ww")
 
 	tests := []struct {

--- a/overlays/udev.netname/internal/udev_netname_test.go
+++ b/overlays/udev.netname/internal/udev_netname_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -13,7 +14,7 @@ import (
 func Test_udev_netnameOverlay(t *testing.T) {
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "var/lib/warewulf/overlays/udev.netname/rootfs/etc/udev/rules.d/70-persistent-net.rules.ww", "../rootfs/etc/udev/rules.d/70-persistent-net.rules.ww")
 
 	tests := []struct {

--- a/overlays/wicked/internal/wicked_test.go
+++ b/overlays/wicked/internal/wicked_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -37,7 +38,7 @@ func Test_wickedOverlay(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env.ImportFile(t, "etc/warewulf/nodes.conf", tt.nodes_conf)
+			env.ImportFile(t, node.GetNodesConf("etc"), tt.nodes_conf)
 			cmd := show.GetCommand()
 			cmd.SetArgs(tt.args)
 			stdout := bytes.NewBufferString("")

--- a/overlays/wwclient/internal/wwclient_test.go
+++ b/overlays/wwclient/internal/wwclient_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -13,7 +14,7 @@ import (
 func Test_wwclientOverlay(t *testing.T) {
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "var/lib/warewulf/overlays/wwclient/rootfs/warewulf/init.d/80-wwclient.ww", "../rootfs/warewulf/init.d/80-wwclient.ww")
 
 	tests := []struct {

--- a/overlays/wwinit/internal/wwinit_test.go
+++ b/overlays/wwinit/internal/wwinit_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/app/wwctl/overlay/show"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -14,7 +15,7 @@ func Test_wwinitOverlay(t *testing.T) {
 	env := testenv.New(t)
 	defer env.RemoveAll(t)
 	env.ImportFile(t, "etc/warewulf/warewulf.conf", "warewulf.conf")
-	env.ImportFile(t, "etc/warewulf/nodes.conf", "nodes.conf")
+	env.ImportFile(t, node.GetNodesConf("etc"), "nodes.conf")
 	env.ImportFile(t, "var/lib/warewulf/overlays/wwinit/rootfs/etc/warewulf/warewulf.conf.ww", "../rootfs/etc/warewulf/warewulf.conf.ww")
 	env.ImportFile(t, "var/lib/warewulf/overlays/wwinit/rootfs/warewulf/config.ww", "../rootfs/warewulf/config.ww")
 


### PR DESCRIPTION
The location for `nodes.conf` can be given a command line parameter, 
but this can fail as some functions (node.Persit()) call node.ConfigFile
which is set by init() what was called *before* the command line parameter 
is read. 
So remove node.ConfigFile completely
