### PR TITLE
fix import from yaml where node does not pre-exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Display a warning during overlay build if an overlay list is empty. #1808
 - Fix processing of UNDEF and UNSET during `wwctl <node|profile> set`. #1837
 - Actually cause grub to sleep and reboot when log messages indiacte. #1838
+- Fixed issue with importing new nodes from yaml. #1842
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added `wwctl overlay import --overwrite` to overwrite existing overlay file.
 - wwclient uses `WW_IPADDR`, if set, to contact the Warewulf server. #1788
+- Add `wwctl node import --yes` to assume yes to confirmations.
 
 ### Fixed
 
@@ -31,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Update GitHub actions to build aarch64 artifacts.
 - Explicitly enforce the number or arguments accepted by some `wwctl` subcommands. #1717
+- Renamed `wwctl node import --cvs` to `--csv`.
 
 ### Removed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -45,3 +45,4 @@
 * Ian Kaufman <ikaufman@ucsd.edu> [@iankgt40](https://github.com/iankgt40)
 * Daniele Colombo [@dacolombo](https://github.com/dacolombo)
 * Stephen Simpson [@ssimpson89](https://github.com/ssimpson89)
+* Rafael Lopez <raflopez1@gmail.com> @rafalop

--- a/internal/app/wwctl/node/imprt/main.go
+++ b/internal/app/wwctl/node/imprt/main.go
@@ -27,11 +27,10 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("could not read: %s", err)
 	}
-	if !ImportCVS {
+	if !ImportCSV {
 		err = yaml.Unmarshal(buffer, importMap)
 		if err == nil {
-			yes := util.Confirm(fmt.Sprintf("Are you sure you want to modify %d nodes", len(importMap)))
-			if yes {
+			if setYes || util.Confirm(fmt.Sprintf("Are you sure you want to modify %d nodes", len(importMap))) {
 				err = apinode.NodeAddFromYaml(&wwapiv1.NodeYaml{NodeConfMapYaml: string(buffer)})
 				if err != nil {
 					return fmt.Errorf("got following problem when writing back yaml: %s", err)
@@ -68,8 +67,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 				}
 			}
 		}
-		yes := util.Confirm(fmt.Sprintf("Are you sure you want to import %d nodes", len(importMap)))
-		if yes {
+		if setYes || util.Confirm(fmt.Sprintf("Are you sure you want to import %d nodes", len(importMap))) {
 			// create second buffer an marshall nodeMap to it
 			buffer, err = yaml.Marshal(importMap)
 			if err != nil {

--- a/internal/app/wwctl/node/imprt/main_test.go
+++ b/internal/app/wwctl/node/imprt/main_test.go
@@ -1,0 +1,81 @@
+package imprt
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/testenv"
+	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
+)
+
+func Test_Node_Import(t *testing.T) {
+	tests := map[string]struct {
+		args       []string
+		importFile string
+		wantErr    bool
+		inDB       string
+		outDB      string
+	}{
+		"import new node": {
+			args: []string{"importFile"},
+			importFile: `
+n1:
+  id: n1
+  profiles:
+  - default
+  network devices:
+    eth0:
+      device: eth0
+      hwaddr: c4:cb:e1:bb:dd:e9
+      ipaddr: 192.168.1.10`,
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes: {}`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n1:
+    profiles:
+    - default
+    network devices:
+      eth0:
+        device: eth0
+        hwaddr: c4:cb:e1:bb:dd:e9
+        ipaddr: 192.168.1.10`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			env := testenv.New(t)
+			defer env.RemoveAll()
+			{
+				wd, err := os.Getwd()
+				assert.NoError(t, err)
+				defer func() { assert.NoError(t, os.Chdir(wd)) }()
+			}
+			assert.NoError(t, os.Chdir(env.GetPath(".")))
+			env.WriteFile("./importFile", tt.importFile)
+			env.WriteFile("etc/warewulf/nodes.conf", tt.inDB)
+			warewulfd.SetNoDaemon()
+
+			baseCmd := GetCommand()
+			args := append(tt.args, "--yes")
+			baseCmd.SetArgs(args)
+			buf := new(bytes.Buffer)
+			baseCmd.SetOut(buf)
+			baseCmd.SetErr(buf)
+			err := baseCmd.Execute()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				content := env.ReadFile("etc/warewulf/nodes.conf")
+				assert.YAMLEq(t, tt.outDB, content)
+			}
+		})
+	}
+}

--- a/internal/app/wwctl/node/imprt/root.go
+++ b/internal/app/wwctl/node/imprt/root.go
@@ -9,18 +9,25 @@ import (
 var (
 	baseCmd = &cobra.Command{
 		DisableFlagsInUseLine: true,
-		Use:                   "import [OPTIONS] NODENAME",
-		Short:                 "Import node(s) from yaml file",
+		Use:                   "import [OPTIONS] FILE",
+		Short:                 "Import node(s) from yaml FILE",
 		Long:                  "This command imports all the nodes defined in a file. It will overwrite nodes with same name.",
 		RunE:                  CobraRunE,
 		Args:                  cobra.ExactArgs(1),
 		Aliases:               []string{"import"},
 	}
-	ImportCVS bool
+	ImportCSV bool
+	setYes    bool
 )
 
 func init() {
-	baseCmd.PersistentFlags().BoolVarP(&ImportCVS, "cvs", "c", false, "Import CVS file")
+	baseCmd.PersistentFlags().BoolVarP(&ImportCSV, "csv", "c", false, "Import CSV file")
+	baseCmd.Flags().BoolVar(&ImportCSV, "cvs", false, "Import CSV file")
+	baseCmd.Flags().Lookup("cvs").Hidden = true
+	if err := baseCmd.Flags().MarkDeprecated("cvs", "use --csv instead"); err != nil {
+		panic(err)
+	}
+	baseCmd.PersistentFlags().BoolVarP(&setYes, "yes", "y", false, "Set 'yes' to all questions asked")
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/internal/pkg/api/node/edit.go
+++ b/internal/pkg/api/node/edit.go
@@ -21,14 +21,14 @@ func NodeAddFromYaml(nodeList *wwapiv1.NodeYaml) (err error) {
 	if err != nil {
 		return fmt.Errorf("could not unmarshal Yaml: %w", err)
 	}
-	for nodeName, node := range nodeMap {
+	for nodeName, nodeData := range nodeMap {
 		if _, err = nodeDB.GetNodeOnly(nodeName); err == node.ErrNotFound {
 			_, err = nodeDB.AddNode(nodeName)
 			if err != nil {
 				return fmt.Errorf("couldn't add new node: %w", err)
 			}
 		}
-		err = nodeDB.SetNode(nodeName, *node)
+		err = nodeDB.SetNode(nodeName, *nodeData)
 		if err != nil {
 			return fmt.Errorf("couldn't set node: %w", err)
 		}

--- a/internal/pkg/api/node/edit.go
+++ b/internal/pkg/api/node/edit.go
@@ -22,6 +22,12 @@ func NodeAddFromYaml(nodeList *wwapiv1.NodeYaml) (err error) {
 		return fmt.Errorf("could not unmarshal Yaml: %w", err)
 	}
 	for nodeName, node := range nodeMap {
+		if _, err = nodeDB.GetNodeOnly(nodeName); err == node.ErrNotFound {
+			_, err = nodeDB.AddNode(nodeName)
+			if err != nil {
+				return fmt.Errorf("couldn't add new node: %w", err)
+			}
+		}
 		err = nodeDB.SetNode(nodeName, *node)
 		if err != nil {
 			return fmt.Errorf("couldn't set node: %w", err)


### PR DESCRIPTION
Check if node exists, if not add it first before
attempting SetNode().

Fixes: #1842

## Description of the Pull Request (PR):

Currently `wwctl node import /some/yaml` that contains new node entries fails. This appears to be because the NodeAddFromYaml function only calls SetNode, which expects a node id to already exist in the node db (nodes.conf). This PR adds the code to check if the node exists, if not, add it first before calling SetNode.


## This fixes or addresses the following GitHub issues:

- Fixes #1842


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
