### PR TITLE
Urlencode asset keys during dracut boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Specify init=/init when booting with Grub+dracut. #1573
 - Fix a warewulfd panic when no kernel fields are specified. #1689
 - Create site overlay directory. #1690
+- Urlencode asset keys during dracut boot. #1610
 
 ## v4.6.0rc1, 2025-01-29
 

--- a/dracut/modules.d/90wwinit/parse-wwinit.sh
+++ b/dracut/modules.d/90wwinit/parse-wwinit.sh
@@ -6,12 +6,9 @@
 if [ "${root}" = "wwinit" ]
 then
     info "root=${root}"
-    uuid=$(dmidecode -s system-uuid)
-    assetkey=$(dmidecode -s chassis-asset-tag | sed -E -e 's/(^ +| +$)//g' -e 's/^(Unknown|Not Specified)$//g' -e 's/ /_/g')
-    wwinit_uri="$(getarg wwinit.uri)?assetkey=${assetkey}&uuid=${uuid}"
-    export wwinit_image="${wwinit_uri}&stage=image&compress=gz"; info "wwinit_image=${wwinit_image}"
-    export wwinit_system="${wwinit_uri}&stage=system&compress=gz"; info "wwinit_system=${wwinit_system}"
-    export wwinit_runtime="${wwinit_uri}&stage=runtime&compress=gz"; info "wwinit_runtime=${wwinit_runtime}"
+    export wwinit_uuid=$(dmidecode -s system-uuid)
+    export wwinit_assetkey=$(dmidecode -s chassis-asset-tag)
+    export wwinit_uri="$(getarg wwinit.uri)"
 
     wwinit_tmpfs_size=$(getarg wwinit.tmpfs.size=)
     if [ -n "$wwinit_tmpfs_size" ]
@@ -20,11 +17,11 @@ then
         export wwinit_tmpfs_size_option="-o size=${wwinit_tmpfs_size}"
     fi
 
-    if [ -n "${wwinit_image}" ]
+    if [ -n "${wwinit_uri}" ]
     then
-        info "Found root=${root} and a Warewulf image. Will boot from Warewulf."
+        info "Found root=${root} and a Warewulf server uri. Will boot from Warewulf."
         rootok=1
     else
-        die "Found root=${root} but no image. Cannot boot from Warewulf."
+        die "Found root=${root} but no Warewulf server uri. Cannot boot from Warewulf."
     fi
 fi

--- a/internal/pkg/warewulfd/provision.go
+++ b/internal/pkg/warewulfd/provision.go
@@ -83,7 +83,7 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 
 	if remoteNode.AssetKey != "" && remoteNode.AssetKey != rinfo.assetkey {
 		w.WriteHeader(http.StatusUnauthorized)
-		wwlog.Denied("Incorrect asset key for node: %s", remoteNode.Id())
+		wwlog.Denied("incorrect asset key: node %s: %s", remoteNode.Id(), rinfo.assetkey)
 		updateStatus(remoteNode.Id(), status_stage, "BAD_ASSET", rinfo.ipaddr)
 		return
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Urlencode the asset tag during dracut boot.


## This fixes or addresses the following GitHub issues:

- Fixes: #1610


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
