### PR TITLE
have dracut explicitly configure defined interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Parallelized and optimized overlay build. #1018
 - Added note about dnsmasq interface options in Rocky 9.
 - Added retries to curl in wwinit dracut module. #1631
+- Added ip= argument to dracut ipxe script. #1630
 
 ### Removed
 

--- a/etc/ipxe/dracut.ipxe
+++ b/etc/ipxe/dracut.ipxe
@@ -23,7 +23,7 @@ kernel --name kernel ${uri}&stage=kernel || goto reboot
 echo Downloading initramfs
 initrd --name initramfs ${uri}&stage=initramfs || goto reboot
 
-set dracut_net rd.neednet=1 {{range $devname, $netdev := .NetDevs}}{{if and $netdev.Hwaddr $netdev.Device}} ifname={{$netdev.Device}}:{{$netdev.Hwaddr}} {{end}}{{end}}
+set dracut_net rd.neednet=1 {{range $devname, $netdev := .NetDevs}}{{if and $netdev.Hwaddr $netdev.Device}} ifname={{$netdev.Device}}:{{$netdev.Hwaddr}} ip={{$netdev.Device}}:dhcp {{end}}{{end}}
 set dracut_wwinit root=wwinit wwinit.uri=${baseuri} init=/init
 
 echo Booting initramfs


### PR DESCRIPTION

## Description of the Pull Request (PR):

During migration of our cluster to warewulf we ran into an issue with dracut and ib. Our nodes are using infiniband exclusively with only ipmi being served over ethernet. It seems that dracut (without ip= defined) will attempt to configure the first interface using dhcp and no others. In our environment this results in dracut boots failing to actually pull down containers as the ib interface isn't configured.

This PR adds an additional ```ip=``` argument for each configured interface in addition to the already present ```ifname=``` argument to the kernel cmdline.


## This fixes or addresses the following GitHub issues:

- Fixes #1620


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
