### PR TITLE
Port NFS exports before applying defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Wait until ignition has completed before trying to mount.
 - Fix timeout problem for wwclient. #1741
 - Fixed default "true" state of NetDev.OnBoot. #1754
+- Port NFS mounts during `wwctl upgrade nodes` before applying defaults. #1758
 
 ### Removed
 

--- a/internal/pkg/upgrade/node_test.go
+++ b/internal/pkg/upgrade/node_test.go
@@ -880,6 +880,73 @@ nfs:
     mount: true
   - path: /var
     mount: false
+    mount options: defaults
+  - path: /srv
+    mount options: defaults
+`,
+	},
+	{
+		name:        "Legacy extended export mounts with defaults",
+		addDefaults: true,
+		legacyYaml: `
+nodeprofiles:
+  default: {}
+`,
+		upgradedYaml: `
+nodeprofiles:
+  default:
+    ipxe template: default
+    runtime overlay:
+      - hosts
+      - ssh.authorized_keys
+      - syncuser
+    system overlay:
+      - wwinit
+      - wwclient
+      - fstab
+      - hostname
+      - ssh.host_keys
+      - issue
+      - resolv
+      - udev.netname
+      - systemd.netname
+      - ifcfg
+      - NetworkManager
+      - debian.interfaces
+      - wicked
+      - ignition
+    kernel:
+      args:
+      - quiet
+      - crashkernel=no
+      - vga=791
+      - net.naming-scheme=v238
+    init: /sbin/init
+    root: initramfs
+    resources:
+      fstab:
+        - spec: warewulf:/home
+          file: /home
+          vfstype: nfs
+        - spec: warewulf:/opt
+          file: /opt
+          mntops: defaults,ro
+          vfstype: nfs
+nodes: {}
+`,
+		warewulfConf: `
+nfs:
+  export paths:
+  - path: /home
+    mount: true
+  - path: /opt
+    mount options: defaults,ro
+    mount: true
+  - path: /var
+    mount: false
+    mount options: defaults
+  - path: /srv
+    mount options: defaults
 `,
 	},
 	{


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fixes an issue where `wwctl upgrade nodes` applied default NFS mounts and ported in NFS entries from warewulf.conf.

## This fixes or addresses the following GitHub issues:

- Closes: #1758


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
