### PR TITLE
wwctl upgrade nodes --replace-overlays avoids applying overlays multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix processing of UNDEF and UNSET during `wwctl <node|profile> set`. #1837
 - Actually cause grub to sleep and reboot when log messages indiacte. #1838
 - Fixed issue with importing new nodes from yaml. #1842
+- `wwctl upgrade nodes --replace-overlays` avoids applying overlays multiple times. #1823
 
 ### Changed
 

--- a/internal/pkg/upgrade/node.go
+++ b/internal/pkg/upgrade/node.go
@@ -329,18 +329,10 @@ func (legacy *Node) Upgrade(addDefaults bool, replaceOverlays bool) (upgraded *n
 		}
 	}
 	if replaceOverlays {
-		if indexOf(upgraded.SystemOverlay, "wwinit") != -1 {
-			upgraded.SystemOverlay = replaceSliceElement(
-				upgraded.SystemOverlay,
-				indexOf(upgraded.SystemOverlay, "wwinit"),
-				wwinitSplitOverlays)
-		}
-		if indexOf(upgraded.RuntimeOverlay, "generic") != -1 {
-			upgraded.RuntimeOverlay = replaceSliceElement(
-				upgraded.RuntimeOverlay,
-				indexOf(upgraded.RuntimeOverlay, "generic"),
-				genericSplitOverlays)
-		}
+		upgraded.SystemOverlay = replaceOverlay(
+			upgraded.SystemOverlay, "wwinit", wwinitSplitOverlays)
+		upgraded.RuntimeOverlay = replaceOverlay(
+			upgraded.RuntimeOverlay, "generic", genericSplitOverlays)
 	}
 	if legacy.Resources != nil {
 		for key, value := range legacy.Resources {
@@ -535,18 +527,10 @@ func (legacy *Profile) Upgrade(addDefaults bool, replaceOverlays bool) (upgraded
 		}
 	}
 	if replaceOverlays {
-		if indexOf(upgraded.SystemOverlay, "wwinit") != -1 {
-			upgraded.SystemOverlay = replaceSliceElement(
-				upgraded.SystemOverlay,
-				indexOf(upgraded.SystemOverlay, "wwinit"),
-				wwinitSplitOverlays)
-		}
-		if indexOf(upgraded.RuntimeOverlay, "generic") != -1 {
-			upgraded.RuntimeOverlay = replaceSliceElement(
-				upgraded.RuntimeOverlay,
-				indexOf(upgraded.RuntimeOverlay, "generic"),
-				genericSplitOverlays)
-		}
+		upgraded.SystemOverlay = replaceOverlay(
+			upgraded.SystemOverlay, "wwinit", wwinitSplitOverlays)
+		upgraded.RuntimeOverlay = replaceOverlay(
+			upgraded.RuntimeOverlay, "generic", genericSplitOverlays)
 	}
 	if legacy.Resources != nil {
 		for key, value := range legacy.Resources {

--- a/internal/pkg/upgrade/node_test.go
+++ b/internal/pkg/upgrade/node_test.go
@@ -676,7 +676,7 @@ nodes:
 `,
 	},
 	{
-		name:            "replace overlays conflicts",
+		name:            "replace overlays",
 		addDefaults:     false,
 		replaceOverlays: true,
 		legacyYaml: `
@@ -692,6 +692,99 @@ nodes:
       - generic
     system overlay:
       - wwinit
+`,
+		upgradedYaml: `
+nodeprofiles:
+  default:
+    runtime overlay:
+      - hosts
+      - ssh.authorized_keys
+      - syncuser
+    system overlay:
+      - wwinit
+      - wwclient
+      - fstab
+      - hostname
+      - ssh.host_keys
+      - issue
+      - resolv
+      - udev.netname
+      - systemd.netname
+      - ifcfg
+      - NetworkManager
+      - debian.interfaces
+      - wicked
+      - ignition
+nodes:
+  n1:
+    runtime overlay:
+      - hosts
+      - ssh.authorized_keys
+      - syncuser
+    system overlay:
+      - wwinit
+      - wwclient
+      - fstab
+      - hostname
+      - ssh.host_keys
+      - issue
+      - resolv
+      - udev.netname
+      - systemd.netname
+      - ifcfg
+      - NetworkManager
+      - debian.interfaces
+      - wicked
+      - ignition
+`,
+	},
+	{
+		name:            "replace overlays again",
+		addDefaults:     false,
+		replaceOverlays: true,
+		legacyYaml: `
+nodeprofiles:
+  default:
+    runtime overlay:
+      - hosts
+      - ssh.authorized_keys
+      - syncuser
+    system overlay:
+      - wwinit
+      - wwclient
+      - fstab
+      - hostname
+      - ssh.host_keys
+      - issue
+      - resolv
+      - udev.netname
+      - systemd.netname
+      - ifcfg
+      - NetworkManager
+      - debian.interfaces
+      - wicked
+      - ignition
+nodes:
+  n1:
+    runtime overlay:
+      - hosts
+      - ssh.authorized_keys
+      - syncuser
+    system overlay:
+      - wwinit
+      - wwclient
+      - fstab
+      - hostname
+      - ssh.host_keys
+      - issue
+      - resolv
+      - udev.netname
+      - systemd.netname
+      - ifcfg
+      - NetworkManager
+      - debian.interfaces
+      - wicked
+      - ignition
 `,
 		upgradedYaml: `
 nodeprofiles:

--- a/internal/pkg/upgrade/slices.go
+++ b/internal/pkg/upgrade/slices.go
@@ -15,3 +15,26 @@ func replaceSliceElement[T any](original []T, index int, replacement []T) []T {
 	}
 	return append(original[:index], append(replacement, original[index+1:]...)...)
 }
+
+func replaceOverlay(originals []string, toReplace string, replacements []string) []string {
+	if indexOf(originals, toReplace) == -1 {
+		return originals
+	}
+
+	lookup := make(map[string]bool)
+	for _, v := range originals {
+		lookup[v] = true
+	}
+
+	var newReplacements []string
+	for _, v := range replacements {
+		if !lookup[v] || v == toReplace {
+			newReplacements = append(newReplacements, v)
+		}
+	}
+
+	return replaceSliceElement(
+		originals,
+		indexOf(originals, toReplace),
+		newReplacements)
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

`wwctl upgrade nodes --replace-overlays` avoids applying overlays multiple times

## This fixes or addresses the following GitHub issues:

- Closes: #1823


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
