### PR TITLE
Change upgraded default kernel args to match distributed `nodes.conf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Support Ubuntu-style dracut initrd images.
 
+### Changed
+
+- Match default kernel arguments from `wwctl upgrade nodes` with the distributed `nodes.conf`.
+
 ### Fixed
 
 - Fix nightly builds.

--- a/internal/pkg/upgrade/node.go
+++ b/internal/pkg/upgrade/node.go
@@ -123,7 +123,7 @@ func (legacy *NodesYaml) Upgrade(addDefaults bool, replaceOverlays bool, warewul
 				defaultProfile.RuntimeOverlay, genericSplitOverlays...)
 		}
 		if len(defaultProfile.Kernel.Args) < 1 {
-			defaultProfile.Kernel.Args = []string{"quiet", "crashkernel=no", "vga=791", "net.naming-scheme=v238"}
+			defaultProfile.Kernel.Args = []string{"quiet", "crashkernel=no"}
 		}
 		if defaultProfile.Init == "" {
 			defaultProfile.Init = "/sbin/init"

--- a/internal/pkg/upgrade/node_test.go
+++ b/internal/pkg/upgrade/node_test.go
@@ -576,8 +576,6 @@ nodeprofiles:
       args:
       - quiet
       - crashkernel=no
-      - vga=791
-      - net.naming-scheme=v238
     init: /sbin/init
     root: initramfs
     resources:
@@ -656,8 +654,6 @@ nodeprofiles:
       args:
       - quiet
       - crashkernel=no
-      - vga=791
-      - net.naming-scheme=v238
     init: /sbin/init
     root: initramfs
     resources:
@@ -919,8 +915,6 @@ nodeprofiles:
       args:
       - quiet
       - crashkernel=no
-      - vga=791
-      - net.naming-scheme=v238
     init: /sbin/init
     root: initramfs
     resources:


### PR DESCRIPTION
## Description of the Pull Request (PR):

We changed the default kernel args in `nodes.conf` but not in what is generated by `wwctl upgrade nodes`. This PR synchronizes them.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
