### PR TITLE
Remove toolchain directive from go.mod

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.23'] # ['1.21', '1.22', '1.23'] # https://github.com/warewulf/warewulf/issues/1571
+        go-version: ['1.21', '1.22', '1.23']
     steps:
       - name: Checkout Warewulf
         uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/warewulf/warewulf
 
 go 1.21.0
 
-toolchain go1.23.3
-
 require (
 	dario.cat/mergo v1.0.0
 	github.com/Masterminds/sprig/v3 v3.2.3


### PR DESCRIPTION
## Description of the Pull Request (PR):

The toolchain directive specified a newer version of the go toolchain from the go runtime used, and newer than our minimum supported.


## This fixes or addresses the following GitHub issues:

- Fixes #1571


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
