### PR TITLE
Use sh to parse and exec IPMI command (fixes #1663)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix default nodes.conf to use the new kernel command line list format. #1670
 - Fix `make install` when `sudo` does not set `$PWD`. #1660
+- Use sh to parse and exec IPMI command. #1663
 
 ## v4.6.0rc1, 2025-01-29
 

--- a/internal/pkg/power/ipmitool.go
+++ b/internal/pkg/power/ipmitool.go
@@ -67,7 +67,7 @@ func (ipmi *IPMI) Command() ([]byte, error) {
 	if ipmi.ShowOnly {
 		return []byte(cmdStr), nil
 	}
-	ipmiCmd := exec.Command(cmdStr)
+	ipmiCmd := exec.Command("/bin/sh", "-c", cmdStr)
 	return ipmiCmd.CombinedOutput()
 }
 
@@ -76,7 +76,7 @@ func (ipmi *IPMI) InteractiveCommand() (err error) {
 	if err != nil {
 		return err
 	}
-	ipmiCmd := exec.Command(cmdStr)
+	ipmiCmd := exec.Command("/bin/sh", "-c", cmdStr)
 	ipmiCmd.Stdout = os.Stdout
 	ipmiCmd.Stdin = os.Stdin
 	ipmiCmd.Stderr = os.Stderr


### PR DESCRIPTION
## Description of the Pull Request (PR):

Just passing the command that is returned from expanding the bmc template to `sh -c` rather than trying to execute itself. Pro's and cons, but the target community won't have problems with this being evaluated as a shell command (where e.g. env variables are honored).

Disclaimer: didn't test yet, no update to test-suite 


## This fixes or addresses the following GitHub issues:

- Fixes #1663


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
