### PR TITLE
Fix yaml indentation in network bond example

### DIFF
--- a/userdocs/nodes/network.rst
+++ b/userdocs/nodes/network.rst
@@ -51,16 +51,16 @@ The ``ifcfg`` and ``NetworkManager`` overlays can configure a network bond like 
        device: bond0
        ipaddr: 192.168.3.100
        netmask: 255.255.255.0
-   en1:
-     device: en1
-     hwaddr: e6:92:39:49:7b:03
-     tags:
-       master: bond0
-   en2:
-     device: en2
-     hwaddr: 9a:77:29:73:14:f1
-     tags:
-       master: bond0
+     en1:
+       device: en1
+       hwaddr: e6:92:39:49:7b:03
+       tags:
+         master: bond0
+     en2:
+       device: en2
+       hwaddr: 9a:77:29:73:14:f1
+       tags:
+         master: bond0
 
 .. _vlan:
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

The network bonding documentation had a yaml document with improper indentation.

https://warewulf.org/docs/v4.6.x/nodes/network.html#bonding

This fixes the indentation.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
