### PR TITLE
create commandline options for Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added `wwctl image build --syncuser`. #1321
 - Added support for a DNSSEARCH netdev tag in network configuration overlays. #1256
 - Added `WW_HISTFILE` to control shell history location during `wwctl image shell`. #1732
+- Added target help in Makefile. #1740
 
 ### Changed
 

--- a/userdocs/quickstart/el.rst
+++ b/userdocs/quickstart/el.rst
@@ -30,7 +30,7 @@ If you prefer, you can also install Warewulf from source.
 
    git clone https://github.com/warewulf/warewulf.git
    cd warewulf
-   make
+   make all
    make install
 
 Configure firewalld

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -129,7 +129,7 @@ make defaults \
     IPXESOURCE=/usr/share/ipxe \
     DRACUTMODDIR=/usr/lib/dracut/modules.d \
     CACHEDIR=%{_localstatedir}/cache
-make
+make build
 %if %{api}
 make api
 %endif


### PR DESCRIPTION
@anderbubble simply checkout this PR and run `make help`
I would like to have this in 4.6.0 (as it doesn't have any functionality) and can 
you document the targets I forgot?

Stolen from the Schedmd people without any shame as syncuser creates so much
pain which we need only for munge

Signed-off-by: Christian Goll <cgoll@suse.com>
