### PR TITLE
Add note in userdoc regarding dracut and machine-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Bump github.com/containers/storage from 1.53.0 to 1.55.2 #1316, #892
 - Process nodes.conf path dynamically from config. #1595, #1596, #1569
 - Split overlays into distribution and site overlays. #831
+- Added note to booting userdoc for removing machine-id. #1609
 
 ### Removed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -44,3 +44,4 @@
 * Nicholas Porter <nap23@unm.edu>
 * Ian Kaufman <ikaufman@ucsd.edu> [@iankgt40](https://github.com/iankgt40)
 * Daniele Colombo [@dacolombo](https://github.com/dacolombo)
+* Stephen Simpson [@ssimpson89](https://github.com/ssimpson89)

--- a/userdocs/contents/boot-management.rst
+++ b/userdocs/contents/boot-management.rst
@@ -326,6 +326,12 @@ initramfs inside the container.
    dnf -y install warewulf-dracut
    dracut --force --no-hostonly --add wwinit --regenerate-all
 
+.. note::
+
+   In some systems, such as ``rockylinux:8``, it may be 
+   necessary to remove ``/etc/machine-id`` for dracut to properly generate 
+   the initramfs in the location that Warewulf is expecting.
+
 Set the node's iPXE template to ``dracut`` to direct iPXE to fetch the
 node's initramfs image and boot with dracut semantics, rather than
 booting the node image directly.


### PR DESCRIPTION
## Description of the Pull Request (PR):

In Rocky Linux 8, running the provided dracut command does not create the initramfs in a place where Warewulf is expecting it and thus fails to pull the image during the two stage boot. The fix appears to be to remove machine-id from /etc. This documentation PR reflects that

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
