### PR TITLE
Configure nodes.conf dynamically from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Merge Kernel.Override into Kernel.Version to specify the desired kernel version or path. #1556
 - Provide detected kernel version to overlay templates. #1556
 - Bump github.com/containers/storage from 1.53.0 to 1.55.2 #1316, #892
+- Process nodes.conf path dynamically from config. #1595, #1596, #1569
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,6 @@ wwctl: $(config) $(call godeps,cmd/wwctl/main.go)
 wwclient: $(config) $(call godeps,cmd/wwclient/main.go)
 	CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -ldflags "-extldflags -static" -o wwclient cmd/wwclient/main.go
 
-update_configuration: $(config) $(call godeps,cmd/update_configuration/update_configuration.go)
-	go build -X 'github.com/warewulf/warewulf/internal/pkg/node.ConfigFile=./etc/nodes.conf'" \
-	    -mod vendor -tags "$(WW_GO_BUILD_TAGS)" -o update_configuration cmd/update_configuration/update_configuration.go
-
 wwapid: $(config) $(apiconfig) $(call godeps,internal/app/api/wwapid/wwapid.go)
 	go build -o ./wwapid internal/app/api/wwapid/wwapid.go
 

--- a/internal/app/wwctl/configure/dhcp/root.go
+++ b/internal/app/wwctl/configure/dhcp/root.go
@@ -15,9 +15,6 @@ var (
 	}
 )
 
-func init() {
-}
-
 // GetRootCommand returns the root cobra.Command for the application.
 func GetCommand() *cobra.Command {
 	return baseCmd

--- a/internal/app/wwctl/configure/hostfile/root.go
+++ b/internal/app/wwctl/configure/hostfile/root.go
@@ -12,9 +12,6 @@ var (
 	}
 )
 
-func init() {
-}
-
 // GetRootCommand returns the root cobra.Command for the application.
 func GetCommand() *cobra.Command {
 	return baseCmd

--- a/internal/app/wwctl/configure/nfs/root.go
+++ b/internal/app/wwctl/configure/nfs/root.go
@@ -13,9 +13,6 @@ var (
 	}
 )
 
-func init() {
-}
-
 // GetRootCommand returns the root cobra.Command for the application.
 func GetCommand() *cobra.Command {
 	return baseCmd

--- a/internal/app/wwctl/configure/ssh/root.go
+++ b/internal/app/wwctl/configure/ssh/root.go
@@ -17,9 +17,6 @@ var (
 	keyTypes []string
 )
 
-func init() {
-}
-
 // GetRootCommand returns the root cobra.Command for the application.
 func GetCommand() *cobra.Command {
 	baseCmd.PersistentFlags().StringArrayVarP(&keyTypes, "keytypes", "t", []string{}, "ssh key types to be created")

--- a/internal/app/wwctl/container/copy/root.go
+++ b/internal/app/wwctl/container/copy/root.go
@@ -26,7 +26,6 @@ var (
 )
 
 func init() {
-	// Nothing to do here
 	baseCmd.PersistentFlags().BoolVarP(&Build, "build", "b", false, "Build container after copy")
 }
 

--- a/internal/app/wwctl/container/rename/root.go
+++ b/internal/app/wwctl/container/rename/root.go
@@ -25,7 +25,6 @@ var baseCmd = &cobra.Command{
 var SetBuild bool
 
 func init() {
-	// Nothing to do here
 	baseCmd.PersistentFlags().BoolVarP(&SetBuild, "build", "b", false, "Build container after rename")
 }
 

--- a/internal/app/wwctl/genconf/completions/root.go
+++ b/internal/app/wwctl/genconf/completions/root.go
@@ -14,9 +14,6 @@ var (
 	Zsh bool
 )
 
-func init() {
-}
-
 func GetCommand() *cobra.Command {
 	return baseCmd
 }

--- a/internal/app/wwctl/genconf/man/root.go
+++ b/internal/app/wwctl/genconf/man/root.go
@@ -15,9 +15,6 @@ var (
 	}
 )
 
-func init() {
-}
-
 func GetCommand() *cobra.Command {
 	return baseCmd
 }

--- a/internal/app/wwctl/genconf/reference/root.go
+++ b/internal/app/wwctl/genconf/reference/root.go
@@ -14,9 +14,6 @@ var (
 	}
 )
 
-func init() {
-}
-
 func GetCommand() *cobra.Command {
 	return baseCmd
 }

--- a/internal/app/wwctl/genconf/warewulfconf/print/root.go
+++ b/internal/app/wwctl/genconf/warewulfconf/print/root.go
@@ -14,9 +14,6 @@ var (
 	}
 )
 
-func init() {
-}
-
 func GetCommand() *cobra.Command {
 	return baseCmd
 }

--- a/internal/app/wwctl/node/export/root.go
+++ b/internal/app/wwctl/node/export/root.go
@@ -29,9 +29,6 @@ var (
 	NoHeader bool
 )
 
-func init() {
-}
-
 // GetRootCommand returns the root cobra.Command for the application.
 func GetCommand() *cobra.Command {
 	return baseCmd

--- a/internal/app/wwctl/node/set/main_test.go
+++ b/internal/app/wwctl/node/set/main_test.go
@@ -2,12 +2,9 @@ package set
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
-	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -646,19 +643,6 @@ nodes:
 		},
 	}
 
-	conf_yml := ``
-	tempWarewulfConf, warewulfConfErr := os.CreateTemp("", "warewulf.conf-")
-	assert.NoError(t, warewulfConfErr)
-	defer os.Remove(tempWarewulfConf.Name())
-	_, warewulfConfErr = tempWarewulfConf.Write([]byte(conf_yml))
-	assert.NoError(t, warewulfConfErr)
-	assert.NoError(t, tempWarewulfConf.Sync())
-	assert.NoError(t, warewulfconf.New().Read(tempWarewulfConf.Name()))
-
-	tempNodeConf, nodesConfErr := os.CreateTemp("", "nodes.conf-")
-	assert.NoError(t, nodesConfErr)
-	defer os.Remove(tempNodeConf.Name())
-	node.ConfigFile = tempNodeConf.Name()
 	warewulfd.SetNoDaemon()
 	for _, tt := range tests {
 		run_test(t, tt)

--- a/internal/app/wwctl/overlay/chmod/root.go
+++ b/internal/app/wwctl/overlay/chmod/root.go
@@ -29,9 +29,6 @@ var (
 	}
 )
 
-func init() {
-}
-
 // GetRootCommand returns the root cobra.Command for the application.
 func GetCommand() *cobra.Command {
 	return baseCmd

--- a/internal/app/wwctl/overlay/chown/root.go
+++ b/internal/app/wwctl/overlay/chown/root.go
@@ -28,9 +28,6 @@ var (
 	}
 )
 
-func init() {
-}
-
 // GetRootCommand returns the root cobra.Command for the application.
 func GetCommand() *cobra.Command {
 	return baseCmd

--- a/internal/app/wwctl/overlay/create/root.go
+++ b/internal/app/wwctl/overlay/create/root.go
@@ -16,9 +16,6 @@ var (
 	}
 )
 
-func init() {
-}
-
 // GetRootCommand returns the root cobra.Command for the application.
 func GetCommand() *cobra.Command {
 	return baseCmd

--- a/internal/app/wwctl/power/root.go
+++ b/internal/app/wwctl/power/root.go
@@ -20,8 +20,6 @@ var (
 )
 
 func init() {
-	//	baseCmd.PersistentFlags().BoolVarP(&test, "test", "t", false, "Testing.")
-
 	baseCmd.AddCommand(powercycle.GetCommand())
 	baseCmd.AddCommand(poweroff.GetCommand())
 	baseCmd.AddCommand(poweron.GetCommand())

--- a/internal/app/wwctl/profile/list/main_test.go
+++ b/internal/app/wwctl/profile/list/main_test.go
@@ -8,8 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
-	"github.com/warewulf/warewulf/internal/pkg/node"
+	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -96,31 +95,13 @@ nodes:
 		},
 	}
 
-	conf_yml := ``
-	tempWarewulfConf, warewulfConfErr := os.CreateTemp("", "warewulf.conf-")
-	assert.NoError(t, warewulfConfErr)
-	defer os.Remove(tempWarewulfConf.Name())
-	_, warewulfConfErr = tempWarewulfConf.Write([]byte(conf_yml))
-	assert.NoError(t, warewulfConfErr)
-	assert.NoError(t, tempWarewulfConf.Sync())
-	assert.NoError(t, warewulfconf.New().Read(tempWarewulfConf.Name()))
-
-	tempNodeConf, nodesConfErr := os.CreateTemp("", "nodes.conf-")
-	assert.NoError(t, nodesConfErr)
-	defer os.Remove(tempNodeConf.Name())
-	node.ConfigFile = tempNodeConf.Name()
 	warewulfd.SetNoDaemon()
-	for _, tt := range tests {
-		var err error
-		_, err = tempNodeConf.Seek(0, 0)
-		assert.NoError(t, err)
-		assert.NoError(t, tempNodeConf.Truncate(0))
-		_, err = tempNodeConf.Write([]byte(tt.inDb))
-		assert.NoError(t, err)
-		assert.NoError(t, tempNodeConf.Sync())
-		assert.NoError(t, err)
+	env := testenv.New(t)
+	defer env.RemoveAll(t)
 
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			env.WriteFile(t, "etc/warewulf/nodes.conf", tt.inDb)
 			baseCmd := GetCommand()
 			baseCmd.SetArgs(tt.args)
 			stdoutR, stdoutW, _ := os.Pipe()
@@ -270,28 +251,12 @@ nodes:
 		},
 	}
 
-	conf_yml := ``
-	tempWarewulfConf, warewulfConfErr := os.CreateTemp("", "warewulf.conf-")
-	assert.NoError(t, warewulfConfErr)
-	defer os.Remove(tempWarewulfConf.Name())
-	_, warewulfConfErr = tempWarewulfConf.Write([]byte(conf_yml))
-	assert.NoError(t, warewulfConfErr)
-	assert.NoError(t, tempWarewulfConf.Sync())
-	assert.NoError(t, warewulfconf.New().Read(tempWarewulfConf.Name()))
-
-	tempNodeConf, nodesConfErr := os.CreateTemp("", "nodes.conf-")
-	assert.NoError(t, nodesConfErr)
-	defer os.Remove(tempNodeConf.Name())
-	node.ConfigFile = tempNodeConf.Name()
 	warewulfd.SetNoDaemon()
+	env := testenv.New(t)
+	defer env.RemoveAll(t)
+
 	for _, tt := range tests {
-		var err error
-		_, err = tempNodeConf.Seek(0, 0)
-		assert.NoError(t, err)
-		assert.NoError(t, tempNodeConf.Truncate(0))
-		_, err = tempNodeConf.Write([]byte(tt.inDb))
-		assert.NoError(t, err)
-		assert.NoError(t, tempNodeConf.Sync())
+		env.WriteFile(t, "etc/warewulf/nodes.conf", tt.inDb)
 
 		t.Run(tt.name, func(t *testing.T) {
 			baseCmd := GetCommand()

--- a/internal/app/wwctl/root.go
+++ b/internal/app/wwctl/root.go
@@ -59,7 +59,7 @@ func init() {
 	rootCmd.AddCommand(ssh.GetCommand())
 	rootCmd.AddCommand(genconf.GetCommand())
 	rootCmd.AddCommand(clean.GetCommand())
-	rootCmd.AddCommand(upgrade.Command)
+	rootCmd.AddCommand(upgrade.GetCommand())
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/internal/app/wwctl/upgrade/cobra.go
+++ b/internal/app/wwctl/upgrade/cobra.go
@@ -7,17 +7,15 @@ import (
 	"github.com/warewulf/warewulf/internal/app/wwctl/upgrade/nodes"
 )
 
-var (
-	Command = &cobra.Command{
+func GetCommand() *cobra.Command {
+	command := &cobra.Command{
 		DisableFlagsInUseLine: true,
 		Use:                   "upgrade <config|nodes> [OPTIONS]",
 		Short:                 "Upgrade configuration files",
 		Long: `Upgrade warewulf.conf or nodes.conf from a previous version of Warewulf 4 to a format
 supported by the current version.`,
 	}
-)
-
-func init() {
-	Command.AddCommand(config.Command)
-	Command.AddCommand(nodes.Command)
+	command.AddCommand(config.GetCommand())
+	command.AddCommand(nodes.GetCommand())
+	return command
 }

--- a/internal/app/wwctl/upgrade/config/cobra.go
+++ b/internal/app/wwctl/upgrade/config/cobra.go
@@ -7,12 +7,17 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/warewulf/warewulf/internal/pkg/config"
-	libupgrade "github.com/warewulf/warewulf/internal/pkg/upgrade"
+	"github.com/warewulf/warewulf/internal/pkg/upgrade"
 	"github.com/warewulf/warewulf/internal/pkg/util"
 )
 
 var (
-	Command = &cobra.Command{
+	inputPath  string
+	outputPath string
+)
+
+func GetCommand() *cobra.Command {
+	command := &cobra.Command{
 		DisableFlagsInUseLine: true,
 		Use:                   "config [OPTIONS]",
 		Short:                 "Upgrade an existing warewulf.conf",
@@ -20,14 +25,9 @@ var (
 supported by the current version.`,
 		RunE: UpgradeNodesConf,
 	}
-
-	inputPath  string
-	outputPath string
-)
-
-func init() {
-	Command.Flags().StringVarP(&inputPath, "input-path", "i", config.ConfigFile, "Path to a legacy warewulf.conf")
-	Command.Flags().StringVarP(&outputPath, "output-path", "o", config.ConfigFile, "Path to write the upgraded warewulf.conf to")
+	command.Flags().StringVarP(&inputPath, "input-path", "i", config.ConfigFile, "Path to a legacy warewulf.conf")
+	command.Flags().StringVarP(&outputPath, "output-path", "o", config.ConfigFile, "Path to write the upgraded warewulf.conf to")
+	return command
 }
 
 func UpgradeNodesConf(cmd *cobra.Command, args []string) error {
@@ -35,7 +35,7 @@ func UpgradeNodesConf(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	legacy, err := libupgrade.ParseConfig(data)
+	legacy, err := upgrade.ParseConfig(data)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/api/util/util.go
+++ b/internal/pkg/api/util/util.go
@@ -1,12 +1,11 @@
 package util
 
 import (
-	"fmt"
 	"syscall"
 
 	"github.com/manifoldco/promptui"
 	"github.com/warewulf/warewulf/internal/pkg/api/routes/wwapiv1"
-	"github.com/warewulf/warewulf/internal/pkg/node"
+	"github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
@@ -31,17 +30,10 @@ Simple check if the config can be written in case wwctl isn't run as root
 */
 func CanWriteConfig() (canwrite *wwapiv1.CanWriteConfig, err error) {
 	canwrite = new(wwapiv1.CanWriteConfig)
-	// node is not initialized yet
-	if node.ConfigFile == "" {
-		_, err := node.New()
-		if err != nil {
-			canwrite.CanWriteConfig = false
-			return canwrite, fmt.Errorf("unable to initialize the node %w", err)
-		}
-	}
-	err = syscall.Access(node.ConfigFile, syscall.O_RDWR)
+	nodesConf := config.Get().Paths.NodesConf()
+	err = syscall.Access(nodesConf, syscall.O_RDWR)
 	if err != nil {
-		wwlog.Warn("Couldn't open %s:%s", node.ConfigFile, err)
+		wwlog.Warn("Couldn't open %s:%s", nodesConf, err)
 		canwrite.CanWriteConfig = false
 	} else {
 		canwrite.CanWriteConfig = true

--- a/internal/pkg/config/buildconfig.go.in
+++ b/internal/pkg/config/buildconfig.go.in
@@ -71,6 +71,10 @@ func (this WarewulfConf) GrubBoot() bool {
 	return util.BoolP(this.GrubBootP)
 }
 
+func (paths BuildConfig) NodesConf() string {
+	return path.Join(paths.Sysconfdir, "warewulf", "nodes.conf")
+}
+
 func (paths BuildConfig) OciBlobCachedir() string {
 	return path.Join(paths.Cachedir, "warewulf")
 }

--- a/internal/pkg/node/constructors.go
+++ b/internal/pkg/node/constructors.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/gob"
 	"os"
-	"path"
 	"sort"
 
 	"dario.cat/mergo"
@@ -14,23 +13,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var (
-	ConfigFile string
-)
-
-func init() {
-	conf := warewulfconf.Get()
-	if ConfigFile == "" {
-		ConfigFile = path.Join(conf.Paths.Sysconfdir, "warewulf/nodes.conf")
-	}
-}
-
 /*
 Creates a new nodeDb object from the on-disk configuration
 */
 func New() (NodesYaml, error) {
-	wwlog.Verbose("Opening node configuration file: %s", ConfigFile)
-	data, err := os.ReadFile(ConfigFile)
+	nodesConf := warewulfconf.Get().Paths.NodesConf()
+	wwlog.Verbose("Opening node configuration file: %s", nodesConf)
+	data, err := os.ReadFile(nodesConf)
 	if err != nil {
 		return NodesYaml{}, err
 	}

--- a/internal/pkg/node/modifiers.go
+++ b/internal/pkg/node/modifiers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
+	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
@@ -109,12 +110,12 @@ func (config *NodesYaml) DelProfile(nodeID string) error {
 Write the the NodeYaml to disk.
 */
 func (config *NodesYaml) Persist() error {
-	return config.PersistToFile(ConfigFile)
+	return config.PersistToFile(warewulfconf.Get().Paths.NodesConf())
 }
 
 func (config *NodesYaml) PersistToFile(configFile string) error {
 	if configFile == "" {
-		configFile = ConfigFile
+		configFile = warewulfconf.Get().Paths.NodesConf()
 	}
 	out, dumpErr := config.Dump()
 	if dumpErr != nil {

--- a/internal/pkg/testenv/testenv.go
+++ b/internal/pkg/testenv/testenv.go
@@ -12,10 +12,9 @@ import (
 	"testing"
 	"time"
 
-	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
-
 	"github.com/stretchr/testify/assert"
-	"github.com/warewulf/warewulf/internal/pkg/node"
+
+	"github.com/warewulf/warewulf/internal/pkg/config"
 )
 
 const initWarewulfConf = ``
@@ -61,7 +60,7 @@ func New(t *testing.T) (env *TestEnv) {
 	env.WriteFile(t, path.Join(Sysconfdir, "warewulf/warewulf.conf"), initWarewulfConf)
 
 	// re-read warewulf.conf
-	conf := warewulfconf.New()
+	conf := config.New()
 	err = conf.Read(env.GetPath(path.Join(Sysconfdir, "warewulf/warewulf.conf")))
 	assert.NoError(t, err)
 
@@ -94,9 +93,6 @@ func New(t *testing.T) (env *TestEnv) {
 	} {
 		env.MkdirAll(t, confPath)
 	}
-
-	// node.init() has already run, so set the config path again
-	node.ConfigFile = env.GetPath(path.Join(Sysconfdir, "warewulf/nodes.conf"))
 
 	return
 }

--- a/internal/pkg/warewulfd/util.go
+++ b/internal/pkg/warewulfd/util.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/node"
-	nodepkg "github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/overlay"
 	"github.com/warewulf/warewulf/internal/pkg/util"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -51,7 +51,7 @@ func getOverlayFile(n node.Node, context string, stage_overlays []string, autobu
 	build := !util.IsFile(stage_file)
 	wwlog.Verbose("stage file: %s", stage_file)
 	if !build && autobuild {
-		build = util.PathIsNewer(stage_file, nodepkg.ConfigFile)
+		build = util.PathIsNewer(stage_file, config.Get().Paths.NodesConf())
 
 		for _, overlayname := range stage_overlays {
 			build = build || util.PathIsNewer(stage_file, overlay.OverlaySourceDir(overlayname))


### PR DESCRIPTION
## Description of the Pull Request (PR):

Removes the use of init() to initialize the path to `nodes.conf`, replacing it with a dynamic lookup from config.

- Closes: #1596 
- See also: #1569


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
