### PR TITLE
error out on undefined keys in power template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added target help in Makefile. #1740
 - Added fstab mounts for `/home` and `/opt` to initial default profile. #1744
 - Add support for an `IPXEMenuEntry` tag to select the boot method during iPXE.
+- Error out if key isn't known for power template #1768
 
 ### Changed
 

--- a/internal/pkg/power/ipmitool.go
+++ b/internal/pkg/power/ipmitool.go
@@ -43,7 +43,7 @@ func (ipmi *IPMI) getStr() (cmdStr string, err error) {
 	if err != nil {
 		return "", fmt.Errorf("couldn't find the template which defines the ipmi/bmc command: %s", err)
 	}
-	cmdTmpl, err := template.New("bmc command").Parse(string(fbuf))
+	cmdTmpl, err := template.New("bmc command").Option("missingkey=error").Parse(string(fbuf))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
An error out if the key isn't known seems to be the best solution, as users might have defined their own power templates

- Closes: #1768
