### PR TITLE
Set default for dhcp.template in warewulf.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added missing hostlist support for `wwctl node` and `wwctl overlay build`. #1635
 - Added support for comma-separated hostlist patterns. #1635
+- Added default value for `warewulf.conf:dhcp.template`. #1725
 
 ### Fixed
 
 - Fixed detection of overlay files in `wwctl overlay list --long`.
 - Fixed panics in `wwctl node sensors` and `wwctl node console` when ipmi not configured.
 - Fixed completions for `wwctl` commands.
+- Return "" when NetDev.IpCIDR is empty.
 
 ### Removed
 
 - Removed partial support for regex searches in node and profile lists. #1635
-### Fixed
-
-- Return "" when NetDev.IpCIDR is empty.
 
 ## v4.6.0rc2, 2025-02-07
 

--- a/etc/warewulf.conf
+++ b/etc/warewulf.conf
@@ -10,6 +10,7 @@ dhcp:
   range start: 10.0.1.1
   range end: 10.0.1.255
   systemd name: dhcpd
+  template: default
 tftp:
   enabled: true
   systemd name: tftp


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add a default for the dhcp.template variable used in dhcp.conf.  This removes hacks out of the OpenHPC recipe for Warewulf since configuration is done through `sed` scripts and adding a line is a bit fragile/extra step.

```yaml
dhcp:
  template: dynamic
```

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
