### PR TITLE
Remove a redundant "Building image" log message after image exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use configured warewulf.conf path in `wwctl upgrade`. #1658
 - Fixed negation for slice field elements during profile/node merge. #1677
 - Show each overlay only once, even when both site and distribution versions exist. #1675
+- Remove a redundant "Building image" log message after image exec. #1694
 
 ## v4.6.0rc1, 2025-01-29
 

--- a/internal/app/wwctl/image/exec/main.go
+++ b/internal/app/wwctl/image/exec/main.go
@@ -154,7 +154,6 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if Build {
-		wwlog.Info("Building image: %s", imageName)
 		err = image.Build(imageName, false)
 		if err != nil {
 			return fmt.Errorf("could not build image: %s: %s", imageName, err)


### PR DESCRIPTION
## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
