### PR TITLE
WWWORKER overwrites runtime.NumCPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix timeout problem for wwclient. #1741
 - Fixed default "true" state of NetDev.OnBoot. #1754
 - Port NFS mounts during `wwctl upgrade nodes` before applying defaults. #1758
+- Set WWWORKER from commandline for reproducible builds
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ wwapird: $(config) $(apiconfig) $(call godeps,internal/app/api/wwapird/wwapird.g
 .PHONY: man_pages
 man_pages: wwctl $(wildcard docs/man/man5/*.5)
 	mkdir -p docs/man/man1
-	./wwctl --emptyconf genconfig man docs/man/man1
+	WWWORKER=8 ./wwctl --emptyconf genconfig man docs/man/man1
 	gzip --force docs/man/man1/*.1
 	for manpage in docs/man/man5/*.5; do gzip <$${manpage} >$${manpage}.gz; done
 

--- a/internal/app/wwctl/overlay/build/root.go
+++ b/internal/app/wwctl/overlay/build/root.go
@@ -1,7 +1,9 @@
 package build
 
 import (
+	"os"
 	"runtime"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	"github.com/warewulf/warewulf/internal/app/wwctl/completions"
@@ -29,7 +31,13 @@ func init() {
 	}
 	baseCmd.PersistentFlags().StringVarP(&OverlayDir, "output", "o", "", `Do not create an overlay image for distribution but write to
 	the given directory. An overlay must also be ge given to use this option.`)
-	baseCmd.PersistentFlags().IntVar(&Workers, "workers", runtime.NumCPU(), "The number of parallel workers building overlays")
+	workers := runtime.NumCPU()
+	numCPU := os.Getenv("WWWORKER")
+	wwWorker, err := strconv.Atoi(numCPU)
+	if err == nil {
+		workers = wwWorker
+	}
+	baseCmd.PersistentFlags().IntVar(&Workers, "workers", workers, "The number of parallel workers building overlays")
 }
 
 // GetRootCommand returns the root cobra.Command for the application.


### PR DESCRIPTION
runtime.NumCPU varies for different build hosts, so the
environment variable WWWORKER can be set to keep this number
constant as this number ends up in
docs/man/man1/wwctl-overlay-build.1
and so in the packages

Signed-off-by: Christian Goll <cgoll@suse.com>
