### PR TITLE
Added firewalld and nftables setup to configuration.rst

### DIFF
--- a/userdocs/contents/configuration.rst
+++ b/userdocs/contents/configuration.rst
@@ -10,7 +10,7 @@ warewulf.conf
 =============
 
 The Warewulf configuration exists as follows in the current version of
-Warewulf (4.5.2):
+Warewulf (4.5.8):
 
 .. code-block:: yaml
 
@@ -227,3 +227,44 @@ Directories
 The ``/etc/warewulf/ipxe/`` directory contains *text/templates* that
 are used by the Warewulf configuration process to configure the
 ``ipxe`` service.
+
+FirewallD
+=========
+
+When using ``firewalld`` with Warewulf, the following services are required to be added for successful node interconnectivity:
+
+.. code-block:: console
+
+   firewall-cmd --permanent --add-service=warewulf
+   firewall-cmd --permanent --add-service=dhcp
+   firewall-cmd --permanent --add-service=nfs
+   firewall-cmd --permanent --add-service=tftp
+
+Make sure the ``--reload`` command is ran afterwards:
+
+.. code-block:: console
+
+   firewall-cmd --reload
+
+nftables
+========
+
+When deploying ``nftables`` with Warewulf, ensure that TCP port ``9873`` for HTTP requests is available, else you will not be able to add new nodes to the cluster.
+
+This can be done with the ``nft add rule`` command:
+
+.. code-block:: console
+
+   nft add rule inet filter input tcp dport 9873 accept
+
+Save the changes to your ``nftables.conf`` file:
+
+.. code-block:: console
+
+   nft list ruleset > /etc/nftables.conf
+
+Restart the ``nftables`` service:
+
+.. code-block:: console
+
+   systemctl restart nftables


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds `firewalld` and `nftables` setup information to the `configuration.rst` file. A user recently ran into trouble with their `nftables` configuration with adding a new node and this was solved by ensuring they enabled TCP port `9873` in their `nftables` config file on the Controller Node.

## This fixes or addresses the following GitHub issues:

- Fixes # 
- N/A


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [X] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [X] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [X] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [X] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [X] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [X] The test suite has been updated, if necessary
