### PR TITLE
fix SUSE specific udev regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - wwclient uses `WW_IPADDR`, if set, to contact the Warewulf server. #1788
 - Add `wwctl node import --yes` to assume yes to confirmations.
 - Set an IPMI tag ``vlan`` to configure the vlan during ``ipmiwrite``. #1031
+- Added net.ifnames=1 to default kernel argument list. #1820
 
 ### Fixed
 

--- a/etc/nodes.conf
+++ b/etc/nodes.conf
@@ -23,6 +23,7 @@ nodeprofiles:
       args:
        - quiet
        - crashkernel=no
+       - net.ifnames=1
     init: /sbin/init
     root: initramfs
     ipxe template: default

--- a/internal/pkg/upgrade/node.go
+++ b/internal/pkg/upgrade/node.go
@@ -126,7 +126,7 @@ func (legacy *NodesYaml) Upgrade(addDefaults bool, replaceOverlays bool, warewul
 			defaultProfile.Kernel = new(node.KernelConf)
 		}
 		if len(defaultProfile.Kernel.Args) < 1 {
-			defaultProfile.Kernel.Args = []string{"quiet", "crashkernel=no"}
+			defaultProfile.Kernel.Args = []string{"quiet", "crashkernel=no", "net.ifnames=1"}
 		}
 		if defaultProfile.Init == "" {
 			defaultProfile.Init = "/sbin/init"

--- a/internal/pkg/upgrade/node_test.go
+++ b/internal/pkg/upgrade/node_test.go
@@ -578,6 +578,7 @@ nodeprofiles:
       args:
       - quiet
       - crashkernel=no
+      - net.ifnames=1
     init: /sbin/init
     root: initramfs
     resources:
@@ -658,6 +659,7 @@ nodeprofiles:
       args:
       - quiet
       - crashkernel=no
+      - net.ifnames=1
     init: /sbin/init
     root: initramfs
     resources:
@@ -1014,6 +1016,7 @@ nodeprofiles:
       args:
       - quiet
       - crashkernel=no
+      - net.ifnames=1
     init: /sbin/init
     root: initramfs
     resources:


### PR DESCRIPTION
Fix regression that net.ifnames=1 was missing in the kernel command line, which forces SUSE udev to default behavior

