### PR TITLE
Make .ww suffix optional during wwctl overlay show --render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Hide internal `wwctl completion` and `wwctl genconfig` commands. #1716
+- Make .ww suffix optional during `wwctl overlay show --render`. #649
 
 ### Fixed
 

--- a/internal/app/wwctl/overlay/show/main.go
+++ b/internal/app/wwctl/overlay/show/main.go
@@ -26,11 +26,11 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	overlayFile := overlay_.File(fileName)
-	if !util.IsFile(overlayFile) {
-		return fmt.Errorf("file: %s does not exist within overlay", overlayFile)
-	}
 
 	if NodeName == "" {
+		if !util.IsFile(overlayFile) {
+			return fmt.Errorf("%s: %s not found", overlayName, overlayFile)
+		}
 		f, err := os.ReadFile(overlayFile)
 		if err != nil {
 			return err
@@ -39,7 +39,13 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		wwlog.Output("%s", string(f))
 	} else {
 		if !util.IsFile(overlayFile) {
-			return fmt.Errorf("%s is not a file", overlayFile)
+			possibleFile := fmt.Sprintf("%s.ww", overlayFile)
+			if filepath.Ext(overlayFile) != ".ww" && util.IsFile(possibleFile) {
+				wwlog.Debug("found overlay template: %s", possibleFile)
+				overlayFile = possibleFile
+			} else {
+				return fmt.Errorf("%s: %s not found", overlayName, overlayFile)
+			}
 		}
 		if filepath.Ext(overlayFile) != ".ww" {
 			wwlog.Warn("%s lacks the '.ww' suffix, will not be rendered in an overlay", fileName)

--- a/internal/app/wwctl/overlay/show/main_test.go
+++ b/internal/app/wwctl/overlay/show/main_test.go
@@ -127,6 +127,17 @@ nodes:
 		assert.NoError(t, err)
 		assert.Contains(t, buf.String(), "testoverlay")
 	})
+	t.Run("overlay shows overlay without suffix", func(t *testing.T) {
+		baseCmd.SetArgs([]string{"-r", "node1", "testoverlay", "overlay"})
+		baseCmd := GetCommand()
+		buf := new(bytes.Buffer)
+		baseCmd.SetOut(buf)
+		baseCmd.SetErr(buf)
+		wwlog.SetLogWriter(buf)
+		err := baseCmd.Execute()
+		assert.NoError(t, err)
+		assert.Contains(t, buf.String(), "testoverlay")
+	})
 	t.Run("site overlays precede", func(t *testing.T) {
 		baseCmd.SetArgs([]string{"-r", "node1", "dist", "foo.ww"})
 		baseCmd := GetCommand()


### PR DESCRIPTION
## Description of the Pull Request (PR):

Look for an overlay template with a `.ww` suffix if the specified file has no `.ww` suffix and does not exist.


## This fixes or addresses the following GitHub issues:

- Closes: #649


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
