### PR TITLE
Don't populate NetDevs[].Type or NetDevs[].Netmask during upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed negation for slice field elements during profile/node merge. #1677
 - Show each overlay only once, even when both site and distribution versions exist. #1675
 - Remove a redundant "Building image" log message after image exec. #1694
+- Don't populate NetDevs[].Type or NetDevs[].Netmask during upgrade. #1661
 
 ## v4.6.0rc1, 2025-01-29
 

--- a/internal/pkg/node/mergo_test.go
+++ b/internal/pkg/node/mergo_test.go
@@ -885,6 +885,22 @@ nodes:
 			fieldValues: []string{"ro1,ro2,~ro1,ro3", "so1,so2,so4,~so2"},
 			sources:     []string{"default,n1", "default,n1"},
 		},
+		"netmask inheritance": {
+			nodesConf: `
+nodeprofiles:
+  p1:
+    network devices:
+      default:
+        netmask: 255.255.255.0
+nodes:
+  n1:
+    profiles:
+    - p1`,
+			node:   "n1",
+			field:  "NetDevs[default].Netmask",
+			source: "p1",
+			value:  "255.255.255.0",
+		},
 	}
 
 	for name, tt := range tests {

--- a/internal/pkg/upgrade/node.go
+++ b/internal/pkg/upgrade/node.go
@@ -224,7 +224,15 @@ func (this *Node) Upgrade(addDefaults bool, replaceOverlays bool) (upgraded *nod
 	}
 	if this.NetDevs != nil {
 		for name, netDev := range this.NetDevs {
-			upgraded.NetDevs[name] = netDev.Upgrade(addDefaults)
+			upgraded.NetDevs[name] = netDev.Upgrade(false)
+			if addDefaults {
+				if upgraded.NetDevs[name].Type == "" {
+					wwlog.Warn("NetDevs[%s].Type not specified: verify default settings manually", name)
+				}
+				if len(upgraded.NetDevs[name].Netmask) == 0 {
+					wwlog.Warn("NetDevs[%s].Netmask not specified: verify default settings manually", name)
+				}
+			}
 		}
 	}
 	if this.PrimaryNetDev != "" {
@@ -630,7 +638,7 @@ func (this *NetDev) Upgrade(addDefaults bool) (upgraded *node.NetDev) {
 			upgraded.Type = "ethernet"
 		}
 		if upgraded.Netmask == nil {
-			upgraded.Netmask = net.ParseIP("255.255.255.0")
+			upgraded.Netmask = net.IP{255, 255, 255, 0}
 		}
 	}
 	return

--- a/internal/pkg/upgrade/node_test.go
+++ b/internal/pkg/upgrade/node_test.go
@@ -558,9 +558,7 @@ nodes:
       - default
     network devices:
       default:
-        type: ethernet
         ipaddr: 192.168.0.100
-        netmask: 255.255.255.0
 `,
 	},
 	{
@@ -589,7 +587,6 @@ nodes:
     network devices:
       default:
         ipaddr: 10.0.0.100
-        netmask: 255.255.0.0
 `,
 		upgradedYaml: `
 nodeprofiles:
@@ -625,13 +622,11 @@ nodes:
       - custom
     network devices:
       default:
-        type: ethernet
         ipaddr: 10.0.0.100
-        netmask: 255.255.0.0
 `,
 	},
 	{
-		name:            "add defaults conflicts",
+		name:            "replace overlays conflicts",
 		addDefaults:     false,
 		replaceOverlays: true,
 		legacyYaml: `


### PR DESCRIPTION
## Description of the Pull Request (PR):

NetDev defaults don't behave quite the same as standard fields, because they need to be set per-device. Meanwhile, trying to set a value may erroneously override values that are on the default profile.

Switch this to a warning rather than attempting to take explicit action.


## This fixes or addresses the following GitHub issues:

- Closes: #1661


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
