### PR TITLE
Generates as much of the DHCP subnet as possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Removed partial support for regex searches in node and profile lists. #1635
 
+### Changed
+
+- DHCP template generates as much of the subnet and range definition as possible. #1469
+
 ## v4.6.0rc2, 2025-02-07
 
 ### Added

--- a/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
+++ b/overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww
@@ -46,11 +46,15 @@ if exists user-class and option user-class = "iPXE" {
 }
 {{- end }}
 
-{{- if and .Network .Netmask .Dhcp.RangeStart .Dhcp.RangeEnd }}
+{{- if and .Network .Netmask }}
 subnet {{.Network}} netmask {{.Netmask}} {
     max-lease-time 120;
+{{- if and .Dhcp.RangeStart .Dhcp.RangeEnd }}
     range {{.Dhcp.RangeStart}} {{.Dhcp.RangeEnd}};
+{{- end }}
+{{- if .Ipaddr }}
     next-server {{.Ipaddr}};
+{{- end }}
 }
 {{- end }}
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

If `.Network` and `.Netmask` are defined, generate the subnet.

If `.RangeStart` and `.RangeEnd` are defined, generate the dynamic range.

If `.Ipaddr` is defined, generate "next-server".

This makes it possible to disable just the dynamic range without losing access to the next-server required by static host entries.


## This fixes or addresses the following GitHub issues:

- Closes: #1469


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
