### PR TITLE
adding retry to curl in wwinit dracut module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Parallelized overlay build. #1018
 - Parallelized and optimized overlay build. #1018
 - Added note about dnsmasq interface options in Rocky 9.
+- Added retries to curl in wwinit dracut module. #1631
 
 ### Removed
 

--- a/dracut/modules.d/90wwinit/load-wwinit.sh
+++ b/dracut/modules.d/90wwinit/load-wwinit.sh
@@ -15,6 +15,6 @@ do
         then
             localport="--local-port 1-1023"
         fi
-        (curl --silent ${localport} -L "${archive}" | gzip -d | cpio -im --directory="${NEWROOT}") || die "Unable to load ${archive}"
+        (curl --retry 60 --retry-delay 1 --silent ${localport} -L "${archive}" | gzip -d | cpio -im --directory="${NEWROOT}") || die "Unable to load ${archive}"
     fi
 done


### PR DESCRIPTION
## Description of the Pull Request (PR):

Dracut doesn't seem to always wait for the network to be as up as we might like before running the wwinit module. This PR makes the curl transfer retry up to 60 times, waiting 1s between attempts, to download images.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
