### PR TITLE
wwctl node list <--yaml|--json> outputs a map keyed by node name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Document defining kernel args that include commas. #1679
 - Recommend installing ipmitool with Warewulf package. #970
+### Changed
+
+- `wwctl node list <--yaml|--json>` outputs a map keyed by node name. #1667
 
 ### Fixed
 

--- a/internal/app/wwctl/node/list/main_test.go
+++ b/internal/app/wwctl/node/list/main_test.go
@@ -428,8 +428,9 @@ func TestListMultipleFormats(t *testing.T) {
 			name: "single node list yaml output",
 			args: []string{"-y"},
 			stdout: `
-- profiles:
-    - default
+n01:
+    profiles:
+        - default
 `,
 			inDb: `
 nodeprofiles:
@@ -444,8 +445,8 @@ nodes:
 			name: "single node list json output",
 			args: []string{"-j"},
 			stdout: `
-[
-  {
+{
+  "n01": {
     "Discoverable": "",
     "AssetKey": "",
     "Profiles": [
@@ -468,7 +469,7 @@ nodes:
     "FileSystems": null,
     "Resources": null
   }
-]
+}
 `,
 			inDb: `
 nodeprofiles:
@@ -483,8 +484,8 @@ nodes:
 			name: "multiple nodes list json output",
 			args: []string{"-j"},
 			stdout: `
-[
-  {
+{
+  "n01": {
     "Discoverable": "",
     "AssetKey": "",
     "Profiles": [
@@ -507,7 +508,7 @@ nodes:
     "FileSystems": null,
     "Resources": null
   },
-  {
+  "n02": {
     "Discoverable": "",
     "AssetKey": "",
     "Profiles": [
@@ -530,7 +531,7 @@ nodes:
     "FileSystems": null,
     "Resources": null
   }
-]
+}
 `,
 			inDb: `
 nodeprofiles:
@@ -548,10 +549,12 @@ nodes:
 			name: "multiple nodes list yaml output",
 			args: []string{"-y"},
 			stdout: `
-- profiles:
-    - default
-- profiles:
-    - default
+n01:
+    profiles:
+        - default
+n02:
+    profiles:
+        - default
 `,
 			inDb: `
 nodeprofiles:

--- a/internal/pkg/api/node/list.go
+++ b/internal/pkg/api/node/list.go
@@ -101,13 +101,16 @@ func NodeList(nodeGet *wwapiv1.GetNodeList) (nodeList wwapiv1.NodeList, err erro
 			}
 		}
 	} else if nodeGet.Type == wwapiv1.GetNodeList_YAML || nodeGet.Type == wwapiv1.GetNodeList_JSON {
-		filterNodes := node.FilterNodeListByName(nodes, nodeGet.Nodes)
+		nodeMap := make(map[string]node.Node)
+		for _, n := range node.FilterNodeListByName(nodes, nodeGet.Nodes) {
+			nodeMap[n.Id()] = n
+		}
 		var buf []byte
 		if nodeGet.Type == wwapiv1.GetNodeList_JSON {
-			buf, _ = json.MarshalIndent(filterNodes, "", "  ")
+			buf, _ = json.MarshalIndent(nodeMap, "", "  ")
 		}
 		if nodeGet.Type == wwapiv1.GetNodeList_YAML {
-			buf, _ = yaml.Marshal(filterNodes)
+			buf, _ = yaml.Marshal(nodeMap)
 		}
 		nodeList.Output = append(nodeList.Output, string(buf))
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

The yaml and json output from `wwctl node list` was a simple list of nodes, which did not include the node name / id. This builds a map keyed by the node id and returns that in stead.


## This fixes or addresses the following GitHub issues:

- Fixes: #1667


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
