### PR TITLE
Package the netplan overlay

### DIFF
--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -202,6 +202,7 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/ifcfg/rootfs/*
 %attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/ignition/rootfs/*
 %attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/issue/rootfs/*
+%attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/netplan/rootfs/*
 %attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/resolv/rootfs/*
 %attr(700, root, root) %{_sharedstatedir}/warewulf/overlays/ssh.authorized_keys/rootfs/*
 %attr(-, root, root) %{_sharedstatedir}/warewulf/overlays/ssh.host_keys/rootfs/*


### PR DESCRIPTION
## Description of the Pull Request (PR):

Update `warewulf.spec.in` to package the new netplan overlay from #1463.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
