### PR TITLE
Don't mount /run during wwinit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Document defining kernel args that include commas. #1679
 
+### Changes
+
+- Don't mount /run during wwinit. #1566
+
 ### Fixed
 
 - Fix default nodes.conf to use the new kernel command line list format. #1670

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -5,13 +5,9 @@
 #
 # Edit at your own risk! DANGER DANGER.
 
-echo -n "Mounting kernel file systems:"
-mkdir /proc /dev /sys /run 2>/dev/null
-mount -t proc proc /proc && echo -n " /proc"
-mount -t devtmpfs devtmpfs /dev && echo -n " /dev"
-mount -t sysfs sysfs /sys && echo -n " /sys"
-mount -t tmpfs tmpfs /run && echo -n " /run"
-echo
+mountpoint -q /proc || (mkdir -p /proc && mount -t proc proc /proc && echo "Mounted /proc")
+mountpoint -q /dev || (mkdir -p /dev && mount -t devtmpfs devtmpfs /dev && echo "Mounted /dev")
+mountpoint -q /sys || (mkdir -p /sys && mount -t sysfs sysfs /sys && echo "Mounted /sys")
 
 if [ -f "/warewulf/config" ]; then
     . /warewulf/config
@@ -35,8 +31,8 @@ elif [ "${WWROOT}" = "ramfs" -o "${WWROOT}" = "tmpfs" ]; then
     echo "Setting up new ${WWROOT} rootfs..."
     mkdir /newroot
     mount wwroot /newroot -t ${WWROOT} -o mpol=interleave # mpol ignored for ramfs
-    tar -cf - --exclude ./proc --exclude ./sys --exclude ./dev --exclude ./run --exclude ./newroot . | tar -xf - -C /newroot
-    mkdir /newroot/proc /newroot/dev /newroot/sys /newroot/run 2>/dev/null
+    tar -cf - --exclude ./proc --exclude ./sys --exclude ./dev --exclude --exclude ./newroot . | tar -xf - -C /newroot
+    mkdir /newroot/proc /newroot/dev /newroot/sys 2>/dev/null
     echo "Switching to new rootfs and invoking /warewulf/wwinit..."
     exec /sbin/switch_root /newroot /warewulf/wwinit
 else


### PR DESCRIPTION
## Description of the Pull Request (PR):

systemd mounts /run itself (and does so redundantly if we do); and it appears we don't depend on /run for anything during wwinit.

Meanwhile, I'm cleaning up the other mounts so they're a bit more reliable.


## This fixes or addresses the following GitHub issues:

- Fixes: #1566


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
