### PR TITLE
Set an IPMI tag ``vlan`` to configure the vlan during ``ipmiwrite``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added `wwctl overlay import --overwrite` to overwrite existing overlay file.
 - wwclient uses `WW_IPADDR`, if set, to contact the Warewulf server. #1788
 - Add `wwctl node import --yes` to assume yes to confirmations.
+- Set an IPMI tag ``vlan`` to configure the vlan during ``ipmiwrite``. #1031
 
 ### Fixed
 

--- a/overlays/wwinit/rootfs/warewulf/config.ww
+++ b/overlays/wwinit/rootfs/warewulf/config.ww
@@ -8,3 +8,6 @@ WWIPMI_GATEWAY="{{$.Ipmi.Gateway}}"
 WWIPMI_USER="{{$.Ipmi.UserName}}"
 WWIPMI_PASSWORD="{{$.Ipmi.Password}}"
 WWIPMI_WRITE="{{$.Ipmi.Write.Bool}}"
+{{- if $.Ipmi.Tags.vlan }}
+WWIPMI_VLAN="{{$.Ipmi.Tags.vlan}}"
+{{- end }}

--- a/overlays/wwinit/rootfs/warewulf/init.d/50-ipmi
+++ b/overlays/wwinit/rootfs/warewulf/init.d/50-ipmi
@@ -32,6 +32,16 @@ command -v ipmitool >/dev/null 2>&1 || (
 
 lan_info="$(ipmitool lan print 1)"
 
+if [ -n "$WWIPMI_VLAN" ]; then
+    prev_vlan=$(echo "$lan_info" | grep "^802.1q VLAN ID *:" | awk -F': ' '{print $2 }')
+    if [ "$prev_vlan" == "$WWIPMI_VLAN" ] || [ "$prev_vlan" = "Disabled" -a "$WWIPMI_VLAN" = off ]; then
+        echo "IPMI VLAN: $WWIPMI_VLAN"
+    else
+        echo "IPMI VLAN: $prev_vlan -> $WWIPMI_VLAN"
+        echo ipmitool lan set 1 vlan id "$WWIPMI_VLAN"
+    fi
+fi
+
 if [ -n "$WWIPMI_IPADDR" ]; then
     prev_ip=$(echo "$lan_info" | grep "^IP Address *:" | awk -F': ' '{ print $2 }')
     if [ "$prev_ip" != "$WWIPMI_IPADDR" ]; then

--- a/userdocs/nodes/ipmi.rst
+++ b/userdocs/nodes/ipmi.rst
@@ -28,6 +28,13 @@ desired IPMI configuration to the node's BMC during boot.
     wwctl node set n1 \
       --ipmiaddr=192.168.2.1
 
+Additionally, a ``vlan`` ipmi tag can be used to set the IPMI VLAN ID.
+
+.. code-block::
+
+   wwctl profile set default \
+     --ipmitagadd vlan=42
+
 ``wwctl node list`` has a specific overview for IPMI settings.
 
 .. code-block:: console


### PR DESCRIPTION
## Description of the Pull Request (PR):

Set an IPMI tag ``vlan`` to configure the vlan during ``ipmiwrite``


## This fixes or addresses the following GitHub issues:

- Closes: #1031


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
