### PR TITLE
Fix display of dotted field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Replaced unreadable >= character external sphinx module for pdf doc build.
 - Handle missing ipmi fields during bmc commands. #1768
 - Properly configure a default IPMI template during `wwctl upgrade nodes --add-defaults`.
+- Fixed display of dotted field names. #1825
 
 ### Changed
 

--- a/internal/pkg/node/fields.go
+++ b/internal/pkg/node/fields.go
@@ -114,7 +114,7 @@ func getNestedFieldValue(obj interface{}, name string) (value reflect.Value, err
 		value = value.Elem()
 	}
 
-	fieldNames := strings.Split(name, ".")
+	fieldNames := splitFieldName(name)
 	for _, fieldName := range fieldNames {
 		var key string
 		fieldName, key = parseMapField(fieldName)
@@ -139,6 +139,45 @@ func getNestedFieldValue(obj interface{}, name string) (value reflect.Value, err
 		}
 	}
 	return
+}
+
+// splitName splits a string into components using the '.' character as a delimiter,
+// except when the '.' appears inside square brackets.
+//
+// For example, given the input "NetDevs[eth0.100].Type", it returns:
+//
+//	[]string{"NetDevs[eth0.100]", "Type"}
+func splitFieldName(s string) []string {
+	var parts []string
+	var current []rune
+	inBracket := false
+
+	for _, r := range s {
+		switch r {
+		case '[':
+			inBracket = true
+			current = append(current, r)
+		case ']':
+			inBracket = false
+			current = append(current, r)
+		case '.':
+			if inBracket {
+				// If we're inside brackets, keep the dot.
+				current = append(current, r)
+			} else {
+				// Outside brackets, split here.
+				parts = append(parts, string(current))
+				current = nil
+			}
+		default:
+			current = append(current, r)
+		}
+	}
+	// Append any remaining characters as the last part.
+	if len(current) > 0 {
+		parts = append(parts, string(current))
+	}
+	return parts
 }
 
 // getNestedFieldString retrieves the string representation

--- a/internal/pkg/node/mergo_test.go
+++ b/internal/pkg/node/mergo_test.go
@@ -672,6 +672,18 @@ nodeprofiles:
 			source: "",
 			value:  "p1,p2",
 		},
+		"dotted netdev name": {
+			nodesConf: `
+nodes:
+  n1:
+    network devices:
+      eth0.100:
+        type: Ethernet`,
+			node:   "n1",
+			field:  "NetDevs[eth0.100].Type",
+			source: "",
+			value:  "Ethernet",
+		},
 		"node netdev tag": {
 			nodesConf: `
 nodes:


### PR DESCRIPTION
## Description of the Pull Request (PR):

v4.6.0 broke the display of dotted Tags and NetDevs, like `NetDev[eth0.100]` or `Tags[My.Tag.Name]` by always splitting on `.`, even when inside a bracketed expression.

This PR fixes that behavior by only splitting on `.` when not in a `[ ]` portion of the name.

Thanks to @atopion for the first pass at a fix, and for reporting the issue.


## This fixes or addresses the following GitHub issues:

- Fixes: #1825


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
