### PR TITLE
Add Dev Container support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Warewulf Development",
+  "image": "registry.docker.com/library/rockylinux:9",
+  "remoteUser": "vscode",
+  "onCreateCommand": "sudo dnf install -y dnf-utils && sudo dnf config-manager --set-enabled crb && sudo dnf install -y unzip cpio gpgme-devel python3-sphinx python3-sphinx_rtd_theme",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {},
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "latest"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "ms-vscode.makefile-tools"
+      ]
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Adds `wwctl container <exec|shell> --build=false` to prevent automatically (re)building the container. #1490, #1489
 - Added resources as generic, arbitrary YAML data for nodes and profiles. #1568
 - New `fstab` resource configures mounts in fstab overlay, including NFS mounts. #515
+- Add Dev Container support #1653
 
 ### Changed
 

--- a/userdocs/contributing/development-environment-devcontainer.rst
+++ b/userdocs/contributing/development-environment-devcontainer.rst
@@ -1,0 +1,8 @@
+=============================
+Development Environment (Dev Container/VSC)
+=============================
+
+Using a Dev Container for development
+=====================================================
+
+Visual Studio Code (VSC) can utilize a Dev Container for a self-contained environment that has all the necessary tools and dependencies to build and test Warewulf. The Dev Container is based on the Rocky 9 image and is built using the `devcontainer.json` file in the `.devcontainer` directory of the Warewulf repository.  To use this working Docker/Podman and VSC installations are required.  To use the Dev Container, click the "Open a Remote Window" button on the bottom left of the editor (`><` icon) and select "Reopen in Container".  This will build the container and open a new VSC window with the container as the development environment. 

--- a/userdocs/index.rst
+++ b/userdocs/index.rst
@@ -47,6 +47,7 @@ Welcome to the Warewulf User Guide!
    Contributing <contributing/contributing>
    Debugging <contributing/debugging>
    Documentation <contributing/documentation>
+   Development Environment (Dev Container/VSC) <contributing/development-environment-devcontainer>
    Development Environment (Vagrant) <contributing/development-environment-vagrant>
    Development Environment (KVM) <contributing/development-environment-kvm>
    Development Environment (VirtualBox) <contributing/development-environment-vbox>


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add preliminary Development Containers support for VSC (https://containers.dev/)
Based on a Rocky9 container and includes the following features.
 * common-utils (creates vscode user)
  * go toolchain (latest)
  * makefile support
 
Lightly tested but will build and `make test` in a Dev Container.  This is a dev feature so no CHANGELOG added.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
