### PR TITLE
Reduced default verbosity of `wwctl overlay build`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added logging to wwinit scripts. #1156
 - Renamed /warewulf/wwinit to /warewulf/prescripts. #1156
 - Display auto-detected kernel version during iPXE and GRUB. #1742
+- Reduced default verbosity of `wwctl overlay build`.
 
 ### Fixed
 

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -108,12 +108,14 @@ func BuildAllOverlays(nodes []node.Node, allNodes []node.Node, workerCount int) 
 	var wg sync.WaitGroup
 	worker := func() {
 		for n := range nodeChan {
-			wwlog.Info("Building system overlays for %s: [%s]", n.Id(), strings.Join(n.SystemOverlay, ", "))
+			wwlog.Info("Building system overlay image for %s", n.Id())
+			wwlog.Debug("System overlays for %s: [%s]", n.Id(), strings.Join(n.SystemOverlay, ", "))
 			if err := BuildOverlay(n, allNodes, "system", n.SystemOverlay); err != nil {
 				errChan <- fmt.Errorf("could not build system overlays %v for node %s: %w", n.SystemOverlay, n.Id(), err)
 			}
 
-			wwlog.Info("Building runtime overlays for %s: [%s]", n.Id(), strings.Join(n.RuntimeOverlay, ", "))
+			wwlog.Info("Building runtime overlay image for %s", n.Id())
+			wwlog.Debug("Runtime overlays for %s: [%s]", n.Id(), strings.Join(n.RuntimeOverlay, ", "))
 			if err := BuildOverlay(n, allNodes, "runtime", n.RuntimeOverlay); err != nil {
 				errChan <- fmt.Errorf("could not build runtime overlays %v for node %s: %w", n.RuntimeOverlay, n.Id(), err)
 			}
@@ -239,7 +241,12 @@ func BuildOverlay(nodeConf node.Node, allNodes []node.Node, context string, over
 	}
 
 	// create the dir where the overlay images will reside
-	name := fmt.Sprintf("overlay %s/%v", nodeConf.Id(), overlayNames)
+	var name string
+	if context != "" {
+		name = fmt.Sprintf("%s %s overlay", nodeConf.Id(), context)
+	} else {
+		name = fmt.Sprintf("%s overlay/%v", nodeConf.Id(), overlayNames)
+	}
 	overlayImage := OverlayImage(nodeConf.Id(), context, overlayNames)
 	overlayImageDir := path.Dir(overlayImage)
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Previously, `wwctl overlay build` generated info logs that included the full list of overlays included in each overlay image. But, now that overlay lists are long, even by default, these logs got very long and difficult to read.

This PR reduces the default verbosity for system and runtime overlays. Previous output moved to `--debug`.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
