### PR TITLE
Create temporary files in overlay directory during `wwctl overlay edit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `wwctl node list <--yaml|--json>` outputs a map keyed by node name. #1667
 - Don't mount /run during wwinit. #1566
 - Simpler permissions in official RPM packages. #1696
+- Create temporary files in overlay directory during `wwctl overlay edit`. #1473
 
 ### Fixed
 

--- a/internal/app/wwctl/overlay/edit/main.go
+++ b/internal/app/wwctl/overlay/edit/main.go
@@ -48,7 +48,7 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 		return fmt.Errorf("%s does not exist. Use '--parents' option to create automatically", overlayFileDir)
 	}
 
-	tempFile, tempFileErr := os.CreateTemp("", "ww-overlay-edit-")
+	tempFile, tempFileErr := os.CreateTemp(overlay_.Path(), "ww-overlay-edit-")
 	if tempFileErr != nil {
 		return fmt.Errorf("unable to create temporary file for editing: %s", tempFileErr)
 	}


### PR DESCRIPTION
## This fixes or addresses the following GitHub issues:

- Fixes: #1473


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
