### PR TITLE
Various minor documentation updates

### DIFF
--- a/userdocs/overlays/overlays.rst
+++ b/userdocs/overlays/overlays.rst
@@ -294,6 +294,11 @@ If a ``PasswordlessRoot`` tag is set to "true", the overlay will also insert a
 "passwordless" root entry. This can be particularly useful for accessing a
 cluster node when its network interface is not properly configured.
 
+.. warning::
+
+   ``PasswordlessRoot`` is not recommended for production; it should only be
+   used during debugging, when normal authentication is not functional.
+
 ignition
 --------
 

--- a/userdocs/server/bootloaders.rst
+++ b/userdocs/server/bootloaders.rst
@@ -334,13 +334,13 @@ Warewulf provides a dracut module to configure the dracut initramfs to load the
 image. This module is available in the ``warewulf-dracut`` subpackage, which
 must be installed in the image.
 
-With the ``warewulf-dracut`` package installed, you can build an initramfs
-inside the image.
+With the ``warewulf-dracut`` package installed in the image, you can then build
+an initramfs inside the image.
 
 .. code-block:: shell
 
-   dnf -y install warewulf-dracut
-   dracut --force --no-hostonly --add wwinit --regenerate-all
+   wwctl image exec rockylinux-9 --build=false -- /usr/bin/dnf -y install https://github.com/warewulf/warewulf/releases/download/v4.6.0/warewulf-dracut-4.6.0-1.el9.noarch.rpm
+   wwctl image exec rockylinux-9 -- /usr/bin/dracut --force --no-hostonly --add wwinit --regenerate-all
 
 .. note::
 

--- a/userdocs/server/installation.rst
+++ b/userdocs/server/installation.rst
@@ -18,14 +18,14 @@ Rocky Linux 9
 
 .. code-block:: console
 
-   # dnf install https://github.com/warewulf/warewulf/releases/download/v4.6.0rc2/warewulf-4.6.0rc2-1.el9.x86_64.rpm
+   # dnf install https://github.com/warewulf/warewulf/releases/download/v4.6.0/warewulf-4.6.0-1.el9.x86_64.rpm
 
 openSuse Leap
 -------------
 
 .. code-block:: console
 
-   # zypper install https://github.com/warewulf/warewulf/releases/download/v4.6.0rc2/warewulf-4.6.0rc2-1.suse.lp155.x86_64.rpm
+   # zypper install https://github.com/warewulf/warewulf/releases/download/v4.6.0/warewulf-4.6.0-1.suse.lp155.x86_64.rpm
 
 Container images
 ================
@@ -97,9 +97,9 @@ appropriate substitutions:
 
 .. code-block:: bash
 
-   curl -LO https://github.com/warewulf/warewulf/releases/download/v4.6.0rc2/warewulf-4.6.0rc2.tar.gz
-   tar -xf warewulf-4.6.0rc2.tar.gz
-   cd warewulf-4.6.0rc2
+   curl -LO https://github.com/warewulf/warewulf/releases/download/v4.6.0/warewulf-4.6.0.tar.gz
+   tar -xf warewulf-4.6.0.tar.gz
+   cd warewulf-4.6.0
    make all && sudo make install
 
 Git
@@ -118,7 +118,7 @@ from the main site, the GitHub releases page, or from a Git tag.
 
    git clone https://github.com/warewulf/warewulf.git
    cd warewulf
-   git checkout main # or switch to a tag like 'v4.6.0rc2'
+   git checkout main # or switch to a tag like 'v4.6.0'
    make all && sudo make install
 
 Runtime Dependencies
@@ -133,6 +133,22 @@ services. Generally these are provided by your distribution.
 
 If you are using an Enterprise Linux compatible distribution you can install
 them with ``dnf install dhcp-server tftp-server nfs-utils``.
+
+Building RPM packages from source
+=================================
+
+You can also build RPM packages from source.
+
+.. code-block:: bash
+
+   dnf -y install epel-release
+   dnf -y install make mock
+   git clone git@github.com:warewulf/warewulf.git
+   (
+      cd warewulf
+      make clean && make dist warewulf.spec && mock -r rocky+epel-9-$(arch) --rebuild --spec=warewulf.spec --sources=.
+   )
+   dnf -y install /var/lib/mock/rocky+epel-9-$(arch)/result/warewulf-*.$(arch).rpm
 
 Starting warewulfd
 ==================


### PR DESCRIPTION
## Description of the Pull Request (PR):

- Document using mock to build RPMs
- Clarify installing warewulf-dracut in the image
- Fix vestigial references to v4.6.0rc2
- Add a warning about using `PasswordlessRoot`

## This fixes or addresses the following GitHub issues:

- Closes: #1767
- Closes: #1769


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
