### PR TITLE
Add support for ubuntu-style dracut image names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## v4.6.0, unreleased
 
+### Added
+
+- Support Ubuntu-style dracut initrd images.
+
 ### Fixed
 
 - Fix nightly builds.

--- a/internal/pkg/image/initramfs.go
+++ b/internal/pkg/image/initramfs.go
@@ -14,6 +14,7 @@ var (
 	initramfsSearchPaths = []string{
 		"/boot/initramfs-*",
 		"/boot/initrd-*",
+		"/boot/initrd.img-*",
 	}
 
 	versionPattern *regexp.Regexp

--- a/internal/pkg/image/initramfs_test.go
+++ b/internal/pkg/image/initramfs_test.go
@@ -20,7 +20,6 @@ func TestFindInitramfs(t *testing.T) {
 	assert.NoError(t, os.MkdirAll(filepath.Join(RootFsDir("image"), "boot"), 0700))
 
 	tests := map[string]struct {
-		name      string
 		initramfs []string
 		ver       string
 		path      string
@@ -44,6 +43,11 @@ func TestFindInitramfs(t *testing.T) {
 			initramfs: []string{"/boot/initrd-1.1.1.aarch64.img"},
 			ver:       "1.1.1",
 			path:      "/boot/initrd-1.1.1.aarch64.img",
+		},
+		"ok case 5 (ubuntu)": {
+			initramfs: []string{"/boot/initrd.img-6.11.0-18-generic"},
+			ver:       "6.11.0-18",
+			path:      "/boot/initrd.img-6.11.0-18-generic",
 		},
 		"prefix match": {
 			initramfs: []string{"/boot/initrd-1.1.1.aarch64.img"},


### PR DESCRIPTION
## Description of the Pull Request (PR):

Ubuntu dracut generates names like `/boot/initrd.img-*` which wasn't caught by the pattern we were already using.

This PR adds that pattern to the dracut search path and adds a test for it.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
