### PR TITLE
Make DHCP range optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Return "" when NetDev.IpCIDR is empty.
 - Updated `wwctl node export` to include node IDs. #1718
 - Don't add "default" profile to new nodes if it does not exist. #1721
+- Make DHCP range optional.
 
 ### Removed
 

--- a/internal/pkg/configure/dhcp.go
+++ b/internal/pkg/configure/dhcp.go
@@ -21,14 +21,6 @@ func DHCP() (err error) {
 		wwlog.Warn("This system is not configured as a Warewulf DHCP controller")
 		return
 	}
-
-	if controller.DHCP.RangeStart == "" {
-		return fmt.Errorf("configuration is not defined: `dhcpd range start`")
-	}
-
-	if controller.DHCP.RangeEnd == "" {
-		return fmt.Errorf("configuration is not defined: `dhcpd range end`")
-	}
 	if controller.Warewulf.EnableHostOverlay() {
 		err = overlay.BuildHostOverlay()
 		if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

The DHCP range was made optional in the template, but I had missed that it is required by `wwctl configure dhcp`. This PR removes it from that code.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
