### PR TITLE
Make nm-wait-online-initrd.service wait for interfaces to be online during dracut boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- Added override.conf for nm-wait-online-initrd.service with dracut.
+
 ## v4.6.1, 2025-04-04
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ install: build docs ## Install Warewulf from source
 	for f in docs/man/man1/*.1.gz; do install -m 0644 $$f $(DESTDIR)$(MANDIR)/man1/; done
 	for f in docs/man/man5/*.5.gz; do install -m 0644 $$f $(DESTDIR)$(MANDIR)/man5/; done
 	install -pd -m 0755 $(DESTDIR)$(DRACUTMODDIR)/90wwinit
-	install -m 0644 dracut/modules.d/90wwinit/*.sh $(DESTDIR)$(DRACUTMODDIR)/90wwinit
+	install -m 0644 dracut/modules.d/90wwinit/*.sh  dracut/modules.d/90wwinit/*.override $(DESTDIR)$(DRACUTMODDIR)/90wwinit
 
 .PHONY: install-sos
 install-sos:

--- a/dracut/modules.d/90wwinit/module-setup.sh
+++ b/dracut/modules.d/90wwinit/module-setup.sh
@@ -17,4 +17,8 @@ install() {
     inst_multiple cpio curl dmidecode
     inst_hook cmdline 30 "$moddir/parse-wwinit.sh"
     inst_hook pre-mount 30 "$moddir/load-wwinit.sh"
+    if dracut_module_included "network-manager" && dracut_module_included "systemd"
+    then
+        inst_simple "$moddir/nm-wait-online-initrd.service.override" "/etc/systemd/system/nm-wait-online-initrd.service.d/override.conf"
+    fi
 }

--- a/dracut/modules.d/90wwinit/nm-wait-online-initrd.service.override
+++ b/dracut/modules.d/90wwinit/nm-wait-online-initrd.service.override
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/nm-online -q -t 300


### PR DESCRIPTION
## Description of the Pull Request (PR):

While discussing #1800 the underlying cause of dracut not necessarily waiting for configured interfaces to actually be up was found. This PR adds an ```override.conf``` when the ```systemd``` and ```network-manager``` modules are included in dracut for the ```nm-online-wait-initrd.service``` unit that removes the ```-s``` argument to the ```nm-online``` invocation in that unit. ```nm-online -s``` returns once ```NetworkManager``` is up and configuration for defined interfaces is requested but not necessarily when interfaces are fully configured and up. This change should make ```nm-online``` wait until the timeout is reached (300s in this pr) or configured interfaces are actually up.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
