### PR TITLE
Add `--overwrite` to `wwctl overlay import`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## v4.6.1, unreleased
 
+### Added
+
+- Added `wwctl overlay import --overwrite` to overwrite existing overlay file.
+
 ### Fixed
 
 - Fixed panic in warewulfd if node netdev is only defined in a profile. #1817

--- a/internal/app/wwctl/overlay/imprt/main.go
+++ b/internal/app/wwctl/overlay/imprt/main.go
@@ -42,7 +42,7 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 		dest = path.Join(dest, path.Base(source))
 	}
 
-	if util.IsFile(overlay_.File(dest)) {
+	if !OverwriteFile && util.IsFile(overlay_.File(dest)) {
 		return fmt.Errorf("a file with that name already exists in the overlay: %s", overlayName)
 	}
 

--- a/internal/app/wwctl/overlay/imprt/root.go
+++ b/internal/app/wwctl/overlay/imprt/root.go
@@ -24,12 +24,14 @@ var (
 			}
 		},
 	}
+	OverwriteFile   bool
 	NoOverlayUpdate bool
 	CreateDirs      bool
 	Workers         int
 )
 
 func init() {
+	baseCmd.PersistentFlags().BoolVarP(&OverwriteFile, "overwrite", "o", false, "Overwrite file if exists")
 	baseCmd.PersistentFlags().BoolVarP(&NoOverlayUpdate, "noupdate", "n", false, "Don't update overlays")
 	baseCmd.PersistentFlags().BoolVarP(&CreateDirs, "parents", "p", false, "Create any necessary parent directories")
 	baseCmd.PersistentFlags().IntVar(&Workers, "workers", 0, "The number of parallel workers building overlays (<=0 indicates 1 worker per CPU)")

--- a/internal/pkg/util/copyfile.go
+++ b/internal/pkg/util/copyfile.go
@@ -14,27 +14,27 @@ func CopyFile(src string, dst string) error {
 	// Open source file
 	srcFD, err := os.Open(src)
 	if err != nil {
-		wwlog.Error("Could not open source file %s: %s", src, err)
+		wwlog.Debug("Could not open source file %s: %s", src, err)
 		return err
 	}
 	defer srcFD.Close()
 
 	srcInfo, err := srcFD.Stat()
 	if err != nil {
-		wwlog.Error("Could not stat source file %s: %s", src, err)
+		wwlog.Debug("Could not stat source file %s: %s", src, err)
 		return err
 	}
 
 	dstFD, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcInfo.Mode())
 	if err != nil {
-		wwlog.Error("Could not create destination file %s: %s", dst, err)
+		wwlog.Debug("Could not create destination file %s: %s", dst, err)
 		return err
 	}
 	defer dstFD.Close()
 
 	bytes, err := io.Copy(dstFD, srcFD)
 	if err != nil {
-		wwlog.Error("File copy from %s to %s failed.\n %s", src, dst, err)
+		wwlog.Debug("File copy from %s to %s failed.\n %s", src, dst, err)
 		return err
 	} else {
 		wwlog.Debug("Copied %d bytes from %s to %s.", bytes, src, dst)
@@ -42,7 +42,7 @@ func CopyFile(src string, dst string) error {
 
 	err = CopyUIDGID(src, dst)
 	if err != nil {
-		wwlog.Error("Ownership copy from %s to %s failed.\n %s", src, dst, err)
+		wwlog.Debug("Ownership copy from %s to %s failed.\n %s", src, dst, err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

Allow files imported into an overlay to be overwritten if they exist.  Updates `wwctl overlay import` documentation to reflect current options.

This enables the use of sed/awk workflows for overlay files, for example:

```bash
./wwctl overlay cat test /test.txt | sed -e 's/9/1/' | sudo ./wwctl overlay import test --overwrite /dev/stdin /test.txt
```

## Closes

- closes #386

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
