### PR TITLE
Fix newline handling in /etc/issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix display of profiles during node list. #1496
 - Fix internal DelProfile function to correctly operate on profiles rather than nodes. #1622
 - Fix parsing of bool command line variables #1627
+- Fix newline handling in /etc/issue. #1648
 
 ## v4.5.8, 2024-10-01
 

--- a/overlays/issue/internal/issue_test.go
+++ b/overlays/issue/internal/issue_test.go
@@ -22,9 +22,43 @@ func Test_issueOverlay(t *testing.T) {
 		log  string
 	}{
 		{
-			name: "/etc/issue",
+			name: "/etc/issue (no kernel specified)",
 			args: []string{"--render", "node1", "issue", "etc/issue.ww"},
-			log:  issue,
+			log: `backupFile: true
+writeFile: true
+Filename: etc/issue
+Warewulf Node:      node1
+Image:              rockylinux-9
+Kernelargs:         quiet crashkernel=no vga=791 net.naming-scheme=v238
+
+Network:
+    default: wwnet0
+    default: \4{wwnet0} (configured: 192.168.3.21)
+    default: e6:92:39:49:7b:03
+    secondary: wwnet1
+    secondary: \4{wwnet1} (configured: 192.168.3.22)
+    secondary: 9a:77:29:73:14:f1
+`,
+		},
+		{
+			name: "/etc/issue (kernel specified)",
+			args: []string{"--render", "node2", "issue", "etc/issue.ww"},
+			log: `backupFile: true
+writeFile: true
+Filename: etc/issue
+Warewulf Node:      node2
+Image:              rockylinux-9
+Kernel:             2.6.0
+Kernelargs:         quiet crashkernel=no vga=791 net.naming-scheme=v238
+
+Network:
+    default: wwnet0
+    default: \4{wwnet0} (configured: 192.168.3.21)
+    default: e6:92:39:49:7b:03
+    secondary: wwnet1
+    secondary: \4{wwnet1} (configured: 192.168.3.22)
+    secondary: 9a:77:29:73:14:f1
+`,
 		},
 	}
 
@@ -46,19 +80,3 @@ func Test_issueOverlay(t *testing.T) {
 		})
 	}
 }
-
-const issue string = `backupFile: true
-writeFile: true
-Filename: etc/issue
-Warewulf Node:      node1
-Image:              rockylinux-9
-Kernelargs:         quiet crashkernel=no vga=791 net.naming-scheme=v238
-
-Network:
-    default: wwnet0
-    default: \4{wwnet0} (configured: 192.168.3.21)
-    default: e6:92:39:49:7b:03
-    secondary: wwnet1
-    secondary: \4{wwnet1} (configured: 192.168.3.22)
-    secondary: 9a:77:29:73:14:f1
-`

--- a/overlays/issue/internal/nodes.conf
+++ b/overlays/issue/internal/nodes.conf
@@ -1,5 +1,5 @@
-nodes:
-  node1:
+nodeprofiles:
+  default:
     image name: rockylinux-9
     kernel:
       args: quiet crashkernel=no vga=791 net.naming-scheme=v238
@@ -19,3 +19,13 @@ nodes:
         tags:
           DNS1: 8.8.8.8
           DNS2: 8.8.4.4
+
+nodes:
+  node1:
+    profiles:
+    - default
+  node2:
+    profiles:
+    - default
+    kernel:
+      version: 2.6.0

--- a/overlays/issue/rootfs/etc/issue.ww
+++ b/overlays/issue/rootfs/etc/issue.ww
@@ -1,6 +1,8 @@
 Warewulf Node:      {{.Id}}
 Image:              {{.ImageName}}
-{{ if .Kernel.Version }}Kernel:             {{.Kernel.Version}} {{ end -}}
+{{- if .Kernel.Version }}
+Kernel:             {{.Kernel.Version}}
+{{- end }}
 Kernelargs:         {{.Kernel.Args}}
 
 Network:


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix a newline handling in /etc/issue.

Previous behavior:

<img width="680" alt="Screenshot 2025-01-23 at 11 35 37 AM" src="https://github.com/user-attachments/assets/845245b4-7fe4-4bd3-96ad-dbfbdb02eca1" />

Note how the kernel version and args are all on the same line.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
