### PR TITLE
Set execute permissions for intermediate directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Specify init=/init when booting with Grub+dracut. #1573
 - Fix a warewulfd panic when no kernel fields are specified. #1689
 - Create site overlay directory. #1690
+- Set execute permissions for intermediate directories during `wwctl overlay import --parents`. #1655
+- Fix log output formatting during overlay build.
 
 ## v4.6.0rc1, 2025-01-29
 

--- a/internal/app/wwctl/overlay/imprt/main.go
+++ b/internal/app/wwctl/overlay/imprt/main.go
@@ -51,11 +51,13 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 			wwlog.Debug("Create dir: %s", parent)
 			srcInfo, err := os.Stat(source)
 			if err != nil {
-				return fmt.Errorf("could not retrieve the stat for file: %s", err)
+				return fmt.Errorf("could not retrieve the stat for file: %w", err)
 			}
-			err = os.MkdirAll(parent, srcInfo.Mode())
+			mode := srcInfo.Mode()
+			mode |= ((mode & 0444) >> 2) // add execute permission wherever srcInfo has read
+			err = os.MkdirAll(parent, mode)
 			if err != nil {
-				return fmt.Errorf("could not create parent dif: %s: %v", parent, err)
+				return fmt.Errorf("could not create parent dir: %s: %w", parent, err)
 			}
 		}
 	}

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -146,7 +146,7 @@ func BuildSpecificOverlays(nodes []node.Node, allNodes []node.Node, overlayNames
 	var wg sync.WaitGroup
 	worker := func() {
 		for n := range nodeChan {
-			wwlog.Info("Building overlay for %s: %v", n, overlayNames)
+			wwlog.Info("Building overlay for %s: %v", n.Id(), overlayNames)
 			for _, overlayName := range overlayNames {
 				err := BuildOverlay(n, allNodes, "", []string{overlayName})
 				if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

Sets execute permissions on directories during `wwctl overlay import --parents` to match read permissions from the source.


## This fixes or addresses the following GitHub issues:

- Fixes: #1655


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
