### PR TITLE
fixup pdf build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+- Removed unreadable >= character and not distro sphinx module for pdf doc build
+
 ## v4.6.0, 2025-03-02
 
 ### Added

--- a/userdocs/conf.py
+++ b/userdocs/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'Warewulf User Guide'
-copyright = '2024, Warewulf Project Contributors'
+copyright = '2025, Warewulf Project Contributors'
 author = 'Warewulf Project Contributors'
 release = 'main'
 
@@ -16,7 +16,6 @@ release = 'main'
 
 extensions = [
     'sphinx.ext.graphviz',
-    'sphinx_reredirects',
 ]
 
 redirects = {

--- a/userdocs/server/bootloaders.rst
+++ b/userdocs/server/bootloaders.rst
@@ -158,7 +158,7 @@ For example, the ``imgextract`` command can be `explicitly enabled`_.
    This is the case in the default state of ``build-ipxe.sh``, which enables
    support for ZLIB and GZIP archive image formats.
 
-Configuring Warewulf (≥ v4.5.0)
+Configuring Warewulf (>= v4.5.0)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In Warewulf v4.5.0, Warewulf can be configured to use these files using the


### PR DESCRIPTION
- sphinx_reredirects isn't part of distros standard packages and so local pdf build fails
- latex doesn't like special characaters like ≥ as it's sooo old, use >= instead
