### PR TITLE
Fix default nodes.conf to use the new kernel command line list format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v4.6.0, unreleased
+
+### Fixed
+
+- Fix default nodes.conf to use the new kernel command line list format. #1670
+
 ## v4.6.0rc1, 2025-01-29
 
 ### Added

--- a/etc/nodes.conf
+++ b/etc/nodes.conf
@@ -21,7 +21,9 @@ nodeprofiles:
       - wicked
       - ignition
     kernel:
-      args: quiet crashkernel=no
+      args:
+       - quiet
+       - crashkernel=no
     init: /sbin/init
     root: initramfs
     ipxe template: default


### PR DESCRIPTION
## Description of the Pull Request (PR):

The default `etc/nodes.conf` has not been upgraded to use the kernel args list (not string). This PR updates the default.

Without it, the default install gives
``console
vscode ➜ /workspaces/warewulf (tm-make-install) $ wwctl node list
ERROR: yaml: unmarshal errors:
  line 24: cannot unmarshal !!str `quiet c...` into []string
```

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
