### PR TITLE
Log cpio errors more prominently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Process nodes.conf path dynamically from config. #1595, #1596, #1569
 - Split overlays into distribution and site overlays. #831
 - Added note to booting userdoc for removing machine-id. #1609
+- Log cpio errors more prominently. #1615
 
 ### Removed
 

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -374,8 +374,10 @@ func CpioCreate(
 	}()
 
 	out, err := proc.CombinedOutput()
-	if len(out) > 0 {
-		wwlog.Debug(string(out))
+	if err != nil {
+		wwlog.Error("cpio failed: %s", out)
+	} else if len(out) > 0 {
+		wwlog.Debug("cpio: %s", out)
 	}
 
 	return FirstError(err, <-err_in)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Previously, cpio output would only be shown as a debug message. Now it is shown as an error message if cpio returns an error.

## This fixes or addresses the following GitHub issues:

- Fixes #1615


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
