### PR TITLE
Install git before checkout

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -51,6 +51,9 @@ jobs:
         permissions: write-all
 
         steps:
+          - name: Install git
+            run: |
+              dnf install -y git
           - name: Checkout Code
             uses: actions/checkout@v4
             with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v4.6.0, unreleased
+
+### Fixed
+
+- Fix nightly builds.
+
 ## v4.6.0rc3, 2025-02-23
 
 ### Added


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fixes nightly builds.

Fixes a bug where the GitHub action checkout does not unzip the `.github` directory when not using git.  This is required to use the `.github/actions/rpm` action.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
