### PR TITLE
Fix make install when sudo does not set PWD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fix default nodes.conf to use the new kernel command line list format. #1670
+- Fix `make install` when `sudo` does not set `$PWD`. #1660
 
 ## v4.6.0rc1, 2025-01-29
 

--- a/Variables.mk
+++ b/Variables.mk
@@ -75,7 +75,7 @@ CONFIG := $(shell pwd)
 IPXESOURCE ?= $(PREFIX)/share/ipxe
 
 # helper functions
-godeps=$(shell 2>/dev/null go list -mod vendor -deps -f '{{if not .Standard}}{{ $$dep := . }}{{range .GoFiles}}{{$$dep.Dir}}/{{.}} {{end}}{{end}}' $(1) | sed "s%${PWD}/%%g")
+godeps=$(shell 2>/dev/null go list -mod vendor -deps -f '{{if not .Standard}}{{ $$dep := . }}{{range .GoFiles}}{{$$dep.Dir}}/{{.}} {{end}}{{end}}' $(1) | sed "s%$(shell pwd)/%%g")
 
 # use GOPROXY for older git clients and speed up downloads
 GOPROXY ?= https://proxy.golang.org


### PR DESCRIPTION
## Description of the Pull Request (PR):

When doing a `make install` on systems where `sudo` does not pass the `PWD` environment variable the dependency paths are mangled.  This occurs in the `godeps` in `Variables.mk` due to the empty `$PWD` in the `sed` function. 

## This fixes or addresses the following GitHub issues:

- Fixes #1660

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
