### PR TITLE
Remove a vestigial printf from wwctl upgrade

### DIFF
--- a/internal/pkg/upgrade/node.go
+++ b/internal/pkg/upgrade/node.go
@@ -133,7 +133,6 @@ func (this *NodesYaml) Upgrade(addDefaults bool, replaceOverlays bool, warewulfc
 			} else {
 				upgraded.NodeProfiles["default"].Resources["fstab"] = fstab
 			}
-			fmt.Printf("RECORDED FSTAB: %+v\n", upgraded.NodeProfiles["default"].Resources["fstab"])
 		}
 	}
 	return upgraded


### PR DESCRIPTION
## Description of the Pull Request (PR):

Removing a vesitigial `fmt.Printf` from `wwctl upgrade` which was left behind from development.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
