### PR TITLE
Support importing containers from directories containing a socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Locally defined `tr` has been dropped, templates updated to use Sprig replace.
 - Bump github.com/opencontainers/image-spec to 1.1.0
-- Bump github.com/containers/storage to 1.53.0
 - Bump google.golang.org/grpc 1.62.1
 - Bump google.golang.org/protobuf to 1.33.0
 - Bump github.com/containers/image/v5 to 5.30.0
@@ -43,7 +42,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Bump github.com/fatih/color from 1.15.0 to 1.17.0 #1224
 - Bump github.com/coreos/ignition/v2 from 2.15.0 to 2.19.0 #1239
 - Bump github.com/sassoftware/go-rpmutils from 0.2.0 to 0.4.0 #1217
-- Bump github.com/containers/storage from 1.53.0 to 1.55.0 #1316
 - Bump github.com/spf13/cobra from 1.8.0 to 1.8.1 #1481
 - Bump google.golang.org/protobuf from 1.34.1 to 1.35.1 #1480
 - Bump golang.org/x/term from 0.20.0 to 0.25.0 #1476
@@ -77,6 +75,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Repurpose Kernel.Override to specify the path to the desired kernel within the container. #1556
 - Merge Kernel.Override into Kernel.Version to specify the desired kernel version or path. #1556
 - Provide detected kernel version to overlay templates. #1556
+- Bump github.com/containers/storage from 1.53.0 to 1.55.2 #1316, #892
 
 ### Removed
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/containers/image/v5 v5.32.2
-	github.com/containers/storage v1.55.0
+	github.com/containers/storage v1.55.2
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 	github.com/coreos/ignition/v2 v2.19.0
 	github.com/coreos/vcontext v0.0.0-20230201181013-d72178a18687

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01 h1:Qzk5C6cYgle
 github.com/containers/libtrust v0.0.0-20230121012942-c1716e8a8d01/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.2.0 h1:X14EgRK3xNFvJEfI5O4Qn4T3E25ANudSOZz/sirVuPM=
 github.com/containers/ocicrypt v1.2.0/go.mod h1:ZNviigQajtdlxIZGibvblVuIFBKIuUI2M0QM12SD31U=
-github.com/containers/storage v1.55.0 h1:wTWZ3YpcQf1F+dSP4KxG9iqDfpQY1otaUXjPpffuhgg=
-github.com/containers/storage v1.55.0/go.mod h1:28cB81IDk+y7ok60Of6u52RbCeBRucbFOeLunhER1RQ=
+github.com/containers/storage v1.55.2 h1:TT1A9LzqAAFKKdlYdKh8NPYCx9jJVIKDqbI0S83sFTc=
+github.com/containers/storage v1.55.2/go.mod h1:28cB81IDk+y7ok60Of6u52RbCeBRucbFOeLunhER1RQ=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=

--- a/internal/pkg/container/imprt_test.go
+++ b/internal/pkg/container/imprt_test.go
@@ -1,0 +1,55 @@
+package container
+
+import (
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/warewulf/warewulf/internal/pkg/testenv"
+	"github.com/warewulf/warewulf/internal/pkg/util"
+)
+
+func Test_ImportContainerDir(t *testing.T) {
+	var tests = map[string]struct {
+		files   []string
+		sockets []string
+	}{
+		"empty container": {
+			files:   nil,
+			sockets: nil,
+		},
+		"sockets": {
+			files: nil,
+			sockets: []string{
+				"/tmp/testsocket",
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			env := testenv.New(t)
+			defer env.RemoveAll(t)
+			src := "/tmp/testcontainer"
+			env.CreateFile(t, filepath.Join(src, "/bin/sh"))
+			for _, file := range tt.files {
+				env.CreateFile(t, filepath.Join(src, file))
+			}
+			for _, socket := range tt.sockets {
+				env.MkdirAll(t, filepath.Dir(filepath.Join(src, socket)))
+				assert.NoError(t, unix.Mknod(env.GetPath(filepath.Join(src, socket)), unix.S_IFSOCK|0777, 0))
+			}
+			assert.NoError(t, ImportDirectory(env.GetPath(src), "testcontainer"))
+			rootfs := "/var/lib/warewulf/chroots/testcontainer/rootfs"
+			for _, file := range tt.files {
+				assert.True(t, util.IsFile(env.GetPath(filepath.Join(rootfs, file))))
+			}
+			for _, socket := range tt.sockets {
+				assert.True(t, util.IsFile(env.GetPath(filepath.Join(rootfs, socket))))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Prevents a panic when importing a container from a directory containing a socket by updating containers/storage to v2.55.2, which includes https://github.com/containers/storage/pull/2117.


## This fixes or addresses the following GitHub issues:

- Fixes #892


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
