### PR TITLE
Don't attempt to back-up an output file that doesn't exist during upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove a redundant "Building image" log message after image exec. #1694
 - Don't populate NetDevs[].Type or NetDevs[].Netmask during upgrade. #1661
 - Prefer parent profile values over child profile values. #1672
+- Don't attempt to back-up an output file that doesn't exist during upgrade. #1671
 
 ## v4.6.0rc1, 2025-01-29
 

--- a/internal/app/wwctl/upgrade/config/cobra.go
+++ b/internal/app/wwctl/upgrade/config/cobra.go
@@ -54,8 +54,10 @@ func UpgradeNodesConf(cmd *cobra.Command, args []string) error {
 		fmt.Print(string(upgradedYaml))
 		return nil
 	} else {
-		if err := util.CopyFile(outputPath, outputPath+"-old"); err != nil {
-			return err
+		if util.IsFile(outputPath) {
+			if err := util.CopyFile(outputPath, outputPath+"-old"); err != nil {
+				return err
+			}
 		}
 		return upgraded.PersistToFile(outputPath)
 	}

--- a/internal/app/wwctl/upgrade/nodes/cobra.go
+++ b/internal/app/wwctl/upgrade/nodes/cobra.go
@@ -81,8 +81,10 @@ func UpgradeNodesConf(cmd *cobra.Command, args []string) error {
 		fmt.Print(string(upgradedYaml))
 		return nil
 	} else {
-		if err := util.CopyFile(outputPath, outputPath+"-old"); err != nil {
-			return err
+		if util.IsFile(outputPath) {
+			if err := util.CopyFile(outputPath, outputPath+"-old"); err != nil {
+				return err
+			}
 		}
 		return upgraded.PersistToFile(outputPath)
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

`wwctl upgrade` copies outputFile to outputFile-old before over-writing; but it was trying to do this even when outputFile didn't exist, causing an error.


## This fixes or addresses the following GitHub issues:

- Fixes: #1671


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
