### PR TITLE
Adding New SOS Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Support Ubuntu-style dracut initrd images.
+- New sos plugin in `warewulf-sos` subpackage.
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,7 @@ install: build docs ## Install Warewulf from source
 	for f in docs/man/man5/*.5.gz; do install -m 0644 $$f $(DESTDIR)$(MANDIR)/man5/; done
 	install -pd -m 0755 $(DESTDIR)$(DRACUTMODDIR)/90wwinit
 	install -m 0644 dracut/modules.d/90wwinit/*.sh $(DESTDIR)$(DRACUTMODDIR)/90wwinit
+	install -D -m 0644 include/sos/warewulf.py $(DESTDIR)$(SOSPLUGINS)/warewulf.py
 
 .PHONY: installapi
 installapi:

--- a/Variables.mk
+++ b/Variables.mk
@@ -51,6 +51,7 @@ BASHCOMPDIR ?= /etc/bash_completion.d
 FIREWALLDDIR ?= /usr/lib/firewalld/services
 LOGROTATEDIR ?= /etc/logrotate.d
 DRACUTMODDIR ?= /usr/lib/dracut/modules.d
+SOSPLUGINS ?= /usr/lib/python3.9/site-packages/sos/report/plugins
 ifeq ($(OS),suse)
   TFTPDIR ?= /srv/tftpboot
 endif

--- a/include/sos/warewulf.py
+++ b/include/sos/warewulf.py
@@ -1,0 +1,39 @@
+from sos.report.plugins import Plugin, IndependentPlugin
+
+class Warewulf(Plugin, IndependentPlugin):
+
+    short_desc = 'Warewulf provisioning server'
+
+    plugin_name = 'warewulf'
+    services = ('warewulfd')
+    packages = ('warewulf')
+
+    def setup(self):
+
+        self.add_copy_spec([
+          "/var/lib/warewulf/overlays/",
+          "/usr/share/warewulf/overlays/",
+          "/var/log/warewulfd.log",
+          "/etc/warewulf/",
+          "/var/lib/dhcpd/",
+          "/etc/dhcp/",
+          "/etc/dnsmasq.d",
+          "/var/lib/dnsmasq/dnsmasq.leases"
+        ])
+
+        self.add_forbidden_path([
+          "/var/lib/warewulf/overlays/wwinit/rootfs/warewulf/wwclient",
+          "/usr/share/warewulf/overlays/wwinit/rootfs/warewulf/wwclient"
+        ])
+
+        self.add_cmd_output([
+            "wwctl node list",
+            "wwctl node list -a",
+            "wwctl container list",
+            "wwctl profile list",
+            "wwctl profile list -a",
+            "wwctl image kernels",
+            "wwctl version"
+        ])
+
+        self.add_journal(units="warewulfd.service")

--- a/userdocs/troubleshooting/troubleshooting.rst
+++ b/userdocs/troubleshooting/troubleshooting.rst
@@ -2,6 +2,21 @@
 Troubleshooting
 ===============
 
+sos
+===
+
+The ``warewulf-sos`` package (new in v4.6.1) adds support for gathering Warewulf
+server configuration information in an sos report.
+
+.. code-block::
+
+   dnf -y install warewulf-sos
+   sos report # optionally, --enable-plugins=warewulf
+
+.. note::
+
+   The ``warewulf-sos`` package is not currently built for SUSE.
+
 warewulfd
 =========
 

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -72,6 +72,7 @@ Requires: dhcp
 BuildRequires: git
 BuildRequires: make
 BuildRequires: gpgme-devel
+BuildRequires: python3-devel
 %if %{api}
 BuildRequires: libassuan-devel
 %endif
@@ -79,30 +80,11 @@ BuildRequires: libassuan-devel
 Recommends: logrotate
 Recommends: ipmitool
 
+
 %description
 Warewulf is a stateless and diskless provisioning
 system for large clusters of bare metal and/or virtual systems.
 
-%package dracut
-Summary: dracut module for loading a Warewulf image
-BuildArch: noarch
-
-Requires: dracut
-%if 0%{?suse_version}
-%else
-Requires: dracut-network
-%endif
-Requires: curl
-Requires: cpio
-Requires: dmidecode
-
-%description dracut
-Warewulf is a stateless and diskless provisioning
-system for large clusters of bare metal and/or virtual systems.
-
-This subpackage contains a dracut module that can be used to generate
-an initramfs that can fetch and boot a Warewulf node image from a
-Warewulf server.
 
 %prep
 %setup -q -n %{name}-%{version} -b0 %if %{?with_offline:-a2}
@@ -128,6 +110,7 @@ make defaults \
     WWCLIENTDIR=/warewulf \
     IPXESOURCE=/usr/share/ipxe \
     DRACUTMODDIR=/usr/lib/dracut/modules.d \
+    SOSPLUGINS=%{python3_sitelib}/sos/report/plugins \
     CACHEDIR=%{_localstatedir}/cache
 make build
 %if %{api}
@@ -231,12 +214,55 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %endif
 
 
+%package dracut
+Summary: dracut module for loading a Warewulf image
+BuildArch: noarch
+
+Requires: dracut
+%if 0%{?suse_version}
+%else
+Requires: dracut-network
+%endif
+Requires: curl
+Requires: cpio
+Requires: dmidecode
+
+%description dracut
+Warewulf is a stateless and diskless provisioning system for large clusters of
+bare metal and/or virtual systems.
+
+This subpackage contains a dracut module that can be used to generate an
+initramfs that can fetch and boot a Warewulf node image from a Warewulf server.
+
 %files dracut
 %defattr(-, root, root)
 %{_prefix}/lib/dracut/modules.d/90wwinit
 
 
+%if 0%{?suse_version} || 0%{?sle_version}
+%else
+%package sos
+Summary: sos plugin for Warewulf
+BuildArch: noarch
+Requires: sos
+
+%description sos
+Warewulf is a stateless and diskless provisioning system for large clusters of
+bare metal and/or virtual systems.
+
+This subpackage contains an sos module that can be used to include information
+about Warewulf in an sos report.
+
+%files sos
+%{python3_sitelib}/sos/report/plugins/warewulf.py
+%{python3_sitelib}/sos/report/plugins/__pycache__/warewulf.*.pyc
+%endif
+
+
 %changelog
+* Thu Feb 20 2025 Stephen Simpson <ssimpson@ciq.com>
+- Added sos plugin
+
 * Sat Feb 1 2025 Jonathon Anderson <janderson@ciq.com>
 - Add Recommends: ipmitool
 


### PR DESCRIPTION
_This is a replacement for PR #1761, which was closed due to the accidental deletion of the original fork_

New `sosreport` plugin added as separate RPM

## Description of the Pull Request (PR):

This PR adds Warewulf support to [sosreport](https://github.com/sosreport/sos). `sosreport` is a tool to collect data for troubleshooting issues on Enterprise Linux distributions. This PR adds a Warewulf plugin that collects data from Warewulf directories, including the configuration, and captures output from several `wwctl` commands. The GitHub workflow for tagged releases has been updated to generate a separate RPM package compatible with both EL8 and EL9 distros.

I considered not including the `wwctl` commands directly since all the data is already available in `/etc/warewulf/`. However, the commands contribute very little in terms of additional space in the report and it doesn't add much to the runtime either.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
