### PR TITLE
Show each overlay only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use sh to parse and exec IPMI command. #1663
 - Use configured warewulf.conf path in `wwctl upgrade`. #1658
 - Fixed negation for slice field elements during profile/node merge. #1677
+- Show each overlay only once, even when both site and distribution versions exist. #1675
 
 ## v4.6.0rc1, 2025-01-29
 

--- a/internal/app/wwctl/node/add/root.go
+++ b/internal/app/wwctl/node/add/root.go
@@ -44,13 +44,13 @@ func GetCommand() *cobra.Command {
 		log.Println(err)
 	}
 	if err := baseCmd.RegisterFlagCompletionFunc("runtime", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		list, _ := overlay.FindOverlays()
+		list := overlay.FindOverlays()
 		return list, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		log.Println(err)
 	}
 	if err := baseCmd.RegisterFlagCompletionFunc("wwinit", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		list, _ := overlay.FindOverlays()
+		list := overlay.FindOverlays()
 		return list, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		log.Println(err)

--- a/internal/app/wwctl/node/set/root.go
+++ b/internal/app/wwctl/node/set/root.go
@@ -60,13 +60,13 @@ func GetCommand() *cobra.Command {
 		log.Println(err)
 	}
 	if err := baseCmd.RegisterFlagCompletionFunc("runtime", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		list, _ := overlay.FindOverlays()
+		list := overlay.FindOverlays()
 		return list, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		log.Println(err)
 	}
 	if err := baseCmd.RegisterFlagCompletionFunc("wwinit", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		list, _ := overlay.FindOverlays()
+		list := overlay.FindOverlays()
 		return list, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		log.Println(err)

--- a/internal/app/wwctl/overlay/build/root.go
+++ b/internal/app/wwctl/overlay/build/root.go
@@ -39,7 +39,7 @@ func init() {
 	baseCmd.PersistentFlags().StringSliceVarP(&OverlayNames, "overlay", "O", []string{}, "Build only specific overlay(s)")
 
 	if err := baseCmd.RegisterFlagCompletionFunc("overlay", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		list, _ := overlay.FindOverlays()
+		list := overlay.FindOverlays()
 		return list, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		log.Println(err)

--- a/internal/app/wwctl/overlay/chmod/root.go
+++ b/internal/app/wwctl/overlay/chmod/root.go
@@ -16,7 +16,7 @@ var (
 		Args:                  cobra.ExactArgs(3),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
-				list, _ := overlay.FindOverlays()
+				list := overlay.FindOverlays()
 				return list, cobra.ShellCompDirectiveNoFileComp
 			} else if len(args) == 1 {
 				ret, err := overlay.OverlayGetFiles(args[0])

--- a/internal/app/wwctl/overlay/chown/root.go
+++ b/internal/app/wwctl/overlay/chown/root.go
@@ -15,7 +15,7 @@ var (
 		Args:                  cobra.RangeArgs(3, 4),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
-				list, _ := overlay.FindOverlays()
+				list := overlay.FindOverlays()
 				return list, cobra.ShellCompDirectiveNoFileComp
 			} else if len(args) == 1 {
 				ret, err := overlay.OverlayGetFiles(args[0])

--- a/internal/app/wwctl/overlay/delete/root.go
+++ b/internal/app/wwctl/overlay/delete/root.go
@@ -16,7 +16,7 @@ var (
 		Aliases:               []string{"rm", "remove", "del"},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
-				list, _ := overlay.FindOverlays()
+				list := overlay.FindOverlays()
 				return list, cobra.ShellCompDirectiveNoFileComp
 			} else if len(args) == 1 {
 				ret, err := overlay.OverlayGetFiles(args[0])

--- a/internal/app/wwctl/overlay/edit/root.go
+++ b/internal/app/wwctl/overlay/edit/root.go
@@ -15,7 +15,7 @@ var (
 		Args:                  cobra.ExactArgs(2),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
-				list, _ := overlay.FindOverlays()
+				list := overlay.FindOverlays()
 				return list, cobra.ShellCompDirectiveNoFileComp
 			} else if len(args) == 1 {
 				ret, err := overlay.OverlayGetFiles(args[0])

--- a/internal/app/wwctl/overlay/imprt/root.go
+++ b/internal/app/wwctl/overlay/imprt/root.go
@@ -20,7 +20,7 @@ var (
 			if len(args) != 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
-			list, _ := overlay.FindOverlays()
+			list := overlay.FindOverlays()
 			return list, cobra.ShellCompDirectiveNoFileComp
 		},
 	}

--- a/internal/app/wwctl/overlay/list/main.go
+++ b/internal/app/wwctl/overlay/list/main.go
@@ -1,7 +1,6 @@
 package list
 
 import (
-	"fmt"
 	"os"
 	"syscall"
 
@@ -18,11 +17,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		overlays = args
 	} else {
-		var err error
-		overlays, err = overlay.FindOverlays()
-		if err != nil {
-			return fmt.Errorf("could not obtain list of overlays from system: %w", err)
-		}
+		overlays = overlay.FindOverlays()
 	}
 
 	t := table.New(cmd.OutOrStdout())

--- a/internal/app/wwctl/overlay/list/root.go
+++ b/internal/app/wwctl/overlay/list/root.go
@@ -18,7 +18,7 @@ var (
 			if len(args) != 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
-			list, _ := overlay.FindOverlays()
+			list := overlay.FindOverlays()
 			return list, cobra.ShellCompDirectiveNoFileComp
 		},
 	}

--- a/internal/app/wwctl/overlay/show/root.go
+++ b/internal/app/wwctl/overlay/show/root.go
@@ -19,7 +19,7 @@ var (
 		Args:                  cobra.ExactArgs(2),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
-				list, _ := overlay.FindOverlays()
+				list := overlay.FindOverlays()
 				return list, cobra.ShellCompDirectiveNoFileComp
 			} else if len(args) == 1 {
 				ret, err := overlay.OverlayGetFiles(args[0])

--- a/internal/app/wwctl/profile/add/root.go
+++ b/internal/app/wwctl/profile/add/root.go
@@ -43,13 +43,13 @@ func GetCommand() *cobra.Command {
 		log.Println(err)
 	}
 	if err := baseCmd.RegisterFlagCompletionFunc("runtime", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		list, _ := overlay.FindOverlays()
+		list := overlay.FindOverlays()
 		return list, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		log.Println(err)
 	}
 	if err := baseCmd.RegisterFlagCompletionFunc("wwinit", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		list, _ := overlay.FindOverlays()
+		list := overlay.FindOverlays()
 		return list, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		log.Println(err)

--- a/internal/app/wwctl/profile/set/root.go
+++ b/internal/app/wwctl/profile/set/root.go
@@ -65,13 +65,13 @@ func GetCommand() *cobra.Command {
 		log.Println(err)
 	}
 	if err := baseCmd.RegisterFlagCompletionFunc("runtime", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		list, _ := overlay.FindOverlays()
+		list := overlay.FindOverlays()
 		return list, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		log.Println(err)
 	}
 	if err := baseCmd.RegisterFlagCompletionFunc("wwinit", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		list, _ := overlay.FindOverlays()
+		list := overlay.FindOverlays()
 		return list, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		log.Println(err)

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -205,25 +205,29 @@ func BuildHostOverlay() error {
 /*
 Get all overlays present in warewulf
 */
-func FindOverlays() (overlayList []string, err error) {
+func FindOverlays() (overlayList []string) {
 	dotfilecheck, _ := regexp.Compile(`^\..*`)
 	controller := config.Get()
 	var files []fs.DirEntry
-	if distfiles, err := os.ReadDir(controller.Paths.DistributionOverlaydir()); err == nil {
+	if distfiles, err := os.ReadDir(controller.Paths.DistributionOverlaydir()); err != nil {
+		wwlog.Warn("error reading overlays from %s: %s", controller.Paths.DistributionOverlaydir(), err)
+	} else {
 		files = append(files, distfiles...)
 	}
-	if sitefiles, err := os.ReadDir(path.Join(controller.Paths.SiteOverlaydir())); err == nil {
+	if sitefiles, err := os.ReadDir(controller.Paths.SiteOverlaydir()); err != nil {
+		wwlog.Warn("error reading overalys from %s: %s", controller.Paths.SiteOverlaydir(), err)
+	} else {
 		files = append(files, sitefiles...)
 	}
 	for _, file := range files {
 		wwlog.Debug("Evaluating overlay source: %s", file.Name())
 		isdotfile := dotfilecheck.MatchString(file.Name())
 
-		if (file.IsDir()) && !(isdotfile) {
+		if file.IsDir() && !isdotfile && !util.InSlice(overlayList, file.Name()) {
 			overlayList = append(overlayList, file.Name())
 		}
 	}
-	return overlayList, nil
+	return overlayList
 }
 
 /*


### PR DESCRIPTION
## Description of the Pull Request (PR):

When an overlay exists as both a distribution and a site overlay, only show the overlay in the list once.


## This fixes or addresses the following GitHub issues:

- Fixes #1675


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
