### PR TITLE
added round robin boot servers

### DIFF
--- a/etc/warewulf.conf
+++ b/etc/warewulf.conf
@@ -1,5 +1,10 @@
 ipaddr: 10.0.0.1
 netmask: 255.255.252.0
+rrbootaddrs:
+  - 10.0.0.165
+  - 10.0.0.166
+  - 10.0.0.167
+  - 10.0.0.168
 warewulf:
   secure: false
   update interval: 60

--- a/internal/pkg/config/root.go
+++ b/internal/pkg/config/root.go
@@ -29,6 +29,7 @@ var cachedConf WarewulfYaml
 type WarewulfYaml struct {
 	Comment         string        `yaml:"comment,omitempty"`
 	Ipaddr          string        `yaml:"ipaddr,omitempty"`
+	Rrbootaddrs     []string      `yaml:"rrbootaddrs,omitempty"`
 	Ipaddr6         string        `yaml:"ipaddr6,omitempty"`
 	Netmask         string        `yaml:"netmask,omitempty"`
 	Network         string        `yaml:"network,omitempty"`

--- a/internal/pkg/overlay/datastructure.go
+++ b/internal/pkg/overlay/datastructure.go
@@ -24,6 +24,7 @@ type TemplateStruct struct {
 	BuildTimeUnix string
 	BuildSource   string
 	Ipaddr        string
+	Rrbootaddrs   []string
 	Ipaddr6       string
 	Netmask       string
 	Network       string
@@ -71,6 +72,7 @@ func InitStruct(nodeData node.Node) (TemplateStruct, error) {
 	tstruct.Paths = *controller.Paths
 	tstruct.Warewulf = *controller.Warewulf
 	tstruct.Ipaddr = controller.Ipaddr
+	tstruct.Rrbootaddrs = controller.Rrbootaddrs
 	tstruct.Ipaddr6 = controller.Ipaddr6
 	tstruct.Netmask = controller.Netmask
 	tstruct.Network = controller.Network

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"syscall"
 	"text/template"
+	"math/rand"
 
 	"github.com/Masterminds/sprig/v3"
 
@@ -372,6 +373,7 @@ func RenderTemplateFile(fileName string, data TemplateStruct) (
 		"IncludeFrom":  templateContainerFileInclude,
 		"IncludeBlock": templateFileBlock,
 		"basename":     path.Base,
+		"random":       func(a []string) int { return rand.Intn(len(a))},
 		"inc":          func(i int) int { return i + 1 },
 		"dec":          func(i int) int { return i - 1 },
 		"file":         func(str string) string { return fmt.Sprintf("{{ /* file \"%s\" */ }}", str) },

--- a/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
+++ b/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
@@ -26,17 +26,17 @@ if substring (option vendor-class-identifier, 0, 9) = "PXEClient" {
   next-server {{ $.Ipaddr }};
   if substring (option vendor-class-identifier, 15, 5) = "00000" {
     # pure BIOS clients will get iPXE configuration
-    filename "http://{{$.Ipaddr}}:{{$.Warewulf.Port}}/ipxe/${mac:hexhyp}";
+    filename "http://${next-server}:{{$.Warewulf.Port}}/ipxe/${mac:hexhyp}";
   } else {
     # EFI clients will get shim and grub instead
     filename "warewulf/shim.efi";
   }
 } elsif substring (option vendor-class-identifier, 0, 10) = "HTTPClient" {
-  filename "http://{{$.Ipaddr}}:{{$.Warewulf.Port}}/efiboot/shim.efi";
+  filename "http:${next-server}:{{$.Warewulf.Port}}/efiboot/shim.efi";
 }
 {{- else }}
 if exists user-class and option user-class = "iPXE" {
-    filename "http://{{$.Ipaddr}}:{{$.Warewulf.Port}}/ipxe/${mac:hexhyp}?assetkey=${asset}&uuid=${uuid}";
+    filename "http:${next-server}:{{$.Warewulf.Port}}/ipxe/${mac:hexhyp}?assetkey=${asset}&uuid=${uuid}";
 } else {
 {{range $type,$name := $.Tftp.IpxeBinaries }}
     if option architecture-type = {{ $type }} {
@@ -49,7 +49,8 @@ if exists user-class and option user-class = "iPXE" {
 subnet {{$.Network}} netmask {{$.Netmask}} {
     max-lease-time 120;
     range {{$.Dhcp.RangeStart}} {{$.Dhcp.RangeEnd}};
-    next-server {{.Ipaddr}};
+    {{$r := random .Rrbootaddrs}}
+    next-server {{(index .Rrbootaddrs $r)}};
 }
 
 {{- if eq .Dhcp.Template "static" }}


### PR DESCRIPTION
## Description of the Pull Request (PR):

This is a draft I put together while experimenting with multiple Warewulf servers all serving boot images into the same network.
The idea is to use the DHCP config generated by Warewulf to distribute the HTTP traffic to a random server out of a given pool to spread out the load during a cluster boot without going through a loadbalancer or depending on DNS.
I'm not aware of a solution to do this directly in the template so I added a config parameter in `warewulf.conf`
If the community is somehow interested in this feature, I can continue to work on that, but I would be happy for any input on how to properly integrate it into Warewulf logic.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
