### PR TITLE
Re-order SSH key types to make ed25519 default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Don't mount /run during wwinit. #1566
 - Simpler permissions in official RPM packages. #1696
 - Create temporary files in overlay directory during `wwctl overlay edit`. #1473
+- Re-order SSH key types to make ed25519 default. #981
 
 ### Fixed
 

--- a/etc/warewulf.conf
+++ b/etc/warewulf.conf
@@ -33,7 +33,7 @@ image mounts:
     readonly: true
 ssh:
   key types:
+    - ed25519
+    - ecdsa
     - rsa
     - dsa
-    - ecdsa
-    - ed25519

--- a/internal/pkg/config/ssh.go
+++ b/internal/pkg/config/ssh.go
@@ -1,5 +1,5 @@
 package config
 
 type SSHConf struct {
-	KeyTypes []string `yaml:"key types,omitempty" default:"[\"rsa\",\"dsa\",\"ecdsa\",\"ed25519\"]"`
+	KeyTypes []string `yaml:"key types,omitempty" default:"[\"ed25519\",\"ecdsa\",\"rsa\",\"dsa\"]"`
 }

--- a/internal/pkg/configure/ssh.go
+++ b/internal/pkg/configure/ssh.go
@@ -6,6 +6,7 @@ import (
 	"path"
 
 	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
+	"github.com/warewulf/warewulf/internal/pkg/overlay"
 	"github.com/warewulf/warewulf/internal/pkg/util"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
@@ -18,6 +19,15 @@ func SSH(keyTypes ...string) error {
 	if os.Getuid() == 0 {
 		fmt.Printf("Updating system keys\n")
 		conf := warewulfconf.Get()
+
+		if conf.Warewulf.EnableHostOverlay() {
+			if err := overlay.BuildHostOverlay(); err != nil {
+				wwlog.Warn("host overlay could not be built: %s", err)
+			}
+		} else {
+			wwlog.Info("host overlays are disabled")
+		}
+
 		wwkeydir := path.Join(conf.Paths.Sysconfdir, "warewulf/keys") + "/"
 
 		err := os.MkdirAll(path.Join(conf.Paths.Sysconfdir, "warewulf/keys"), 0755)

--- a/overlays/debug/internal/debug_test.go
+++ b/overlays/debug/internal/debug_test.go
@@ -109,11 +109,11 @@ data from other structures.
 
 ### SSH
 - Key types:
+  - ed25519
+  - ecdsa
   - rsa
   - dsa
-  - ecdsa
-  - ed25519
-- First key type: rsa
+- First key type: ed25519
 
 ## Node
 

--- a/overlays/host/internal/host_test.go
+++ b/overlays/host/internal/host_test.go
@@ -313,7 +313,7 @@ Filename: etc/profile.d/ssh_setup.csh
 if ( ( $_UID > 500 || $_UID == 0 ) && ( ! -f "$HOME/.ssh/config" && ! -f "$HOME/.ssh/cluster" ) ) then
     echo "Configuring SSH for cluster access"
     install -d -m 700 $HOME/.ssh
-    ssh-keygen -t rsa -f $HOME/.ssh/cluster -N '' -C "Warewulf Cluster key" >& /dev/null
+    ssh-keygen -t ed25519 -f $HOME/.ssh/cluster -N '' -C "Warewulf Cluster key" >& /dev/null
     cat $HOME/.ssh/cluster.pub >>! $HOME/.ssh/authorized_keys
     chmod 0600 $HOME/.ssh/authorized_keys
 
@@ -347,7 +347,7 @@ Filename: etc/profile.d/ssh_setup.sh
 if [ $_UID -ge 500 -o $_UID -eq 0 ] && [ ! -f "$HOME/.ssh/config" -a ! -f "$HOME/.ssh/cluster" ]; then
     echo "Configuring SSH for cluster access"
     install -d -m 700 $HOME/.ssh
-    ssh-keygen -t rsa -f $HOME/.ssh/cluster -N '' -C "Warewulf Cluster key" > /dev/null 2>&1
+    ssh-keygen -t ed25519 -f $HOME/.ssh/cluster -N '' -C "Warewulf Cluster key" > /dev/null 2>&1
     cat $HOME/.ssh/cluster.pub >> $HOME/.ssh/authorized_keys
     chmod 0600 $HOME/.ssh/authorized_keys
 

--- a/userdocs/contents/configuration.rst
+++ b/userdocs/contents/configuration.rst
@@ -46,10 +46,10 @@ Warewulf (4.6.0):
        readonly: true
    ssh:
      key types:
+       - ed25519
+       - ecdsa
        - rsa
        - dsa
-       - ecdsa
-       - ed25519
    wwclient:
      port: 0
 
@@ -165,10 +165,10 @@ SSH key types to generate during ``wwctl configure ssh`` may be overridden using
 
    ssh:
      key types:
+       - ed25519
+       - ecdsa
        - rsa
        - dsa
-       - ecdsa
-       - ed25519
 
 Warewulf will generate host keys for each listed key type.
 The first listed key type is used to generate authentication ssh keys.


### PR DESCRIPTION
## Description of the Pull Request (PR):

- Re-orders ssh key types so that ed25519 is first, which causes it to be used by default.
- Builds the host overlay as part of `wwctl configure ssh`.


## This fixes or addresses the following GitHub issues:

- Fixes: #981


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
