### PR TITLE
Fix a null-pointer bug in `wwctl upgrade config`

### DIFF
--- a/internal/pkg/upgrade/config.go
+++ b/internal/pkg/upgrade/config.go
@@ -176,7 +176,7 @@ func (this *NFSExportConf) Upgrade() (upgraded *config.NFSExportConf) {
 	upgraded = new(config.NFSExportConf)
 	upgraded.Path = this.Path
 	upgraded.ExportOptions = this.ExportOptions
-	if *(this.Mount) {
+	if this.Mount != nil && *(this.Mount) {
 		wwlog.Warn("Legacy mount configured for NFS export %s: use `wwctl upgrade nodes --with-warewulfconf=<original file>` to port to nodes.conf", this.Path)
 	}
 	return upgraded

--- a/internal/pkg/upgrade/node.go
+++ b/internal/pkg/upgrade/node.go
@@ -97,7 +97,6 @@ func (this *NodesYaml) Upgrade(addDefaults bool, replaceOverlays bool, warewulfc
 	if warewulfconf != nil && warewulfconf.NFS != nil {
 		var fstab []map[string]string
 		for _, export := range warewulfconf.NFS.Exports {
-			fmt.Printf("PORTING EXPORT: %s\n", export)
 			fstab = append(fstab, map[string]string{
 				"spec":    fmt.Sprintf("warewulf:%s", export),
 				"file":    export,
@@ -117,7 +116,6 @@ func (this *NodesYaml) Upgrade(addDefaults bool, replaceOverlays bool, warewulfc
 				fstab = append(fstab, entry)
 			}
 		}
-		fmt.Printf("FSTAB: %+v\n", fstab)
 		if len(fstab) > 0 {
 			if _, ok := upgraded.NodeProfiles["default"]; !ok {
 				upgraded.NodeProfiles["default"] = new(node.Profile)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fixes a null-pointer bug in `wwctl upgrade config`.

Also removes some vestigial development-debug output.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
