### PR TITLE
Adding quotes around escapechar in ipmitool.tmpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Handle missing ipmi fields during bmc commands. #1768
 - Properly configure a default IPMI template during `wwctl upgrade nodes --add-defaults`.
 - Fixed display of dotted field names. #1825
-- Add single quote around escapechar in ipmitool template
+- Add single quote around escapechar in ipmitool template #1830
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Handle missing ipmi fields during bmc commands. #1768
 - Properly configure a default IPMI template during `wwctl upgrade nodes --add-defaults`.
 - Fixed display of dotted field names. #1825
+- Add single quote around escapechar in ipmitool template
 
 ### Changed
 

--- a/internal/pkg/bmc/bmc_test.go
+++ b/internal/pkg/bmc/bmc_test.go
@@ -41,7 +41,7 @@ func Test_Ipmitool(t *testing.T) {
 					Password:   "calvin",
 				},
 			},
-			cmdStr: `ipmitool -I lanplus -e '~' -p 687 -H 192.168.1.100 -U "root" -P "calvin" chassis power status`,
+			cmdStr: `ipmitool -I lanplus -e "~" -p 687 -H 192.168.1.100 -U "root" -P "calvin" chassis power status`,
 		},
 		"nobmc PowerStatus full": {
 			bmc: TemplateStruct{

--- a/internal/pkg/bmc/bmc_test.go
+++ b/internal/pkg/bmc/bmc_test.go
@@ -41,7 +41,7 @@ func Test_Ipmitool(t *testing.T) {
 					Password:   "calvin",
 				},
 			},
-			cmdStr: `ipmitool -I lanplus -e ~ -p 687 -H 192.168.1.100 -U "root" -P "calvin" chassis power status`,
+			cmdStr: `ipmitool -I lanplus -e '~' -p 687 -H 192.168.1.100 -U "root" -P "calvin" chassis power status`,
 		},
 		"nobmc PowerStatus full": {
 			bmc: TemplateStruct{

--- a/lib/warewulf/bmc/ipmitool.tmpl
+++ b/lib/warewulf/bmc/ipmitool.tmpl
@@ -1,6 +1,6 @@
 {{ $cmd := "ipmitool" }}
 {{ if .Interface }}{{ $cmd = cat $cmd "-I" .Interface }}{{ end }}
-{{ if .EscapeChar }}{{ $cmd = cat $cmd "-e" (printf "'%s'" .EscapeChar) }}{{ end }}
+{{ if .EscapeChar }}{{ $cmd = cat $cmd "-e" (printf "\"%s\"" .EscapeChar) }}{{ end }}
 {{ if .Port }}{{ $cmd = cat $cmd "-p" .Port }}{{ end }}
 {{ if .Ipaddr }}{{ $cmd = cat $cmd "-H" .Ipaddr }}{{ end }}
 {{ if .UserName }}{{ $cmd = cat $cmd "-U" (printf "\"%s\"" .UserName) }}{{ end }}

--- a/lib/warewulf/bmc/ipmitool.tmpl
+++ b/lib/warewulf/bmc/ipmitool.tmpl
@@ -1,6 +1,6 @@
 {{ $cmd := "ipmitool" }}
 {{ if .Interface }}{{ $cmd = cat $cmd "-I" .Interface }}{{ end }}
-{{ if .EscapeChar }}{{ $cmd = cat $cmd "-e" .EscapeChar }}{{ end }}
+{{ if .EscapeChar }}{{ $cmd = cat $cmd "-e" (printf "'%s'" .EscapeChar) }}{{ end }}
 {{ if .Port }}{{ $cmd = cat $cmd "-p" .Port }}{{ end }}
 {{ if .Ipaddr }}{{ $cmd = cat $cmd "-H" .Ipaddr }}{{ end }}
 {{ if .UserName }}{{ $cmd = cat $cmd "-U" (printf "\"%s\"" .UserName) }}{{ end }}


### PR DESCRIPTION
## Description of the Pull Request (PR):

The default escape char ```~``` will expand to the user's home directory when passed to ```/bin/sh``` we should put it in quotes to stop that expansion.


## This fixes or addresses the following GitHub issues:

- Fixes #1802


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
