### PR TITLE
Update overlay flags for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - DHCP template generates as much of the subnet and range definition as possible. #1469
+- Updated overlay flags to `wwctl <node|profile> <add|set> [--runtime-overlays|--system-overlays]`. #1495
 
 ## v4.6.0rc2, 2025-02-07
 

--- a/internal/app/wwctl/flags/flags.go
+++ b/internal/app/wwctl/flags/flags.go
@@ -7,6 +7,9 @@ import (
 func AddContainer(cmd *cobra.Command, dest *string) {
 	cmd.Flags().StringVarP(dest, "container", "C", "", "Set image name (backwards-compatibility)")
 	cmd.Flags().Lookup("container").Hidden = true
+	if err := cmd.Flags().MarkDeprecated("container", "use --image instead"); err != nil {
+		panic(err)
+	}
 }
 
 func AddWwinit(cmd *cobra.Command, dest *[]string) {

--- a/internal/app/wwctl/flags/flags.go
+++ b/internal/app/wwctl/flags/flags.go
@@ -8,3 +8,19 @@ func AddContainer(cmd *cobra.Command, dest *string) {
 	cmd.Flags().StringVarP(dest, "container", "C", "", "Set image name (backwards-compatibility)")
 	cmd.Flags().Lookup("container").Hidden = true
 }
+
+func AddWwinit(cmd *cobra.Command, dest *[]string) {
+	cmd.Flags().StringSliceVar(dest, "wwinit", []string{}, "Set the system overlay")
+	cmd.Flags().Lookup("wwinit").Hidden = true
+	if err := cmd.Flags().MarkDeprecated("wwinit", "use --system-overlays instead"); err != nil {
+		panic(err)
+	}
+}
+
+func AddRuntime(cmd *cobra.Command, dest *[]string) {
+	cmd.Flags().StringSliceVar(dest, "runtime", []string{}, "Set the runtime overlay")
+	cmd.Flags().Lookup("runtime").Hidden = true
+	if err := cmd.Flags().MarkDeprecated("runtime", "use --runtime-overlays instead"); err != nil {
+		panic(err)
+	}
+}

--- a/internal/app/wwctl/node/add/root.go
+++ b/internal/app/wwctl/node/add/root.go
@@ -30,6 +30,8 @@ func GetCommand() *cobra.Command {
 	vars.nodeConf.CreateFlags(baseCmd)
 	vars.nodeAdd.CreateAddFlags(baseCmd)
 	flags.AddContainer(baseCmd, &(vars.nodeConf.Profile.ImageName))
+	flags.AddWwinit(baseCmd, &(vars.nodeConf.SystemOverlay))
+	flags.AddRuntime(baseCmd, &(vars.nodeConf.RuntimeOverlay))
 	// register the command line completions
 	if err := baseCmd.RegisterFlagCompletionFunc("image", completions.Images); err != nil { // no limit
 		panic(err)
@@ -37,7 +39,13 @@ func GetCommand() *cobra.Command {
 	if err := baseCmd.RegisterFlagCompletionFunc("kernelversion", completions.NodeKernelVersion); err != nil {
 		panic(err)
 	}
+	if err := baseCmd.RegisterFlagCompletionFunc("runtime-overlays", completions.OverlayList); err != nil {
+		panic(err)
+	}
 	if err := baseCmd.RegisterFlagCompletionFunc("runtime", completions.OverlayList); err != nil {
+		panic(err)
+	}
+	if err := baseCmd.RegisterFlagCompletionFunc("system-overlays", completions.OverlayList); err != nil {
 		panic(err)
 	}
 	if err := baseCmd.RegisterFlagCompletionFunc("wwinit", completions.OverlayList); err != nil {

--- a/internal/app/wwctl/node/set/root.go
+++ b/internal/app/wwctl/node/set/root.go
@@ -34,6 +34,8 @@ func GetCommand() *cobra.Command {
 	vars.nodeAdd.CreateAddFlags(baseCmd)
 	vars.nodeDel.CreateDelFlags(baseCmd)
 	flags.AddContainer(baseCmd, &(vars.nodeConf.Profile.ImageName))
+	flags.AddWwinit(baseCmd, &(vars.nodeConf.SystemOverlay))
+	flags.AddRuntime(baseCmd, &(vars.nodeConf.RuntimeOverlay))
 	baseCmd.PersistentFlags().BoolVarP(&vars.setNodeAll, "all", "a", false, "Set all nodes")
 	baseCmd.PersistentFlags().BoolVarP(&vars.setYes, "yes", "y", false, "Set 'yes' to all questions asked")
 	baseCmd.PersistentFlags().BoolVarP(&vars.setForce, "force", "f", false, "Force configuration (even on error)")
@@ -44,7 +46,13 @@ func GetCommand() *cobra.Command {
 	if err := baseCmd.RegisterFlagCompletionFunc("kernelversion", completions.NodeKernelVersion); err != nil {
 		panic(err)
 	}
+	if err := baseCmd.RegisterFlagCompletionFunc("runtime-overlays", completions.OverlayList); err != nil {
+		panic(err)
+	}
 	if err := baseCmd.RegisterFlagCompletionFunc("runtime", completions.OverlayList); err != nil {
+		panic(err)
+	}
+	if err := baseCmd.RegisterFlagCompletionFunc("system-overlays", completions.OverlayList); err != nil {
 		panic(err)
 	}
 	if err := baseCmd.RegisterFlagCompletionFunc("wwinit", completions.OverlayList); err != nil {

--- a/internal/app/wwctl/profile/add/root.go
+++ b/internal/app/wwctl/profile/add/root.go
@@ -28,6 +28,8 @@ func GetCommand() *cobra.Command {
 	vars.profileConf.CreateFlags(baseCmd)
 	vars.profileAdd.CreateAddFlags(baseCmd)
 	flags.AddContainer(baseCmd, &(vars.profileConf.ImageName))
+	flags.AddWwinit(baseCmd, &(vars.profileConf.SystemOverlay))
+	flags.AddRuntime(baseCmd, &(vars.profileConf.RuntimeOverlay))
 	// register the command line completions
 	if err := baseCmd.RegisterFlagCompletionFunc("image", completions.Images); err != nil { // no limit
 		panic(err)
@@ -35,7 +37,13 @@ func GetCommand() *cobra.Command {
 	if err := baseCmd.RegisterFlagCompletionFunc("kernelversion", completions.ProfileKernelVersion); err != nil {
 		panic(err)
 	}
+	if err := baseCmd.RegisterFlagCompletionFunc("runtime-overlays", completions.OverlayList); err != nil {
+		panic(err)
+	}
 	if err := baseCmd.RegisterFlagCompletionFunc("runtime", completions.OverlayList); err != nil {
+		panic(err)
+	}
+	if err := baseCmd.RegisterFlagCompletionFunc("system-overlays", completions.OverlayList); err != nil {
 		panic(err)
 	}
 	if err := baseCmd.RegisterFlagCompletionFunc("wwinit", completions.OverlayList); err != nil {

--- a/internal/app/wwctl/profile/set/root.go
+++ b/internal/app/wwctl/profile/set/root.go
@@ -40,6 +40,8 @@ func GetCommand() *cobra.Command {
 	vars.profileDel.CreateDelFlags(baseCmd)
 	vars.profileAdd.CreateAddFlags(baseCmd)
 	flags.AddContainer(baseCmd, &(vars.profileConf.ImageName))
+	flags.AddWwinit(baseCmd, &(vars.profileConf.SystemOverlay))
+	flags.AddRuntime(baseCmd, &(vars.profileConf.RuntimeOverlay))
 	baseCmd.PersistentFlags().BoolVarP(&vars.setYes, "yes", "y", false, "Set 'yes' to all questions asked")
 	// register the command line completions
 	if err := baseCmd.RegisterFlagCompletionFunc("image", completions.Images); err != nil { // no limit
@@ -48,7 +50,13 @@ func GetCommand() *cobra.Command {
 	if err := baseCmd.RegisterFlagCompletionFunc("kernelversion", completions.ProfileKernelVersion); err != nil {
 		panic(err)
 	}
+	if err := baseCmd.RegisterFlagCompletionFunc("runtime-overlays", completions.OverlayList); err != nil {
+		panic(err)
+	}
 	if err := baseCmd.RegisterFlagCompletionFunc("runtime", completions.OverlayList); err != nil {
+		panic(err)
+	}
+	if err := baseCmd.RegisterFlagCompletionFunc("system-overlays", completions.OverlayList); err != nil {
 		panic(err)
 	}
 	if err := baseCmd.RegisterFlagCompletionFunc("wwinit", completions.OverlayList); err != nil {

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -42,8 +42,8 @@ type Profile struct {
 	ClusterName    string                 `yaml:"cluster name,omitempty" lopt:"cluster" sopt:"c" comment:"Set cluster group"`
 	ImageName      string                 `yaml:"image name,omitempty" lopt:"image" comment:"Set image name"`
 	Ipxe           string                 `yaml:"ipxe template,omitempty" lopt:"ipxe" comment:"Set the iPXE template name"`
-	RuntimeOverlay []string               `yaml:"runtime overlay,omitempty" lopt:"runtime" sopt:"R" comment:"Set the runtime overlay"`
-	SystemOverlay  []string               `yaml:"system overlay,omitempty" lopt:"wwinit" sopt:"O" comment:"Set the system overlay"`
+	RuntimeOverlay []string               `yaml:"runtime overlay,omitempty" lopt:"runtime-overlays" sopt:"R" comment:"Set the runtime overlay"`
+	SystemOverlay  []string               `yaml:"system overlay,omitempty" lopt:"system-overlays" sopt:"O" comment:"Set the system overlay"`
 	Kernel         *KernelConf            `yaml:"kernel,omitempty"`
 	Ipmi           *IpmiConf              `yaml:"ipmi,omitempty"`
 	Init           string                 `yaml:"init,omitempty" lopt:"init" sopt:"i" comment:"Define the init process to boot the image"`

--- a/userdocs/contents/overlays.rst
+++ b/userdocs/contents/overlays.rst
@@ -211,7 +211,7 @@ from the host to it. This overlay is then combined with the existing overlays.
   # wwctl overlay create welcome
   # wwctl overlay mkdir welcome /etc
   # wwctl overlay import welcome /etc/issue
-  # wwctl profile set default --wwinit=wwinit,wwclient,welcome
+  # wwctl profile set default --system-overlay=wwinit,wwclient,welcome
   ? Are you sure you want to modify 1 profile(s)? [y/N] y
   # wwctl profile list default -a |grep welcome
   default              SystemOverlay      wwinit,wwclient,welcome


### PR DESCRIPTION
## Description of the Pull Request (PR):

Updated overlay flags
    
New flags: `wwctl <node|profile> <add|set> [--runtime-overlays|--system-overlays]`.
    
Previous flags retained hidden, deprecated for backwards-compatibility.

Also marked `--container` flag deprecated, because this syntax wasn't applied when the container -> image refactor was done.


## This fixes or addresses the following GitHub issues:

- Closes: #1495


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
