### PR TITLE
Default nfs resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove redundant `wwctl genconfig completions` command. #1716
 - Remove syncuser warning messages in `wwctl` that assume its use. #1321
 - Remove syncuser from the list of default runtime overlays. #1322
+- Removed check for "discoverable" profiles during `wwctl upgrade nodes`.
 
 ## v4.6.0rc2, 2025-02-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added support for a DNSSEARCH netdev tag in network configuration overlays. #1256
 - Added `WW_HISTFILE` to control shell history location during `wwctl image shell`. #1732
 - Added target help in Makefile. #1740
+- Added fstab mounts for `/home` and `/opt` to initial default profile. #1744
 
 ### Changed
 

--- a/etc/nodes.conf
+++ b/etc/nodes.conf
@@ -28,4 +28,14 @@ nodeprofiles:
     ipxe template: default
     ipmi:
       template: ipmitool.tmpl
+    resources:
+      fstab:
+        - spec: warewulf:/home
+          file: /home
+          vfstype: nfs
+          mntops: defaults,nofail
+        - spec: warewulf:/opt
+          file: /opt
+          vfstype: nfs
+          mntops: defaults,noauto,nofail,ro
 nodes: {}

--- a/internal/pkg/upgrade/node.go
+++ b/internal/pkg/upgrade/node.go
@@ -158,7 +158,8 @@ func (legacy *NodesYaml) Upgrade(addDefaults bool, replaceOverlays bool, warewul
 }
 
 type Node struct {
-	Profile `yaml:"-,inline"`
+	Discoverable string `yaml:"discoverable,omitempty"`
+	Profile      `yaml:"-,inline"`
 }
 
 func (legacy *Node) Upgrade(addDefaults bool, replaceOverlays bool) (upgraded *node.Node) {
@@ -330,7 +331,6 @@ type Profile struct {
 	ImageName      string                 `yaml:"image name,omitempty"`
 	ContainerName  string                 `yaml:"container name,omitempty"`
 	Disabled       string                 `yaml:"disabled,omitempty"`
-	Discoverable   string                 `yaml:"discoverable,omitempty"`
 	Disks          map[string]*Disk       `yaml:"disks,omitempty"`
 	FileSystems    map[string]*FileSystem `yaml:"filesystems,omitempty"`
 	Init           string                 `yaml:"init,omitempty"`
@@ -382,9 +382,6 @@ func (legacy *Profile) Upgrade(addDefaults bool, replaceOverlays bool) (upgraded
 	}
 	if legacy.Disabled != "" {
 		logIgnore("Disabled", legacy.Disabled, "obsolete")
-	}
-	if legacy.Discoverable != "" {
-		logIgnore("Discoverable", legacy.Discoverable, "invalid for profiles")
 	}
 	if legacy.Disks != nil {
 		for name, disk := range legacy.Disks {

--- a/internal/pkg/upgrade/node_test.go
+++ b/internal/pkg/upgrade/node_test.go
@@ -552,6 +552,16 @@ nodeprofiles:
       - net.naming-scheme=v238
     init: /sbin/init
     root: initramfs
+    resources:
+      fstab:
+        - spec: warewulf:/home
+          file: /home
+          vfstype: nfs
+          mntops: defaults,nofail
+        - spec: warewulf:/opt
+          file: /opt
+          vfstype: nfs
+          mntops: defaults,noauto,nofail,ro
 nodes:
   n1:
     profiles:
@@ -579,6 +589,12 @@ nodeprofiles:
       - udev.netname
       - systemd.netname
       - NetworkManager
+    resources:
+      fstab:
+        - spec: warewulf:/scratch
+          file: /scratch
+          vfstype: nfs
+          mntops: defaults,nofail
   custom: {}
 nodes:
   n1:
@@ -616,6 +632,12 @@ nodeprofiles:
       - net.naming-scheme=v238
     init: /sbin/init
     root: initramfs
+    resources:
+      fstab:
+        - spec: warewulf:/scratch
+          file: /scratch
+          vfstype: nfs
+          mntops: defaults,nofail
 nodes:
   n1:
     profiles:


### PR DESCRIPTION
## Description of the Pull Request (PR):

Adds fstab resources for `/home` and `/opt` to the initial default profile, and to the default profile during an upgrade if requested.


## This fixes or addresses the following GitHub issues:

- Fixes #1744


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
