### PR TITLE
Use `wwctl overlay <import|build> --workers=0` to indicate default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix nightly builds.
 
+### Changed
+
+- User `wwctl overlay <import|build> --workers=0` to indicate `runtime.NumCPU()`. #1782
+
 ## v4.6.0rc3, 2025-02-23
 
 ### Added

--- a/internal/app/wwctl/overlay/build/main.go
+++ b/internal/app/wwctl/overlay/build/main.go
@@ -3,6 +3,7 @@ package build
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -67,10 +68,15 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	oldMask := syscall.Umask(000)
 	defer syscall.Umask(oldMask)
 
+	workers := Workers
+	if workers <= 0 {
+		workers = runtime.NumCPU()
+	}
+
 	if len(OverlayNames) > 0 {
-		err = overlay.BuildSpecificOverlays(filteredNodes, allNodes, OverlayNames, Workers)
+		err = overlay.BuildSpecificOverlays(filteredNodes, allNodes, OverlayNames, workers)
 	} else {
-		err = overlay.BuildAllOverlays(filteredNodes, allNodes, Workers)
+		err = overlay.BuildAllOverlays(filteredNodes, allNodes, workers)
 	}
 
 	if err != nil {

--- a/internal/app/wwctl/overlay/build/root.go
+++ b/internal/app/wwctl/overlay/build/root.go
@@ -1,8 +1,6 @@
 package build
 
 import (
-	"runtime"
-
 	"github.com/spf13/cobra"
 	"github.com/warewulf/warewulf/internal/app/wwctl/completions"
 )
@@ -29,7 +27,7 @@ func init() {
 	}
 	baseCmd.PersistentFlags().StringVarP(&OverlayDir, "output", "o", "", `Do not create an overlay image for distribution but write to
 	the given directory. An overlay must also be ge given to use this option.`)
-	baseCmd.PersistentFlags().IntVar(&Workers, "workers", runtime.NumCPU(), "The number of parallel workers building overlays")
+	baseCmd.PersistentFlags().IntVar(&Workers, "workers", 0, "The number of parallel workers building overlays (<=0 indicates 1 worker per CPU)")
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/internal/app/wwctl/overlay/imprt/main.go
+++ b/internal/app/wwctl/overlay/imprt/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 
 	"github.com/spf13/cobra"
 	"github.com/warewulf/warewulf/internal/pkg/node"
@@ -88,7 +89,11 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 			}
 		}
 
-		return overlay.BuildSpecificOverlays(updateNodes, nodes, []string{overlayName}, Workers)
+		workers := Workers
+		if workers <= 0 {
+			workers = runtime.NumCPU()
+		}
+		return overlay.BuildSpecificOverlays(updateNodes, nodes, []string{overlayName}, workers)
 	}
 
 	return nil

--- a/internal/app/wwctl/overlay/imprt/root.go
+++ b/internal/app/wwctl/overlay/imprt/root.go
@@ -1,8 +1,6 @@
 package imprt
 
 import (
-	"runtime"
-
 	"github.com/spf13/cobra"
 	"github.com/warewulf/warewulf/internal/app/wwctl/completions"
 )
@@ -34,7 +32,7 @@ var (
 func init() {
 	baseCmd.PersistentFlags().BoolVarP(&NoOverlayUpdate, "noupdate", "n", false, "Don't update overlays")
 	baseCmd.PersistentFlags().BoolVarP(&CreateDirs, "parents", "p", false, "Create any necessary parent directories")
-	baseCmd.PersistentFlags().IntVar(&Workers, "workers", runtime.NumCPU(), "The number of parallel workers building overlays")
+	baseCmd.PersistentFlags().IntVar(&Workers, "workers", 0, "The number of parallel workers building overlays (<=0 indicates 1 worker per CPU)")
 }
 
 // GetRootCommand returns the root cobra.Command for the application.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Use `wwctl overlay <import|build> --workers=0` to indicate default value.

By default, uses `runtime.NumCPU()`

The default value is rendered in the generated man pages, which made their content dependent on build system characteristics.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
