### PR TITLE
Update dnsmasq Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improved syncuser conflict help text. #1614
 - Parallelized overlay build. #1018
 - Parallelized and optimized overlay build. #1018
+- Added note about dnsmasq interface options in Rocky 9.
 
 ### Removed
 

--- a/userdocs/contents/dnsmasq.rst
+++ b/userdocs/contents/dnsmasq.rst
@@ -41,6 +41,12 @@ After the installation you have to instruct ``warewulf`` to use ``dnsmasq`` as i
 
 The configuration of ``dnsmasq`` doesn't need to be changed, as the default configuration includes all files with following pattern ``/etc/dnsmasq.d/*conf`` into its configuration.
 This configuration is created by the overlay template ``host:/etc/dnsmasq.d/ww4-hosts.conf.ww``.
+
+.. note::
+
+   In certain OS versions, such as Rocky Linux 9, ``dnsmasq`` is configured to listen locally via the ``interface=lo`` option by default in ``/etc/dnsmasq.conf``. 
+   Replace this with the interface associated with your Warewulf network, or remove/comment out the interface option entirely to enable listening on all interfaces.
+
 In order to build this template run
 
 .. code-block:: shell


### PR DESCRIPTION
## Description of the Pull Request (PR):

In Rocky Linux 9, `dnsmasq` appears to default to listening on loopback only. This PR adds to the documentation that the user will need to change this to the appropriate configuration

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
