### PR TITLE
Explicitly enforce the number or arguments accepted by some `wwctl` subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Update GitHub actions to build aarch64 artifacts.
+- Explicitly enforce the number or arguments accepted by some `wwctl` subcommands. #1717
 
 ### Removed
 

--- a/internal/app/wwclient/root.go
+++ b/internal/app/wwclient/root.go
@@ -31,6 +31,7 @@ var (
 		Long:         "wwclient fetches the runtime overlay and puts it on the disk",
 		RunE:         CobraRunE,
 		SilenceUsage: true,
+		Args:         cobra.NoArgs,
 	}
 	DebugFlag       bool
 	PIDFile         string

--- a/internal/app/wwctl/configure/root.go
+++ b/internal/app/wwctl/configure/root.go
@@ -17,6 +17,7 @@ var (
 		Long: "This application allows you to manage and initialize Warewulf dependent system\n" +
 			"services based on the configuration in the warewulf.conf file.",
 		RunE: CobraRunE,
+		Args: cobra.NoArgs,
 	}
 	allFunctions bool
 )

--- a/internal/app/wwctl/image/delete/root.go
+++ b/internal/app/wwctl/image/delete/root.go
@@ -13,6 +13,7 @@ var (
 		Short:                 "Delete an imported image",
 		Long:                  "This command will delete IMAGEs that have been imported into Warewulf.",
 		RunE:                  CobraRunE,
+		Args:                  cobra.ArbitraryArgs,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) != 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp

--- a/internal/app/wwctl/image/list/root.go
+++ b/internal/app/wwctl/image/list/root.go
@@ -23,6 +23,7 @@ func GetCommand() *cobra.Command {
 		Long:                  "This command will show you the images that are imported into Warewulf.",
 		RunE:                  CobraRunE(&vars),
 		Aliases:               []string{"ls"},
+		Args:                  cobra.ArbitraryArgs,
 		ValidArgsFunction:     completions.Images,
 	}
 	baseCmd.PersistentFlags().BoolVarP(&vars.full, "long", "l", false, "show all")

--- a/internal/app/wwctl/image/root.go
+++ b/internal/app/wwctl/image/root.go
@@ -23,6 +23,7 @@ var baseCmd = &cobra.Command{
 		"node images. These commands will help you import, manage, and transform\n" +
 		"images into bootable Warewulf images.",
 	Aliases: []string{"vnfs", "container"},
+	Args:    cobra.NoArgs,
 }
 
 func init() {

--- a/internal/app/wwctl/node/edit/root.go
+++ b/internal/app/wwctl/node/edit/root.go
@@ -13,6 +13,7 @@ var (
 		Long:                  "This command opens an editor for the given nodes.",
 		RunE:                  CobraRunE,
 		ValidArgsFunction:     completions.Nodes,
+		Args:                  cobra.ArbitraryArgs,
 	}
 	NoHeader bool
 )

--- a/internal/app/wwctl/node/export/root.go
+++ b/internal/app/wwctl/node/export/root.go
@@ -13,6 +13,7 @@ var (
 		Long:                  "This command exports the given nodes as yaml to stdout.",
 		RunE:                  CobraRunE,
 		ValidArgsFunction:     completions.Nodes,
+		Args:                  cobra.ArbitraryArgs,
 	}
 	NoHeader bool
 )

--- a/internal/app/wwctl/node/list/root.go
+++ b/internal/app/wwctl/node/list/root.go
@@ -25,6 +25,7 @@ func GetCommand() *cobra.Command {
 		RunE:              CobraRunE(&vars),
 		Aliases:           []string{"ls"},
 		ValidArgsFunction: completions.Nodes,
+		Args:              cobra.ArbitraryArgs,
 	}
 	baseCmd.PersistentFlags().BoolVarP(&vars.showNet, "net", "n", false, "Show node network configurations")
 	baseCmd.PersistentFlags().BoolVarP(&vars.showIpmi, "ipmi", "i", false, "Show node IPMI configurations")

--- a/internal/app/wwctl/node/root.go
+++ b/internal/app/wwctl/node/root.go
@@ -23,6 +23,7 @@ var (
 			"node ranges. For example: n00[00-4].cluster[0-1] will identify the first 5 nodes\n" +
 			"in cluster0 and cluster1.",
 		Aliases: []string{"nodes"},
+		Args:    cobra.NoArgs,
 	}
 )
 

--- a/internal/app/wwctl/node/status/root.go
+++ b/internal/app/wwctl/node/status/root.go
@@ -13,6 +13,7 @@ var (
 		Long:                  "View and monitor the status of nodes as they are provisioned and check in.",
 		RunE:                  CobraRunE,
 		ValidArgsFunction:     completions.Nodes,
+		Args:                  cobra.ArbitraryArgs,
 	}
 	SetWatch       bool
 	SetUpdate      int

--- a/internal/app/wwctl/overlay/build/root.go
+++ b/internal/app/wwctl/overlay/build/root.go
@@ -13,6 +13,7 @@ var (
 		Long:                  "This command builds overlays for given nodes.",
 		RunE:                  CobraRunE,
 		ValidArgsFunction:     completions.Nodes,
+		Args:                  cobra.ArbitraryArgs,
 	}
 	OverlayNames []string
 	OverlayDir   string

--- a/internal/app/wwctl/overlay/list/root.go
+++ b/internal/app/wwctl/overlay/list/root.go
@@ -14,6 +14,7 @@ var (
 		RunE:                  CobraRunE,
 		Aliases:               []string{"ls"},
 		ValidArgsFunction:     completions.Overlays,
+		Args:                  cobra.ArbitraryArgs,
 	}
 	ListContents bool
 	ListLong     bool

--- a/internal/app/wwctl/overlay/root.go
+++ b/internal/app/wwctl/overlay/root.go
@@ -20,6 +20,7 @@ var (
 		Use:                   "overlay COMMAND [OPTIONS]",
 		Short:                 "Warewulf Overlay Management",
 		Long:                  "Management interface for Warewulf overlays",
+		Args:                  cobra.NoArgs,
 	}
 )
 

--- a/internal/app/wwctl/power/root.go
+++ b/internal/app/wwctl/power/root.go
@@ -16,6 +16,7 @@ var (
 		Use:                   "power COMMAND [OPTIONS]",
 		Short:                 "Warewulf node power management",
 		Long:                  "This command controls the power state of nodes.",
+		Args:                  cobra.NoArgs,
 	}
 )
 

--- a/internal/app/wwctl/profile/add/root.go
+++ b/internal/app/wwctl/profile/add/root.go
@@ -24,6 +24,7 @@ func GetCommand() *cobra.Command {
 		Aliases:               []string{"new", "create"},
 		RunE:                  CobraRunE(&vars),
 		ValidArgsFunction:     completions.None,
+		Args:                  cobra.MinimumNArgs(1),
 	}
 	vars.profileConf.CreateFlags(baseCmd)
 	vars.profileAdd.CreateAddFlags(baseCmd)

--- a/internal/app/wwctl/profile/edit/root.go
+++ b/internal/app/wwctl/profile/edit/root.go
@@ -13,6 +13,7 @@ var (
 		Long:                  "This command opens an editor for the given profiles.",
 		RunE:                  CobraRunE,
 		ValidArgsFunction:     completions.Profiles,
+		Args:                  cobra.ArbitraryArgs,
 	}
 	NoHeader bool
 )

--- a/internal/app/wwctl/profile/list/root.go
+++ b/internal/app/wwctl/profile/list/root.go
@@ -22,6 +22,7 @@ func GetCommand() *cobra.Command {
 		RunE:                  CobraRunE(&vars),
 		Aliases:               []string{"ls"},
 		ValidArgsFunction:     completions.Profiles,
+		Args:                  cobra.ArbitraryArgs,
 	}
 	baseCmd.PersistentFlags().BoolVarP(&vars.showAll, "all", "a", false, "Show all profile configurations")
 	baseCmd.PersistentFlags().BoolVarP(&vars.showYaml, "yaml", "y", false, "Show profile configurations via yaml format")

--- a/internal/app/wwctl/profile/root.go
+++ b/internal/app/wwctl/profile/root.go
@@ -15,6 +15,7 @@ var (
 		Use:                   "profile COMMAND [OPTIONS]",
 		Short:                 "Node configuration profile management",
 		Long:                  "Management of node profile settings",
+		Args:                  cobra.NoArgs,
 	}
 )
 

--- a/internal/app/wwctl/profile/set/root.go
+++ b/internal/app/wwctl/profile/set/root.go
@@ -35,6 +35,7 @@ func GetCommand() *cobra.Command {
 		Aliases:           []string{"modify"},
 		RunE:              CobraRunE(&vars),
 		ValidArgsFunction: completions.Profiles,
+		Args:              cobra.ArbitraryArgs,
 	}
 	vars.profileConf.CreateFlags(baseCmd)
 	vars.profileDel.CreateDelFlags(baseCmd)

--- a/internal/app/wwctl/root.go
+++ b/internal/app/wwctl/root.go
@@ -30,6 +30,7 @@ var (
 		PersistentPreRunE:     rootPersistentPreRunE,
 		SilenceUsage:          true,
 		SilenceErrors:         true,
+		Args:                  cobra.NoArgs,
 	}
 	verboseArg      bool
 	DebugFlag       bool


### PR DESCRIPTION
## Description of the Pull Request (PR):

Explicitly enforce the number or arguments accepted by some `wwctl` subcommands

## This fixes or addresses the following GitHub issues:

- Closes: #1717


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
