### PR TITLE
Add connectivity test/wait to dracut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Update GitHub actions to build aarch64 artifacts.
+## Unreleased
+
+### Added
+- Add connectivity check to dracut before image download. 
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Update GitHub actions to build aarch64 artifacts.
-## Unreleased
 
 ### Added
+
 - Add connectivity check to dracut before image download. #1800 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## v4.6.1, unreleased
 
+### Added
+
+- Add connectivity check to dracut before image download. #1800
+
 ### Fixed
 
 - Fixed panic in warewulfd if node netdev is only defined in a profile. #1817
@@ -14,10 +18,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Update GitHub actions to build aarch64 artifacts.
-
-### Added
-
-- Add connectivity check to dracut before image download. #1800 
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 ### Added
-- Add connectivity check to dracut before image download. 
+- Add connectivity check to dracut before image download. #1800 
 
 ### Removed
 

--- a/dracut/modules.d/90wwinit/load-wwinit.sh
+++ b/dracut/modules.d/90wwinit/load-wwinit.sh
@@ -4,7 +4,15 @@ info "Mounting tmpfs at $NEWROOT"
 mount -t tmpfs -o mpol=interleave ${wwinit_tmpfs_size_option} tmpfs "$NEWROOT"
 
 # check connectivity to warewulfd
-for i in {1..60}; do curl "${wwinit_uri}" > /dev/null; if [[ $? -eq 0 ]]; then break; fi; sleep 1; done;
+for i in {1..60}
+do
+    curl --silent "${wwinit_uri}" > /dev/null
+    if [[ $? -eq 0 ]]
+    then
+        break
+    fi
+    sleep 1
+done
 
 for stage in "image" "system" "runtime"
 do

--- a/dracut/modules.d/90wwinit/load-wwinit.sh
+++ b/dracut/modules.d/90wwinit/load-wwinit.sh
@@ -3,6 +3,9 @@
 info "Mounting tmpfs at $NEWROOT"
 mount -t tmpfs -o mpol=interleave ${wwinit_tmpfs_size_option} tmpfs "$NEWROOT"
 
+# check connectivity to warewulfd
+for i in {1..60}; do curl "${wwinit_uri}" > /dev/null; if [[ $? -eq 0 ]]; then break; fi; sleep 1; done;
+
 for stage in "image" "system" "runtime"
 do
     info "Loading stage: ${stage}"


### PR DESCRIPTION
## Description of the Pull Request (PR):

Curl fetches of system images can fail if the interface is not fully up. This adds an up to 60s delay, testing every second, for connectivity to warewulfd to be functional.


## This fixes or addresses the following GitHub issues:


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
