### PR TITLE
fix Dockerfile: go1.22 is required for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM opensuse/tumbleweed:latest as builder
 
-RUN zypper  -n install --no-recommends git go1.21 libgpgme-devel unzip &&\
+RUN zypper  -n install --no-recommends git go1.22 libgpgme-devel unzip &&\
   zypper -n install -t pattern devel_basis
 
 # now build the warewulf


### PR DESCRIPTION
## Description of the Pull Request (PR):

Dockerfile needs a fix, because go1.22 is required for docker build; with go1.21 it bails out early on.

## This fixes or addresses the following GitHub issues:

- Fixes a bug blocking the docker build process

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)

If the above is a MUST, let's expand on this PR to get things going...