### PR TITLE
Change image provision directory to "images"

### DIFF
--- a/internal/app/wwctl/image/copy/main_test.go
+++ b/internal/app/wwctl/image/copy/main_test.go
@@ -28,6 +28,6 @@ func Test_Copy(t *testing.T) {
 		baseCmd.SetArgs([]string{"-b", "test-image", "test-image-copy"})
 		err := baseCmd.Execute()
 		assert.NoError(t, err)
-		assert.FileExists(t, path.Join(env.BaseDir, testenv.WWProvisiondir, "image", "test-image-copy.img"))
+		assert.FileExists(t, path.Join(env.BaseDir, testenv.WWProvisiondir, "images", "test-image-copy.img"))
 	})
 }

--- a/internal/app/wwctl/image/exec/main_test.go
+++ b/internal/app/wwctl/image/exec/main_test.go
@@ -82,8 +82,8 @@ func Test_Exec(t *testing.T) {
 				nodeName = ""
 				Build = true
 				SyncUser = false
-				os.Remove(env.GetPath("/srv/warewulf/image/test.img"))
-				os.Remove(env.GetPath("/srv/warewulf/image/test.img.gz"))
+				os.Remove(env.GetPath("/srv/warewulf/images/test.img"))
+				os.Remove(env.GetPath("/srv/warewulf/images/test.img.gz"))
 			}()
 			cmd := GetCommand()
 			cmd.SetArgs(tt.args)
@@ -95,11 +95,11 @@ func Test_Exec(t *testing.T) {
 			assert.NotEmpty(t, out.String())
 			assert.Contains(t, out.String(), tt.stdout)
 			if tt.build {
-				assert.FileExists(t, env.GetPath("/srv/warewulf/image/test.img"))
-				assert.FileExists(t, env.GetPath("/srv/warewulf/image/test.img.gz"))
+				assert.FileExists(t, env.GetPath("/srv/warewulf/images/test.img"))
+				assert.FileExists(t, env.GetPath("/srv/warewulf/images/test.img.gz"))
 			} else {
-				assert.NoFileExists(t, env.GetPath("/srv/warewulf/image/test.img"))
-				assert.NoFileExists(t, env.GetPath("/srv/warewulf/image/test.img.gz"))
+				assert.NoFileExists(t, env.GetPath("/srv/warewulf/images/test.img"))
+				assert.NoFileExists(t, env.GetPath("/srv/warewulf/images/test.img.gz"))
 			}
 		})
 	}

--- a/internal/pkg/image/config.go
+++ b/internal/pkg/image/config.go
@@ -25,7 +25,7 @@ func RunDir(name string) string {
 
 func ImageParentDir() string {
 	conf := warewulfconf.Get()
-	return path.Join(conf.Paths.WWProvisiondir, "image")
+	return path.Join(conf.Paths.WWProvisiondir, "images")
 }
 
 func ImageFile(name string) string {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Previous name (before #1641) was "container." New name (from #1641) was "image" but a plural name seems better.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
