### PR TITLE
Prefer parent profile values over child profile values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show each overlay only once, even when both site and distribution versions exist. #1675
 - Remove a redundant "Building image" log message after image exec. #1694
 - Don't populate NetDevs[].Type or NetDevs[].Netmask during upgrade. #1661
+- Prefer parent profile values over child profile values. #1672
 
 ## v4.6.0rc1, 2025-01-29
 

--- a/internal/pkg/node/mergo_test.go
+++ b/internal/pkg/node/mergo_test.go
@@ -82,7 +82,7 @@ nodeprofiles:
     profiles:
     - p2`,
 			node:     "n1",
-			profiles: []string{"p1", "p2"},
+			profiles: []string{"p2", "p1"},
 		},
 		"double nested profile": {
 			nodesConf: `
@@ -98,7 +98,25 @@ nodeprofiles:
     profiles:
     - p3`,
 			node:     "n1",
-			profiles: []string{"p1", "p2", "p3"},
+			profiles: []string{"p3", "p2", "p1"},
+		},
+		"double negated profile": {
+			nodesConf: `
+nodes:
+  n1:
+    profiles:
+    - p1
+    - p2
+    - p3
+nodeprofiles:
+  p2:
+    profiles:
+    - ~p1
+  p3:
+    profiles:
+    - ~p1`,
+			node:     "n1",
+			profiles: []string{"p2", "p3"},
 		},
 		"negated nested profile": {
 			nodesConf: `
@@ -106,18 +124,22 @@ nodes:
   n1:
     profiles:
     - p1
+    - p4
 nodeprofiles:
   p1:
     profiles:
     - p2
   p2:
     profiles:
-    - "~p2"
-    - p3`,
+    - p3
+  p3: {}
+  p4:
+    profiles:
+    - ~p2`,
 			node:     "n1",
-			profiles: []string{"p1", "p3"},
+			profiles: []string{"p3", "p1", "p4"},
 		},
-		"cicular nested profile": {
+		"circular nested profile": {
 			nodesConf: `
 nodes:
   n1:
@@ -134,9 +156,9 @@ nodeprofiles:
     profiles:
     - p1`,
 			node:     "n1",
-			profiles: []string{"p1", "p2", "p3"},
+			profiles: []string{"p3", "p2", "p1"},
 		},
-		"cicular nested profile negation": {
+		"circular nested profile negation": {
 			nodesConf: `
 nodes:
   n1:
@@ -154,7 +176,7 @@ nodeprofiles:
     profiles:
     - p1`,
 			node:     "n1",
-			profiles: []string{"p2", "p3", "p1"},
+			profiles: []string{"p3", "p2"},
 		},
 		"repeated nested profile": {
 			nodesConf: `
@@ -175,7 +197,7 @@ nodeprofiles:
     profiles:
     - pa2`,
 			node:     "n1",
-			profiles: []string{"pa1", "pb1", "pb2", "pa2"},
+			profiles: []string{"pa1", "pb2", "pb1"},
 		},
 	}
 
@@ -280,6 +302,24 @@ nodeprofiles:
 			field:  "Comment",
 			source: "SUPERSEDED",
 			value:  "n1 comment",
+		},
+		"nested profile comments": {
+			nodesConf: `
+nodes:
+  n1:
+    profiles:
+    - p2
+nodeprofiles:
+  p1:
+    comment: p1 comment
+  p2:
+    profiles:
+    - p1
+    comment: p2 comment`,
+			node:   "n1",
+			field:  "Comment",
+			source: "p2",
+			value:  "p2 comment",
 		},
 		"node kernel args": {
 			nodesConf: `


### PR DESCRIPTION
## Description of the Pull Request (PR):

getNodeProfiles was misordering nested profiles, leading to child values taking precedence over parent values.


## This fixes or addresses the following GitHub issues:

- Fixes: #1672


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
