### PR TITLE
Prevent merging of zero-value net.IP fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Create site overlay directory. #1690
 - Set execute permissions for intermediate directories during `wwctl overlay import --parents`. #1655
 - Fix log output formatting during overlay build.
+- Prevent merging of zero-value net.IP fields. #1710
 
 ## v4.6.0rc1, 2025-01-29
 

--- a/internal/pkg/node/mergo.go
+++ b/internal/pkg/node/mergo.go
@@ -71,7 +71,7 @@ type Transformer struct{}
 func (t Transformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
 	if typ == reflect.TypeOf(net.IP{}) {
 		return func(dst, src reflect.Value) error {
-			if !src.IsValid() || !src.CanSet() {
+			if !src.IsValid() || src.IsZero() {
 				return nil
 			}
 			dst.Set(src)

--- a/internal/pkg/node/mergo_test.go
+++ b/internal/pkg/node/mergo_test.go
@@ -935,11 +935,14 @@ nodeprofiles:
 nodes:
   n1:
     profiles:
-    - p1`,
-			node:   "n1",
-			field:  "NetDevs[default].Netmask",
-			source: "p1",
-			value:  "255.255.255.0",
+    - p1
+    network devices:
+      default:
+        ipaddr: 192.168.1.1`,
+			nodes:   []string{"n1", "n1"},
+			fields:  []string{"NetDevs[default].Netmask", "NetDevs[default].Ipaddr"},
+			sources: []string{"p1", ""},
+			values:  []string{"255.255.255.0", "192.168.1.1"},
 		},
 	}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

The custom mergo transformer was merging zero-value `net.IP` fields over-top of non-zero `net.IP` fields. This had the result (for example) that a zero-value netmask field on a node took precedence over a non-zero netmask field from a profile.

This PR causes zero `net.IP` values to be skipped during merge.


## This fixes or addresses the following GitHub issues:

- Fixes: #1710


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
