### PR TITLE
Adjust umask during overlay build

### DIFF
--- a/internal/app/wwctl/overlay/build/main.go
+++ b/internal/app/wwctl/overlay/build/main.go
@@ -64,7 +64,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	oldMask := syscall.Umask(007)
+	oldMask := syscall.Umask(000)
 	defer syscall.Umask(oldMask)
 
 	if len(OverlayNames) > 0 {

--- a/internal/app/wwctl/server/root.go
+++ b/internal/app/wwctl/server/root.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"syscall"
 
 	"github.com/spf13/cobra"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
@@ -21,8 +22,14 @@ func GetCommand() *cobra.Command {
 }
 
 func CobraRunE(cmd *cobra.Command, args []string) error {
+	oldMask := syscall.Umask(000)
+	defer syscall.Umask(oldMask)
+
 	if err := warewulfd.DaemonInitLogging(); err != nil {
 		return fmt.Errorf("failed to configure logging: %w", err)
 	}
-	return fmt.Errorf("failed to start Warewulf server: %w", warewulfd.RunServer())
+	if err := warewulfd.RunServer(); err != nil {
+		return fmt.Errorf("failed to start Warewulf server: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fixes an invalid Umask setting during overlay build, and also makes sure that umask is 0 during warewulfd.


## This fixes or addresses the following GitHub issues:

- Fixes: #1629


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
