### PR TITLE
Fix DelProfile to operate on profiles, not nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Allow iPXE to continue booting without runtime overlay. #806
 - Format errors in logs as strings. #1563
 - Fix display of profiles during node list. #1496
+- Fix internal DelProfile function to correctly operate on profiles rather than nodes. #1622
 
 ## v4.5.8, 2024-10-01
 

--- a/internal/pkg/node/modifiers.go
+++ b/internal/pkg/node/modifiers.go
@@ -93,15 +93,15 @@ func (config *NodesYaml) AddProfile(profileId string) (*Profile, error) {
 }
 
 /*
-delete node with the given id
+delete profile with the given id
 */
-func (config *NodesYaml) DelProfile(nodeID string) error {
-	if _, ok := config.Nodes[nodeID]; !ok {
-		return errors.New("profile does not exist: " + nodeID)
+func (config *NodesYaml) DelProfile(profileID string) error {
+	if _, ok := config.NodeProfiles[profileID]; !ok {
+		return errors.New("profile does not exist: " + profileID)
 	}
 
-	wwlog.Verbose("deleting profile: %s", nodeID)
-	delete(config.Nodes, nodeID)
+	wwlog.Verbose("deleting profile: %s", profileID)
+	delete(config.NodeProfiles, profileID)
 
 	return nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

`node.DelProfile` was erroneously operating on nodes. This pr fixes it to operate on profiles.


## This fixes or addresses the following GitHub issues:

- Fixes: #1622


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
