### PR TITLE
Add option to set editor for wwctl overlay edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added target help in Makefile. #1740
 - Added fstab mounts for `/home` and `/opt` to initial default profile. #1744
 - Add support for an `IPXEMenuEntry` tag to select the boot method during iPXE.
+- Add `--command` option to `wwctl overlay edit` to set editor command.
 
 ### Changed
 

--- a/internal/app/wwctl/overlay/edit/main.go
+++ b/internal/app/wwctl/overlay/edit/main.go
@@ -79,10 +79,16 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	editor := os.Getenv("EDITOR")
+	if Command != "" {
+		editor = Command
+	}
 	if editor == "" {
 		editor = "/bin/vi"
 	}
-	if editorErr := util.ExecInteractive(editor, tempFile.Name()); editorErr != nil {
+	editorArgs := util.ShellSplit(editor) // do not break spaces across quoted strings
+	editor = editorArgs[0]
+	editorArgs = append(editorArgs[1:], tempFile.Name())
+	if editorErr := util.ExecInteractive(editor, editorArgs...); editorErr != nil {
 		return fmt.Errorf("editor process exited with an error: %s", editorErr)
 	}
 

--- a/internal/app/wwctl/overlay/edit/root.go
+++ b/internal/app/wwctl/overlay/edit/root.go
@@ -22,11 +22,13 @@ var (
 	}
 	CreateDirs bool
 	PermMode   int32
+	Command    string
 )
 
 func init() {
 	baseCmd.PersistentFlags().BoolVarP(&CreateDirs, "parents", "p", false, "Create any necessary parent directories")
 	baseCmd.PersistentFlags().Int32VarP(&PermMode, "mode", "m", 0755, "Permission mode for directory")
+	baseCmd.PersistentFlags().StringVarP(&Command, "command", "c", "", "Command to run editor")
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -284,6 +284,23 @@ func FindFilterFiles(
 	return ofiles, nil
 }
 
+// Split a string by spaces perserving quoted strings (no escaping)
+func ShellSplit(s string) []string {
+	re := regexp.MustCompile(`"([^"]*)"|'([^']*)'|\S+`)
+	matches := re.FindAllStringSubmatch(s, -1)
+	var result []string
+	for _, match := range matches {
+		if match[1] != "" {
+			result = append(result, match[1]) // Double-quoted match
+		} else if match[2] != "" {
+			result = append(result, match[2]) // Single-quoted match
+		} else {
+			result = append(result, match[0]) // Non-quoted match
+		}
+	}
+	return result
+}
+
 // ******************************************************************************
 func ExecInteractive(command string, a ...string) error {
 	wwlog.Debug("ExecInteractive(%s, %s)", command, a)

--- a/userdocs/contents/overlays.rst
+++ b/userdocs/contents/overlays.rst
@@ -462,12 +462,13 @@ Edit
 ----
 .. code-block:: console
 
-  wwctl overlay edit [--mode,-m MODE|--parents,-p] overlay-name file
+  wwctl overlay edit [--mode,-m MODE|--parents,-p|--command,-c COMMAND] overlay-name file
 
 Use this command to edit an existing or a new file in the given
 overlay. If a the new file ends with a ``.ww`` suffix an example
 template header is added to the file. With the ``--parents`` flag
-necessary parent directories for a new file are created.
+necessary parent directories for a new file are created. The editor
+is set by the environment variable `EDITOR` or by ``--command`` option.
 
 Import
 ------


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds the `--command` option to `wwctl overlay edit` to override the `$EDITOR` environment variable.  It also allows `$EDITOR` and `--command` to have arguments (think `emacs -nw`).  The arguments are split by space but preserve single and double quotes as a single argument (escaping quotes not supported).  This allows using editor commands such as `sed -i -e` and `tail -a` to modify overlay files from the command line.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
