### PR TITLE
Fix a panic during `wwctl node list --ipmi` for nodes with no ipmi configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Actually cause grub to sleep and reboot when log messages indiacte. #1838
 - Fixed issue with importing new nodes from yaml. #1842
 - `wwctl upgrade nodes --replace-overlays` avoids applying overlays multiple times. #1823
+- Fix a panic during `wwctl node list --ipmi` for nodes with no ipmi configuration. #1847
 
 ### Changed
 

--- a/internal/app/wwctl/node/list/main_test.go
+++ b/internal/app/wwctl/node/list/main_test.go
@@ -189,6 +189,18 @@ nodes:
 `,
 		},
 		{
+			name:    "node list with no ipmi data",
+			args:    []string{"--ipmi"},
+			wantErr: false,
+			stdout: `
+NODE  IPMI IPADDR  IPMI PORT  IPMI USERNAME  IPMI INTERFACE
+----  -----------  ---------  -------------  --------------
+n1    --           --         --             --`,
+			inDb: `
+nodes:
+  n1: {}`,
+		},
+		{
 			name:    "node list profile with ipmi user",
 			args:    []string{"-i"},
 			wantErr: false,

--- a/internal/pkg/api/node/list.go
+++ b/internal/pkg/api/node/list.go
@@ -64,13 +64,20 @@ func NodeList(nodeGet *wwapiv1.GetNodeList) (nodeList wwapiv1.NodeList, err erro
 		nodeList.Output = append(nodeList.Output,
 			fmt.Sprintf("%s:=:%s:=:%s:=:%s:=:%s", "NODE", "IPMI IPADDR", "IPMI PORT", "IPMI USERNAME", "IPMI INTERFACE"))
 		for _, n := range node.FilterNodeListByName(nodes, nodeGet.Nodes) {
+			ipaddr, port, username, iface := "", "", "", ""
+			if n.Ipmi != nil {
+				ipaddr = n.Ipmi.Ipaddr.String()
+				port = n.Ipmi.Port
+				username = n.Ipmi.UserName
+				iface = n.Ipmi.Interface
+			}
 			nodeList.Output = append(nodeList.Output,
 				fmt.Sprintf("%s:=:%s:=:%s:=:%s:=:%s",
 					n.Id(),
-					n.Ipmi.Ipaddr.String(),
-					n.Ipmi.Port,
-					n.Ipmi.UserName,
-					n.Ipmi.Interface))
+					ipaddr,
+					port,
+					username,
+					iface))
 		}
 	} else if nodeGet.Type == wwapiv1.GetNodeList_Long {
 		nodeList.Output = append(nodeList.Output,


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix a panic during `wwctl node list --ipmi` for nodes with no ipmi configuration.


## This fixes or addresses the following GitHub issues:

- Fixes #1847


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
