### PR TITLE
Remove `warewulf.conf:syslog`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Document defining kernel args that include commas. #1679
 - Recommend installing ipmitool with Warewulf package. #970
 - Add completion for profile list. #1695
+- Add OPTIONS argument for `warewulfd.service`. #1707
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix a warewulfd panic when no kernel fields are specified. #1689
 - Create site overlay directory. #1690
 
+### Removed
+
+- Remove `warewulf.conf:syslog`. #1606
+
 ## v4.6.0rc1, 2025-01-29
 
 ### Added

--- a/docs/man/man5/warewulf.conf.5
+++ b/docs/man/man5/warewulf.conf.5
@@ -104,14 +104,6 @@ Default: true
 .IP
 
 .TP
-\fBsyslog\fP
-
-When true, Warewulf server logs are written to syslog.
-
-Default: false
-.IP
-
-.TP
 \fBdatastore\fP
 
 The location where Warewulf caches and stores OCI data.
@@ -260,7 +252,6 @@ warewulf:
   update interval: 60
   autobuild overlays: true
   host overlay: true
-  syslog: false
   datastore: ""
 dhcp:
   enabled: true

--- a/etc/warewulf.conf
+++ b/etc/warewulf.conf
@@ -5,7 +5,6 @@ warewulf:
   update interval: 60
   autobuild overlays: true
   host overlay: true
-  syslog: false
 dhcp:
   enabled: true
   range start: 10.0.1.1

--- a/include/systemd/warewulfd.service.in
+++ b/include/systemd/warewulfd.service.in
@@ -9,7 +9,7 @@ Type=exec
 EnvironmentFile=-/etc/default/warewulfd
 User=root
 Group=root
-ExecStart=@BINDIR@/wwctl server
+ExecStart=@BINDIR@/wwctl server $OPTIONS
 ExecReload=/bin/kill -HUP "$MAINPID"
 Restart=always
 

--- a/internal/app/wwctl/overlay/show/main_test.go
+++ b/internal/app/wwctl/overlay/show/main_test.go
@@ -34,7 +34,6 @@ warewulf:
   update interval: 60
   autobuild overlays: true
   host overlay: true
-  syslog: true
 dhcp:
   enabled: true
   range start: 192.168.0.100

--- a/internal/pkg/config/buildconfig.go.in
+++ b/internal/pkg/config/buildconfig.go.in
@@ -45,7 +45,6 @@ type WarewulfConf struct {
 	UpdateInterval     int   `yaml:"update interval,omitempty" default:"60"`
 	AutobuildOverlaysP *bool `yaml:"autobuild overlays,omitempty" default:"true"`
 	EnableHostOverlayP *bool `yaml:"host overlay,omitempty" default:"true"`
-	SyslogP            *bool `yaml:"syslog,omitempty" default:"false"`
 	GrubBootP          *bool `yaml:"grubboot,omitempty" default:"false"`
 }
 
@@ -59,10 +58,6 @@ func (this WarewulfConf) AutobuildOverlays() bool {
 
 func (this WarewulfConf) EnableHostOverlay() bool {
 	return BoolP(this.EnableHostOverlayP)
-}
-
-func (this WarewulfConf) Syslog() bool {
-	return BoolP(this.SyslogP)
 }
 
 func (this WarewulfConf) GrubBoot() bool {

--- a/internal/pkg/config/root_test.go
+++ b/internal/pkg/config/root_test.go
@@ -15,7 +15,6 @@ func TestDefaultWarewulfYaml(t *testing.T) {
 	assert.Equal(t, 60, conf.Warewulf.UpdateInterval)
 	assert.True(t, conf.Warewulf.AutobuildOverlays())
 	assert.True(t, conf.Warewulf.EnableHostOverlay())
-	assert.False(t, conf.Warewulf.Syslog())
 
 	assert.True(t, conf.DHCP.Enabled())
 	assert.Equal(t, "default", conf.DHCP.Template)
@@ -80,7 +79,6 @@ warewulf:
   update interval: 60
   autobuild overlays: true
   host overlay: true
-  syslog: false
 dhcp:
   enabled: true
   range start: 192.168.200.50
@@ -121,7 +119,6 @@ image mounts:
 	assert.Equal(t, 60, conf.Warewulf.UpdateInterval)
 	assert.True(t, conf.Warewulf.AutobuildOverlays())
 	assert.True(t, conf.Warewulf.EnableHostOverlay())
-	assert.False(t, conf.Warewulf.Syslog())
 
 	assert.True(t, conf.DHCP.Enabled())
 	assert.Equal(t, "192.168.200.50", conf.DHCP.RangeStart)

--- a/internal/pkg/upgrade/config.go
+++ b/internal/pkg/upgrade/config.go
@@ -106,7 +106,9 @@ func (this *WarewulfConf) Upgrade() (upgraded *config.WarewulfConf) {
 	upgraded.UpdateInterval = this.UpdateInterval
 	upgraded.AutobuildOverlaysP = this.AutobuildOverlays
 	upgraded.EnableHostOverlayP = this.EnableHostOverlay
-	upgraded.SyslogP = this.Syslog
+	if this.Syslog != nil {
+		wwlog.Warn("syslog configuration ignored: all logs now go to stdout/stderr")
+	}
 	upgraded.GrubBootP = this.GrubBoot
 	return upgraded
 }

--- a/internal/pkg/upgrade/config_test.go
+++ b/internal/pkg/upgrade/config_test.go
@@ -150,7 +150,6 @@ warewulf:
   secure: true
   update interval: 60
   autobuild overlays: true
-  syslog: false
 dhcp:
   enabled: true
   template: default
@@ -216,7 +215,6 @@ warewulf:
   update interval: 60
   autobuild overlays: true
   host overlay: true
-  syslog: false
 dhcp:
   enabled: true
   template: default
@@ -281,7 +279,6 @@ warewulf:
   update interval: 60
   autobuild overlays: true
   host overlay: true
-  syslog: false
 dhcp:
   enabled: true
   range start: 192.168.200.50
@@ -360,7 +357,6 @@ warewulf:
   update interval: 60
   autobuild overlays: true
   host overlay: true
-  syslog: false
 dhcp:
   enabled: true
   range start: 10.0.1.1
@@ -454,7 +450,6 @@ warewulf:
   update interval: 60
   autobuild overlays: true
   host overlay: true
-  syslog: false
 dhcp:
   enabled: true
   range start: 10.0.1.1

--- a/internal/pkg/warewulfd/daemon.go
+++ b/internal/pkg/warewulfd/daemon.go
@@ -2,7 +2,6 @@ package warewulfd
 
 import (
 	"fmt"
-	"log/syslog"
 	"os"
 	"os/exec"
 	"strconv"
@@ -10,7 +9,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/util"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -53,22 +51,6 @@ func DaemonInitLogging() error {
 		}
 	} else {
 		wwlog.SetLogLevel(wwlog.INFO)
-	}
-
-	conf := warewulfconf.Get()
-
-	if conf.Warewulf.Syslog() {
-
-		wwlog.Debug("Changing log output to syslog")
-
-		logwriter, err := syslog.New(syslog.LOG_NOTICE, "warewulfd")
-		if err != nil {
-			return fmt.Errorf("Could not create syslog writer: %w", err)
-		}
-
-		wwlog.SetLogFormatter(wwlog.DefaultFormatter)
-		wwlog.SetLogWriter(logwriter)
-
 	}
 
 	loginit = true

--- a/overlays/debug/internal/debug_test.go
+++ b/overlays/debug/internal/debug_test.go
@@ -83,7 +83,6 @@ data from other structures.
 - UpdateInterval: 60
 - AutobuildOverlays: true
 - EnableHostOverlay: true
-- Syslog: false
 
 ### Network
 

--- a/overlays/debug/rootfs/tstruct.md.ww
+++ b/overlays/debug/rootfs/tstruct.md.ww
@@ -25,7 +25,6 @@ data from other structures.
 - UpdateInterval: {{ .Warewulf.UpdateInterval }}
 - AutobuildOverlays: {{ .Warewulf.AutobuildOverlays }}
 - EnableHostOverlay: {{ .Warewulf.EnableHostOverlay }}
-- Syslog: {{ .Warewulf.Syslog }}
 
 ### Network
 

--- a/overlays/fstab/internal/warewulf.conf
+++ b/overlays/fstab/internal/warewulf.conf
@@ -7,7 +7,6 @@ warewulf:
   update interval: 60
   autobuild overlays: true
   host overlay: true
-  syslog: true
 dhcp:
   enabled: true
   range start: 192.168.0.100

--- a/overlays/host/internal/warewulf.conf
+++ b/overlays/host/internal/warewulf.conf
@@ -7,7 +7,6 @@ warewulf:
   update interval: 60
   autobuild overlays: true
   host overlay: true
-  syslog: true
 dhcp:
   enabled: true
   range start: 192.168.0.100

--- a/overlays/host/internal/warewulf.conf-static
+++ b/overlays/host/internal/warewulf.conf-static
@@ -7,7 +7,6 @@ warewulf:
   update interval: 60
   autobuild overlays: true
   host overlay: true
-  syslog: true
 dhcp:
   enabled: true
   template: static

--- a/overlays/hosts/internal/warewulf.conf
+++ b/overlays/hosts/internal/warewulf.conf
@@ -7,7 +7,6 @@ warewulf:
   update interval: 60
   autobuild overlays: true
   host overlay: true
-  syslog: true
 dhcp:
   enabled: true
   range start: 192.168.0.100

--- a/overlays/wwinit/internal/warewulf.conf
+++ b/overlays/wwinit/internal/warewulf.conf
@@ -7,7 +7,6 @@ warewulf:
   update interval: 60
   autobuild overlays: true
   host overlay: true
-  syslog: true
 dhcp:
   enabled: true
   range start: 192.168.0.100

--- a/overlays/wwinit/internal/wwinit_test.go
+++ b/overlays/wwinit/internal/wwinit_test.go
@@ -66,7 +66,6 @@ warewulf:
   update interval: 60
   autobuild overlays: true
   host overlay: true
-  syslog: true
 dhcp:
   enabled: true
   range start: 192.168.0.100

--- a/userdocs/contents/configuration.rst
+++ b/userdocs/contents/configuration.rst
@@ -23,7 +23,6 @@ Warewulf (4.6.0):
      update interval: 60
      autobuild overlays: true
      host overlay: true
-     syslog: false
    dhcp:
      enabled: true
      range start: 10.0.1.1
@@ -110,9 +109,6 @@ explained as follows:
   ``host`` overlay is applied to the Warewulf server during
   configuration. (The host overlay is used to configure the dependent
   services.)
-
-* ``warewulf:syslog``: This determines whether Warewulf server logs go
-  to syslog.
 
 * ``nfs:export paths``: Warewulf can automatically set up these NFS
   exports.

--- a/userdocs/contents/troubleshooting.rst
+++ b/userdocs/contents/troubleshooting.rst
@@ -1,6 +1,23 @@
 Troubleshooting
 ===============
 
+warewulfd
+---------
+
+The Warewulf server (``warewulfd``) sends logs to the systemd journal.
+
+.. code-block::
+
+   journalctl -u warewulfd.service
+
+To increase the verbosity of the log, specify either ``--verbose`` or
+``--debug`` in the warewulfd OPTIONS.
+
+.. code-block::
+
+   echo "OPTIONS=--debug" >>/etc/default/warewulfd
+   systemctl restart warewulfd.service
+
 iPXE
 ----
 

--- a/userdocs/contributing/development-environment-vagrant.rst
+++ b/userdocs/contributing/development-environment-vagrant.rst
@@ -199,7 +199,6 @@ Vagrantfile
       update interval: 60
       autobuild overlays: true
       host overlay: true
-      syslog: false
     dhcp:
       enabled: true
       range start: 192.168.200.50

--- a/userdocs/quickstart/debian12.rst
+++ b/userdocs/quickstart/debian12.rst
@@ -74,7 +74,6 @@ address of your cluster's private network interface:
 	  update interval: 60
 	  autobuild overlays: true
 	  host overlay: true
-	  syslog: false
 	dhcp:
 	  enabled: true
 	  range start: 192.168.200.50

--- a/userdocs/quickstart/el.rst
+++ b/userdocs/quickstart/el.rst
@@ -67,7 +67,6 @@ address of your cluster's private network interface.
      update interval: 60
      autobuild overlays: true
      host overlay: true
-     syslog: false
      datastore: /usr/share
      grubboot: false
    dhcp:

--- a/userdocs/quickstart/suse15.rst
+++ b/userdocs/quickstart/suse15.rst
@@ -55,7 +55,6 @@ address of your cluster's private network interface:
       update interval: 60
       autobuild overlays: true
       host overlay: true
-      syslog: false
     dhcp:
       enabled: true
       range start: 192.168.200.50


### PR DESCRIPTION
## Description of the Pull Request (PR):

Removes the syslog configuration to send all log data to stdout/stderr (for receipt by the systemd journal).


## This fixes or addresses the following GitHub issues:

- Fixes: #1606


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
