### PR TITLE
Fix a panic in warewulfd when no kernel fields are specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Document defining kernel args that include commas. #1679
 - Recommend installing ipmitool with Warewulf package. #970
+
 ### Changed
 
 - `wwctl node list <--yaml|--json>` outputs a map keyed by node name. #1667
@@ -31,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Prefer parent profile values over child profile values. #1672
 - Don't attempt to back-up an output file that doesn't exist during upgrade. #1671
 - Specify init=/init when booting with Grub+dracut. #1573
+- Fix a warewulfd panic when no kernel fields are specified. #1689
 
 ## v4.6.0rc1, 2025-01-29
 

--- a/internal/pkg/image/initramfs.go
+++ b/internal/pkg/image/initramfs.go
@@ -66,7 +66,6 @@ func FindInitramfsFromPattern(imageName string, version string, pattern string) 
 			continue
 		} else {
 			initramfs := &Initramfs{Path: filepath.Join("/", path), imageName: imageName}
-			wwlog.Info("%v", initramfs)
 			if strings.HasPrefix(initramfs.Version(), version) {
 				return initramfs
 			}

--- a/internal/pkg/warewulfd/provision.go
+++ b/internal/pkg/warewulfd/provision.go
@@ -98,6 +98,12 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 
 	} else if rinfo.stage == "ipxe" {
 		stage_file = path.Join(conf.Paths.Sysconfdir, "warewulf/ipxe/"+remoteNode.Ipxe+".ipxe")
+		kernelArgs := ""
+		kernelVersion := ""
+		if remoteNode.Kernel != nil {
+			kernelArgs = strings.Join(remoteNode.Kernel.Args, " ")
+			kernelVersion = remoteNode.Kernel.Version
+		}
 		tmpl_data = &templateVars{
 			Id:            remoteNode.Id(),
 			Cluster:       remoteNode.ClusterName,
@@ -107,8 +113,8 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 			Hostname:      remoteNode.Id(),
 			Hwaddr:        rinfo.hwaddr,
 			ImageName:     remoteNode.ImageName,
-			KernelArgs:    strings.Join(remoteNode.Kernel.Args, " "),
-			KernelVersion: remoteNode.Kernel.Version,
+			KernelArgs:    kernelArgs,
+			KernelVersion: kernelVersion,
 			NetDevs:       remoteNode.NetDevs,
 			Tags:          remoteNode.Tags}
 	} else if rinfo.stage == "kernel" {


### PR DESCRIPTION
## This fixes or addresses the following GitHub issues:

- Fixes: #1689


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
