### PR TITLE
Add indicated sleep and reboot during grub boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - assume ipxe template=default if not set. #1808, #1813
 - Display a warning during overlay build if an overlay list is empty. #1808
 - Fix processing of UNDEF and UNSET during `wwctl <node|profile> set`. #1837
+- Actually cause grub to sleep and reboot when log messages indiacte. #1838
 
 ### Changed
 

--- a/etc/grub/grub.cfg.ww
+++ b/etc/grub/grub.cfg.ww
@@ -58,6 +58,8 @@ menuentry "Single-stage boot" --id single-stage {
         echo "!! Unable to load kernel."
         echo "!! Rebooting in 15s..."
         echo "!!"
+        sleep 15
+        reboot
     fi
 
     echo "Downloading images..."
@@ -71,6 +73,8 @@ menuentry "Single-stage boot" --id single-stage {
         echo "!! Unable to load images."
         echo "!! Rebooting in 15s..."
         echo "!!"
+        sleep 15
+        reboot
     fi
 
     echo "Booting..."
@@ -101,6 +105,8 @@ menuentry "Single-stage boot (no compression)" --id single-stage-nocompress {
         echo "!! Unable to load kernel."
         echo "!! Rebooting in 15s..."
         echo "!!"
+        sleep 15
+        reboot
     fi
 
     echo "Downloading images..."
@@ -114,6 +120,8 @@ menuentry "Single-stage boot (no compression)" --id single-stage-nocompress {
         echo "!! Unable to load images."
         echo "!! Rebooting in 15s..."
         echo "!!"
+        sleep 15
+        reboot
     fi
 
     echo "Booting..."
@@ -151,6 +159,8 @@ menuentry "Two stage boot with dracut" --id dracut {
         echo "!! Unable to load kernel."
         echo "!! Rebooting in 15s..."
         echo "!!"
+        sleep 15
+        reboot
     fi
 
     echo "Downloading initramfs..."
@@ -161,6 +171,8 @@ menuentry "Two stage boot with dracut" --id dracut {
         echo "!! Unable to load initramfs."
         echo "!! Rebooting in 15s..."
         echo "!!"
+        sleep 15
+        reboot
     fi
 
     echo "Booting..."


### PR DESCRIPTION
## Description of the Pull Request (PR):

The grub network boot configuration had several places where it intended to sleep to display an error message and then reboot; but the sleep and reboot code was missing.


## This fixes or addresses the following GitHub issues:

- Closes: #1791


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
