### PR TITLE
Document commas in kernel arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## v4.6.0, unreleased
 
+### Added
+
+- Document defining kernel args that include commas. #1679
+
 ### Fixed
 
 - Fix default nodes.conf to use the new kernel command line list format. #1670

--- a/userdocs/contents/nodeconfig.rst
+++ b/userdocs/contents/nodeconfig.rst
@@ -128,7 +128,7 @@ see a list of all configuration attributes, use the command ``wwctl
 node set --help``.
 
 Configuring the Node's Image
-============================
+----------------------------
 
 .. code-block:: console
 
@@ -293,6 +293,18 @@ nodes are sorted lexically, first by cluster, then by ID.)
 
 Once a node has been discovered its "discoverable" flag is
 automatically cleared.
+
+Setting list values
+===================
+
+Some node fields, such as overlays and kernel args, accept a list of values.
+These may be specified as a comma-separated list or as multiple arguments.
+
+To include an explicit comma in the value, enclose the value in inner-quotes.
+
+.. code-block:: console
+
+   # wwctl profile set default --kernelargs 'quiet,crashkernel=no,nosplash' --kernelargs='"console=ttyS0,115200"'
 
 Un-setting Node Attributes
 ==========================


### PR DESCRIPTION
## Description of the Pull Request (PR):

Turns out we already support commas in list values by enclosing the value in quotes.

```
# wwctl profile set default --kernelargs 'quiet,crashkernel=no,nosplash' --kernelargs='"console=ttyS0,115200"'
? Are you sure you want to modify 1 profile(s)? [y/N] y█
# wwctl profile list -a default | grep 'Kernel\.Args'
default  Kernel.Args               quiet,crashkernel=no,nosplash,console=ttyS0,115200
```


## This fixes or addresses the following GitHub issues:

- Closes: #1679


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
