### PR TITLE
make dracut curl invocation retry for all errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Support Ubuntu-style dracut initrd images.
 
+### Changed
+
+- Changed curl in wwinit dracut module to retry on all errors
+
 ### Fixed
 
 - Fix nightly builds.

--- a/dracut/modules.d/90wwinit/load-wwinit.sh
+++ b/dracut/modules.d/90wwinit/load-wwinit.sh
@@ -15,7 +15,7 @@ do
     fi
     (
         curl --location --silent --get ${localport} \
-            --retry 60 --retry-delay 1 \
+            --retry 60 --retry-delay 1 --retry-all-errors \
             --data-urlencode "assetkey=${wwinit_assetkey}" \
             --data-urlencode "uuid=${wwinit_uuid}" \
             --data-urlencode "stage=${stage}" \


### PR DESCRIPTION
## Description of the Pull Request (PR):

the curl invocation should also include --retry-all-errors so non-transient errors are also retried.
This will cover the case where the network is unreachable, possibly because an ip hasn't been assigned yet.

## This fixes or addresses the following GitHub issues:
NA


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
