### PR TITLE
Refactor kernel args as a slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added retries to curl in wwinit dracut module. #1631
 - Added ip= argument to dracut ipxe script. #1630
 - Updated network interface bonding configuration and documentation. #1482, #1280
+- Refactor Kernel arguments as a slice (list) rather than a single string. #1656
 
 ### Removed
 

--- a/internal/app/wwctl/node/add/main_test.go
+++ b/internal/app/wwctl/node/add/main_test.go
@@ -88,7 +88,8 @@ nodes:
 nodes:
   n01:
     kernel:
-      args: foo
+      args:
+      - foo
     profiles:
     - default
 `},

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -71,8 +71,8 @@ type IpmiConf struct {
 }
 
 type KernelConf struct {
-	Version string `yaml:"version,omitempty" lopt:"kernelversion" comment:"Set kernel version" json:"version,omitempty"`
-	Args    string `yaml:"args,omitempty" lopt:"kernelargs" sopt:"A" comment:"Set kernel arguments" json:"args,omitempty"`
+	Version string   `yaml:"version,omitempty" lopt:"kernelversion" comment:"Set kernel version" json:"version,omitempty"`
+	Args    []string `yaml:"args,omitempty" lopt:"kernelargs" sopt:"A" comment:"Set kernel arguments" json:"args,omitempty"`
 }
 
 type NetDev struct {

--- a/internal/pkg/node/fields_test.go
+++ b/internal/pkg/node/fields_test.go
@@ -30,7 +30,8 @@ nodes:
 nodes:
   n1:
     kernel:
-      args: n1 args`,
+      args:
+      - n1 args`,
 			node:  "n1",
 			field: "Kernel.Args",
 			value: "n1 args",

--- a/internal/pkg/node/mergo_test.go
+++ b/internal/pkg/node/mergo_test.go
@@ -284,7 +284,8 @@ nodeprofiles:
 nodes:
   n1:
     kernel:
-      args: n1 args`,
+      args:
+      - n1 args`,
 			node:   "n1",
 			field:  "Kernel.Args",
 			source: "",
@@ -299,7 +300,8 @@ nodes:
 nodeprofiles:
   p1:
     kernel:
-      args: p1 args`,
+      args:
+      - p1 args`,
 			node:   "n1",
 			field:  "Kernel.Args",
 			source: "p1",
@@ -315,52 +317,59 @@ nodes:
 nodeprofiles:
   p1:
     kernel:
-      args: p1 args
+      args:
+      -  p1 args
   p2:
     kernel:
-      args: p2 args`,
+      args:
+      -  p2 args`,
 			node:   "n1",
 			field:  "Kernel.Args",
-			source: "p2",
-			value:  "p2 args",
+			source: "p1,p2",
+			value:  "p1 args,p2 args",
 		},
 		"node kernel args supersedes profile kernel args": {
 			nodesConf: `
 nodes:
   n1:
     kernel:
-      args: n1 args
+      args:
+      -  n1 args
     profiles:
     - p1
 nodeprofiles:
   p1:
     kernel:
-      args: p1 args`,
+      args:
+      -  p1 args`,
 			node:   "n1",
 			field:  "Kernel.Args",
-			source: "SUPERSEDED",
-			value:  "n1 args",
+			source: "p1,n1",
+			value:  "p1 args,n1 args",
 		},
 		"node kernel args supersedes multiple profile kernel args": {
 			nodesConf: `
 nodes:
   n1:
     kernel:
-      args: n1 args
+      args:
+      -  n1 args
     profiles:
     - p1
     - p2
 nodeprofiles:
   p1:
     kernel:
-      args: p1 args
+      args:
+      -  p1 args
   p2:
     kernel:
-      args: p2 args`,
+      args:
+      -  p2 args`,
 			node:   "n1",
 			field:  "Kernel.Args",
-			source: "SUPERSEDED",
-			value:  "n1 args",
+			source: "p1,p2,n1",
+			value:  "p1 args,p2 args,n1 args",
 		},
 		"node tag": {
 			nodesConf: `
@@ -971,7 +980,8 @@ nodes:
       - default
     kernel:
       version: v1.0.0
-      args: kernel-args`,
+      args:
+      - kernel-args`,
 			node:   "node1",
 			kernel: nil,
 		},

--- a/internal/pkg/node/methods_test.go
+++ b/internal/pkg/node/methods_test.go
@@ -49,7 +49,7 @@ func Test_Node_Expand_Flatten(t *testing.T) {
 		assert.Equal(t, map[string]string{}, node.Tags)
 		assert.Equal(t, map[string]string{}, node.Ipmi.Tags)
 		assert.Equal(t, "", node.Kernel.Version)
-		assert.Equal(t, "", node.Kernel.Args)
+		assert.Len(t, node.Kernel.Args, 0)
 		assert.Equal(t, map[string]*NetDev{}, node.NetDevs)
 	})
 
@@ -75,7 +75,7 @@ func Test_Profile_Expand_Flatten(t *testing.T) {
 		assert.Equal(t, map[string]string{}, profile.Tags)
 		assert.Equal(t, map[string]string{}, profile.Ipmi.Tags)
 		assert.Equal(t, "", profile.Kernel.Version)
-		assert.Equal(t, "", profile.Kernel.Args)
+		assert.Len(t, profile.Kernel.Args, 0)
 		assert.Equal(t, map[string]*NetDev{}, profile.NetDevs)
 	})
 

--- a/internal/pkg/overlay/overlay_test.go
+++ b/internal/pkg/overlay/overlay_test.go
@@ -216,7 +216,7 @@ T3
 				"/var/lib/warewulf/overlays/o1/rootfs/node.txt.ww": `
 IPMI user:{{ .Ipmi.UserName}}
 Kernel Version:{{.Kernel.Version}}
-Kernel Args:{{.Kernel.Args}}
+Kernel Args:{{.Kernel.Args | join " "}}
 NetDevs:{{.NetDevs}}
 Tags:{{.Tags}}
 `,

--- a/internal/pkg/upgrade/node_test.go
+++ b/internal/pkg/upgrade/node_test.go
@@ -243,12 +243,14 @@ nodeprofiles:
   default:
     kernel:
       version: "2.6"
-      args: quiet
+      args:
+      - quiet
 nodes:
   n1:
     kernel:
       version: "2.6"
-      args: quiet
+      args:
+      - quiet
 `,
 	},
 	{
@@ -543,7 +545,11 @@ nodeprofiles:
       - wicked
       - ignition
     kernel:
-      args: quiet crashkernel=no vga=791 net.naming-scheme=v238
+      args:
+      - quiet
+      - crashkernel=no
+      - vga=791
+      - net.naming-scheme=v238
     init: /sbin/init
     root: initramfs
 nodes:
@@ -606,7 +612,11 @@ nodeprofiles:
       - systemd.netname
       - NetworkManager
     kernel:
-      args: quiet crashkernel=no vga=791 net.naming-scheme=v238
+      args:
+      - quiet
+      - crashkernel=no
+      - vga=791
+      - net.naming-scheme=v238
     init: /sbin/init
     root: initramfs
 nodes:

--- a/internal/pkg/warewulfd/provision.go
+++ b/internal/pkg/warewulfd/provision.go
@@ -107,7 +107,7 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 			Hostname:      remoteNode.Id(),
 			Hwaddr:        rinfo.hwaddr,
 			ImageName:     remoteNode.ImageName,
-			KernelArgs:    remoteNode.Kernel.Args,
+			KernelArgs:    strings.Join(remoteNode.Kernel.Args, " "),
 			KernelVersion: remoteNode.Kernel.Version,
 			NetDevs:       remoteNode.NetDevs,
 			Tags:          remoteNode.Tags}
@@ -177,7 +177,7 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 			kernelArgs := ""
 			kernelVersion := ""
 			if remoteNode.Kernel != nil {
-				kernelArgs = remoteNode.Kernel.Args
+				kernelArgs = strings.Join(remoteNode.Kernel.Args, " ")
 				kernelVersion = remoteNode.Kernel.Version
 			}
 			tmpl_data = &templateVars{

--- a/overlays/debug/internal/nodes.conf
+++ b/overlays/debug/internal/nodes.conf
@@ -20,7 +20,11 @@ nodeprofiles:
     - wicked
     - ignition
     kernel:
-      args: quiet crashkernel=no vga=791 net.naming-scheme=v238
+      args:
+      - quiet
+      - crashkernel=no
+      - vga=791
+      - net.naming-scheme=v238
     init: /sbin/init
     root: initramfs
     ipxe template: default

--- a/overlays/debug/rootfs/tstruct.md.ww
+++ b/overlays/debug/rootfs/tstruct.md.ww
@@ -97,7 +97,7 @@ node methods in addition to its fields.
 {{- end }}
 - Kernel:
   - Version: {{ .Kernel.Version }}
-  - Args: {{ .Kernel.Args }}
+  - Args: {{ .Kernel.Args | join " " }}
 - Ipmi:
   - UserName: {{ .Ipmi.UserName }}
   - Password: {{ .Ipmi.Password }}

--- a/overlays/issue/internal/nodes.conf
+++ b/overlays/issue/internal/nodes.conf
@@ -2,7 +2,11 @@ nodeprofiles:
   default:
     image name: rockylinux-9
     kernel:
-      args: quiet crashkernel=no vga=791 net.naming-scheme=v238
+      args:
+      - quiet
+      - crashkernel=no
+      - vga=791
+      - net.naming-scheme=v238
     network devices:
       default:
         device: wwnet0

--- a/overlays/issue/rootfs/etc/issue.ww
+++ b/overlays/issue/rootfs/etc/issue.ww
@@ -3,7 +3,7 @@ Image:              {{.ImageName}}
 {{- if .Kernel.Version }}
 Kernel:             {{.Kernel.Version}}
 {{- end }}
-Kernelargs:         {{.Kernel.Args}}
+Kernelargs:         {{.Kernel.Args | join " "}}
 
 Network:
 {{- range $devname, $netdev := .NetDevs}}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Refactor kernel args as a slice (list) rather than a single string. This lets kernel arguments from profiles be inherited and added to by other profiles and nodes.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
