### PR TITLE
Used a quoted string split to allow field names with dots in them

### DIFF
--- a/internal/pkg/node/fields.go
+++ b/internal/pkg/node/fields.go
@@ -114,7 +114,17 @@ func getNestedFieldValue(obj interface{}, name string) (value reflect.Value, err
 		value = value.Elem()
 	}
 
-	fieldNames := strings.Split(name, ".")
+	//fieldNames := strings.Split(name, ".") Test
+	in_quote := false
+	fieldNames := strings.FieldsFunc(name, func(r rune) bool {
+		if r == '[' {
+			in_quote = true
+		} else if r == ']' {
+			in_quote = false
+		}
+		return !in_quote && r == '.'
+	})
+
 	for _, fieldName := range fieldNames {
 		var key string
 		fieldName, key = parseMapField(fieldName)


### PR DESCRIPTION
Hi,
thank you for your great work on this project.
Our cluster has been using Warewulf for the past multiple years now, and we are currently testing the update to 4.6. 

## Description of the Pull Request (PR):

This pull request fixes a regression we found compared to 4.5.8: NetDevs containing a dot (e.g. VLANs like eth0.100) in their name are not displayed any more.

When MapKeys contain a dot, the getNestedFieldValue function splits the string at the wrong place ("NetDevs[eth0.100].Type" -> "NetDevs[eth0" + "100]" + "Type"), causing MapKeys with a dot in the name not to be displayed at all. They are, however, still available in templates.
This PR replaces the split function with a "bracket-aware" split, splitting the MapKeys correctly ("NetDevs[eth0.100].Type" -> "NetDevs[eth0.100]" + "Type").


## This fixes or addresses the following GitHub issues:

Didn't find any.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
