### PR TITLE
Fixed negation for slice field elements during profile/node merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `make install` when `sudo` does not set `$PWD`. #1660
 - Use sh to parse and exec IPMI command. #1663
 - Use configured warewulf.conf path in `wwctl upgrade`. #1658
+- Fixed negation for slice field elements during profile/node merge. #1677
 
 ## v4.6.0rc1, 2025-01-29
 

--- a/internal/app/wwctl/node/list/main_test.go
+++ b/internal/app/wwctl/node/list/main_test.go
@@ -267,7 +267,7 @@ nodes:
 `,
 		},
 		{
-			name:    "multiple overlays list long with negation",
+			name:    "multiple overlays list long",
 			args:    []string{"-l"},
 			wantErr: false,
 			stdout: `
@@ -287,13 +287,13 @@ nodes:
 `,
 		},
 		{
-			name:    "multiple overlays list long",
+			name:    "multiple overlays list long with negation",
 			args:    []string{"-l"},
 			wantErr: false,
 			stdout: `
 NODE NAME  KERNEL VERSION  IMAGE  OVERLAYS (S/R)
 ---------  --------------  -----  --------------
-n01        --              --     sop1/rop1,rop2,nop1,~rop1
+n01        --              --     sop1/rop2,nop1
 `,
 			inDb: `nodeprofiles:
   p1:

--- a/internal/pkg/node/constructors_test.go
+++ b/internal/pkg/node/constructors_test.go
@@ -214,7 +214,7 @@ nodes:
 	assert.Contains(nodemap, "node4")
 	assert.ElementsMatch(nodemap["node4"].RuntimeOverlay, []string{"p1o1", "p1o2", "p2o1", "p2o2", "n1o1", "n1o2"})
 	assert.Contains(nodemap, "node5")
-	assert.ElementsMatch(nodemap["node5"].RuntimeOverlay, []string{"p1o1", "p1o2", "~p1o2", "p2o1", "p2o2", "n1o1"})
+	assert.ElementsMatch(nodemap["node5"].RuntimeOverlay, []string{"p1o1", "p2o1", "p2o2", "n1o1"})
 }
 
 func Test_negated_list(t *testing.T) {

--- a/internal/pkg/node/mergo.go
+++ b/internal/pkg/node/mergo.go
@@ -153,6 +153,7 @@ func (config *NodesYaml) MergeNode(id string) (node Node, fields fieldMap, err e
 	node.id = id
 	node.valid = true
 	node.updatePrimaryNetDev()
+	node.Profile.cleanLists()
 	return node, fields, nil
 }
 

--- a/internal/pkg/node/methods.go
+++ b/internal/pkg/node/methods.go
@@ -382,6 +382,15 @@ func negList(list []string) (ret []string) {
 	return
 }
 
+func (p *Profile) cleanLists() {
+	p.Profiles = cleanList(p.Profiles)
+	p.SystemOverlay = cleanList(p.SystemOverlay)
+	p.RuntimeOverlay = cleanList(p.RuntimeOverlay)
+	if p.Kernel != nil {
+		p.Kernel.Args = cleanList(p.Kernel.Args)
+	}
+}
+
 // clean a list from negated tokens
 func cleanList(list []string) (ret []string) {
 	neg := negList(list)


### PR DESCRIPTION
## Description of the Pull Request (PR):

The new `MergeNode` code broke support for slice element negation for fields other than "profiles." This PR restores that functionality.


## This fixes or addresses the following GitHub issues:

- Fixes: #1677


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
