### PR TITLE
Add wwctl container <exec|shell> --build=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support defining a symlink with an overlay template. #1303
 - New "localtime" overlay to define the system time zone. #1303
 - Add support for nested profiles. #1572, #1598
+- Adds `wwctl container <exec|shell> --build=false` to prevent automatically (re)building the container. #1490, #1489
 
 ### Changed
 

--- a/internal/app/wwctl/container/exec/child/main.go
+++ b/internal/app/wwctl/container/exec/child/main.go
@@ -21,9 +21,6 @@ import (
 )
 
 const exitEval = `$(VALU="$?" ; if [ $VALU == 0 ]; then echo write; else echo discard; fi)`
-const msgStr = `Container image is rebuilt depending on the exit status of the last command.
-
-Run "true" or "false" to enforce or abort image rebuild.`
 
 func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 	if os.Getpid() != 1 {
@@ -82,7 +79,6 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 		return fmt.Errorf("failed to mount: %w", err)
 	}
 	ps1Str := fmt.Sprintf("[%s|%s] Warewulf> ", containerName, exitEval)
-	wwlog.Info(msgStr)
 	if len(lowerObjects) != 0 && nodename == "" {
 		options := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s",
 			path.Join(runDir, "lower"), containerPath, path.Join(runDir, "work"))

--- a/internal/app/wwctl/container/exec/main.go
+++ b/internal/app/wwctl/container/exec/main.go
@@ -145,14 +145,16 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	if userdbChanged && SyncUser {
 		err = container.SyncUids(containerName, false)
 		if err != nil {
-			wwlog.Error("Error in user sync, fix error and run 'syncuser' manually, but trying to build container: %s", err)
+			wwlog.Error("Error in user sync, fix error and run 'syncuser' manually: %s", err)
 		}
 	}
 
-	fmt.Printf("Rebuilding container...\n")
-	err = container.Build(containerName, false)
-	if err != nil {
-		return fmt.Errorf("could not build container %s: %s", containerName, err)
+	if Build {
+		wwlog.Info("Building container image: %s", containerName)
+		err = container.Build(containerName, false)
+		if err != nil {
+			return fmt.Errorf("could not build container image: %s: %s", containerName, err)
+		}
 	}
 	return nil
 }

--- a/internal/app/wwctl/container/exec/root.go
+++ b/internal/app/wwctl/container/exec/root.go
@@ -26,6 +26,7 @@ var (
 		FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	}
 	SyncUser bool
+	Build    bool
 	binds    []string
 	nodeName string
 )
@@ -37,6 +38,7 @@ Bind a local path which must exist into the container. If destination is not
 set, uses the same path as source. "ro" binds read-only. "copy" temporarily
 copies the file into the container.`)
 	baseCmd.PersistentFlags().BoolVar(&SyncUser, "syncuser", false, "Synchronize UIDs/GIDs from host to container")
+	baseCmd.PersistentFlags().BoolVar(&Build, "build", true, "(Re)build the container image automatically")
 	baseCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Create a read only view of the container for the given node")
 }
 

--- a/internal/app/wwctl/container/shell/main.go
+++ b/internal/app/wwctl/container/shell/main.go
@@ -44,5 +44,9 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	cntexec.SetBinds(binds)
 	cntexec.SetNode(nodeName)
 	cntexec.SyncUser = syncUser
+	cntexec.Build = build
+	if cntexec.Build {
+		wwlog.Info("Container image build will be skipped if the shell ends with a non-zero exit code.")
+	}
 	return cntexec.CobraRunE(cmd, allargs)
 }

--- a/internal/app/wwctl/container/shell/root.go
+++ b/internal/app/wwctl/container/shell/root.go
@@ -26,6 +26,7 @@ var (
 	binds    []string
 	nodeName string
 	syncUser bool
+	build    bool
 )
 
 func init() {
@@ -35,6 +36,7 @@ set, uses the same path as source. "ro" binds read-only. "copy" temporarily
 copies the file into the container.`)
 	baseCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Create a read only view of the container for the given node")
 	baseCmd.PersistentFlags().BoolVar(&syncUser, "syncuser", false, "Synchronize UIDs/GIDs from host to container")
+	baseCmd.PersistentFlags().BoolVar(&build, "build", true, "(Re)build the container image automatically")
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/userdocs/contents/containers.rst
+++ b/userdocs/contents/containers.rst
@@ -229,7 +229,7 @@ when using the exec command. This works as follows:
 
 .. code-block:: console
 
-   # wwctl container exec --bind /tmp:/mnt rocky-8 /bin/sh
+   # wwctl container shell --bind /tmp:/mnt rocky-8
    [rocky-8] Warewulf>
 
 .. note::
@@ -257,7 +257,7 @@ can be specified in ``warewulf.conf``:
 
 When the command completes, if anything within the container changed,
 the container will be rebuilt into a bootable static object
-automatically.
+automatically. (To skip the automatic container rebuild, specify ``--build=false``.)
 
 If the files ``/etc/passwd`` or ``/etc/group`` were updated, there
 will be an additional check to confirm if the users are in sync as


### PR DESCRIPTION
## Description of the Pull Request (PR):

Adds a `wwctl container <exec|shell> --build=false` option to prevent automatically (re)building the container.


## This fixes or addresses the following GitHub issues:

- Closes #1490
- Closes #1489


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
