### PR TITLE
Restore some default behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed display of dotted field names. #1825
 - Add single quote around escapechar in ipmitool template #1830
 - Update nodes and profiles when renaming an image. #1637
+- If init is not specified, wwinit looks for /sbin/init, /etc/init, and /bin/init. #1808
+- assume ipxe template=default if not set. #1808, #1813
+- Display a warning during overlay build if an overlay list is empty. #1808
 
 ### Changed
 

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -110,12 +110,18 @@ func BuildAllOverlays(nodes []node.Node, allNodes []node.Node, workerCount int) 
 		for n := range nodeChan {
 			wwlog.Info("Building system overlay image for %s", n.Id())
 			wwlog.Debug("System overlays for %s: [%s]", n.Id(), strings.Join(n.SystemOverlay, ", "))
+			if len(n.SystemOverlay) < 1 {
+				wwlog.Warn("No system overlays defined for %s", n.Id())
+			}
 			if err := BuildOverlay(n, allNodes, "system", n.SystemOverlay); err != nil {
 				errChan <- fmt.Errorf("could not build system overlays %v for node %s: %w", n.SystemOverlay, n.Id(), err)
 			}
 
 			wwlog.Info("Building runtime overlay image for %s", n.Id())
 			wwlog.Debug("Runtime overlays for %s: [%s]", n.Id(), strings.Join(n.RuntimeOverlay, ", "))
+			if len(n.RuntimeOverlay) < 1 {
+				wwlog.Warn("No runtime overlays defined for %s", n.Id())
+			}
 			if err := BuildOverlay(n, allNodes, "runtime", n.RuntimeOverlay); err != nil {
 				errChan <- fmt.Errorf("could not build runtime overlays %v for node %s: %w", n.RuntimeOverlay, n.Id(), err)
 			}

--- a/internal/pkg/warewulfd/provision.go
+++ b/internal/pkg/warewulfd/provision.go
@@ -97,7 +97,11 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 		}
 
 	} else if rinfo.stage == "ipxe" {
-		stage_file = path.Join(conf.Paths.Sysconfdir, "warewulf/ipxe/"+remoteNode.Ipxe+".ipxe")
+		template := remoteNode.Ipxe
+		if template == "" {
+			template = "default"
+		}
+		stage_file = path.Join(conf.Paths.Sysconfdir, "warewulf/ipxe", template+".ipxe")
 		kernelArgs := ""
 		kernelVersion := ""
 		if remoteNode.Kernel != nil {

--- a/overlays/wwinit/rootfs/warewulf/wwprescripts
+++ b/overlays/wwinit/rootfs/warewulf/wwprescripts
@@ -9,6 +9,28 @@ ls -1 "${scriptdir}/" | while read -r name; do
     echo "Running prescript: ${name}..."
     sh "${scriptdir}/${name}"
 done
-echo
-echo "Running ${WWINIT}..."
-exec $WWINIT
+
+init="${WWINIT}"
+if [ -z "${init}" ]
+then
+    for candidate in /sbin/init /etc/init /bin/init
+    do
+        if [ -x "${candidate}" ]
+        then
+            init="${candidate}"
+            break
+        fi
+    done
+fi
+
+if [ -n "${init}" ]
+then
+    echo
+    echo "Running ${init}..."
+    exec "${init}"
+else
+    echo "ERROR: init not defined and not found."
+    echo "Rebooting in 1 minute..."
+    sleep 60
+    echo b > /proc/sysrq-trigger || /sbin/reboot -f
+fi


### PR DESCRIPTION
## Description of the Pull Request (PR):

- If `init` is not specified, wwinit looks for /sbin/init, /etc/init, and /bin/init, matching dracut behavior.
- assume ipxe template=default if not set
- Display a warning during overlay build if an overlay list is empty

## This fixes or addresses the following GitHub issues:

- Closes: #1808
- Closes: #1813

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
