### PR TITLE
Enable Support for IPv6 PXE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - wwclient uses `WW_IPADDR`, if set, to contact the Warewulf server. #1788
 - Add `wwctl node import --yes` to assume yes to confirmations.
 - Set an IPMI tag ``vlan`` to configure the vlan during ``ipmiwrite``. #1031
-- IPv6 support
+- IPv6 PXE support
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - wwclient uses `WW_IPADDR`, if set, to contact the Warewulf server. #1788
 - Add `wwctl node import --yes` to assume yes to confirmations.
 - Set an IPMI tag ``vlan`` to configure the vlan during ``ipmiwrite``. #1031
+- IPv6 support
 
 ### Fixed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,4 +46,4 @@
 * Daniele Colombo [@dacolombo](https://github.com/dacolombo)
 * Stephen Simpson [@ssimpson89](https://github.com/ssimpson89)
 * Rafael Lopez <raflopez1@gmail.com> @rafalop
-* Dacian Reece-Stremtan <dacianstremtan@gmail.com> [@dacianstremtan](https://github.com/dacianstremtan)
+* Dacian Reece-Stremtan <dacianstremtan@gmail.com> 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,3 +46,4 @@
 * Daniele Colombo [@dacolombo](https://github.com/dacolombo)
 * Stephen Simpson [@ssimpson89](https://github.com/ssimpson89)
 * Rafael Lopez <raflopez1@gmail.com> @rafalop
+* Dacian Reece-Stremtan <dacianstremtan@gmail.com> [@dacianstremtan](https://github.com/dacianstremtan)

--- a/internal/pkg/config/root.go
+++ b/internal/pkg/config/root.go
@@ -137,16 +137,21 @@ func (conf *WarewulfYaml) Parse(data []byte, autodetect bool) error {
 			}
 		}
 	}
-
-	if conf.Ipaddr6 != "" {
-		if _, network, err := net.ParseCIDR(conf.Ipaddr6); err == nil {
-			if conf.Ipv6net == "" {
-				conf.Ipv6net = network.IP.String()
-			}
-		} else {
-			return fmt.Errorf("invalid ipv6 address: must use CIDR notation: %s", conf.Ipaddr6)
-		}
-	}
+        if conf.Ipaddr6 != "" {
+                if conf.Ipv6net == "" {
+                        wwlog.Error("Ipv6 network has not been set in warewulf.conf: ipv6net")
+                        return fmt.Errorf("Invalid Ipv6 network")
+                }
+                _, ipv6net, err := net.ParseCIDR(conf.Ipv6net)
+                if err != nil {
+                        wwlog.Error("Invalid Ipv6 address specified, must be CIDR notation: %s", conf.Ipv6net)
+                        return fmt.Errorf("Invalid Ipv6 network")
+                }
+                if msize, _ := ipv6net.Mask.Size(); msize > 64 {
+                        wwlog.Error("ipv6 mask size must be smaller than 64")
+                        return fmt.Errorf("Invalid Ipv6 network size")
+                }
+        }
 
 	return nil
 }

--- a/internal/pkg/config/root.go
+++ b/internal/pkg/config/root.go
@@ -137,21 +137,21 @@ func (conf *WarewulfYaml) Parse(data []byte, autodetect bool) error {
 			}
 		}
 	}
-        if conf.Ipaddr6 != "" {
-                if conf.Ipv6net == "" {
-                        wwlog.Error("Ipv6 network has not been set in warewulf.conf: ipv6net")
-                        return fmt.Errorf("Invalid Ipv6 network")
-                }
-                _, ipv6net, err := net.ParseCIDR(conf.Ipv6net)
-                if err != nil {
-                        wwlog.Error("Invalid Ipv6 address specified, must be CIDR notation: %s", conf.Ipv6net)
-                        return fmt.Errorf("Invalid Ipv6 network")
-                }
-                if msize, _ := ipv6net.Mask.Size(); msize > 64 {
-                        wwlog.Error("ipv6 mask size must be smaller than 64")
-                        return fmt.Errorf("Invalid Ipv6 network size")
-                }
-        }
+	if conf.Ipaddr6 != "" {
+		if conf.Ipv6net == "" {
+			wwlog.Error("Ipv6 network has not been set in warewulf.conf: ipv6net")
+			return fmt.Errorf("Invalid Ipv6 network")
+		}
+		_, ipv6net, err := net.ParseCIDR(conf.Ipv6net)
+		if err != nil {
+			wwlog.Error("Invalid Ipv6 address specified, must be CIDR notation: %s", conf.Ipv6net)
+			return fmt.Errorf("Invalid Ipv6 network")
+		}
+		if msize, _ := ipv6net.Mask.Size(); msize > 64 {
+			wwlog.Error("ipv6 mask size must be smaller than 64")
+			return fmt.Errorf("Invalid Ipv6 network size")
+		}
+	}
 
 	return nil
 }

--- a/internal/pkg/warewulfd/parser.go
+++ b/internal/pkg/warewulfd/parser.go
@@ -12,6 +12,7 @@ import (
 type parserInfo struct {
 	hwaddr     string
 	ipaddr     string
+	ipaddr6    string
 	remoteport int
 	assetkey   string
 	uuid       string
@@ -47,21 +48,19 @@ func parseReq(req *http.Request) (parserInfo, error) {
 	}
 	ret.hwaddr = hwaddr
 	ipaddrtemp = ""
-        ipaddr = strings.Split(req.RemoteAddr, ":")
-        // IPv6 addresses hextets are split on ":"
-        if len(ipaddr) > 2 {
-                for i := 0; i < len(ipaddr)-1; i++ {
-                        ipaddrtemp += ipaddr[i] + ":"
-                }
-                ret.ipaddr6 = strings.TrimSuffix(ipaddrtemp, ":")
-        }
-        ret.ipaddr = strings.Split(req.RemoteAddr, ":")[0]
-        ret.remoteport, _ = strconv.Atoi(strings.Split(req.RemoteAddr, ":")[len(ipaddr)-1])
-        if ret.remoteport == 0 {
-                return ret, errors.New("could not obtain remote port from HTTP request: " + req.RemoteAddr)
-        }
-	ret.remoteport, _ = strconv.Atoi(strings.Split(req.RemoteAddr, ":")[1])
-
+	ipaddr = strings.Split(req.RemoteAddr, ":")
+	// IPv6 addresses hextets are split on ":"
+	if len(ipaddr) > 2 {
+		for i := 0; i < len(ipaddr)-1; i++ {
+			ipaddrtemp += ipaddr[i] + ":"
+		}
+		ret.ipaddr6 = strings.TrimSuffix(ipaddrtemp, ":")
+	}
+	ret.ipaddr = strings.Split(req.RemoteAddr, ":")[0]
+	ret.remoteport, _ = strconv.Atoi(strings.Split(req.RemoteAddr, ":")[len(ipaddr)-1])
+	if ret.remoteport == 0 {
+		return ret, errors.New("could not obtain remote port from HTTP request: " + req.RemoteAddr)
+	}
 	if len(req.URL.Query()["assetkey"]) > 0 {
 		ret.assetkey = req.URL.Query()["assetkey"][0]
 	}

--- a/internal/pkg/warewulfd/provision.go
+++ b/internal/pkg/warewulfd/provision.go
@@ -31,6 +31,7 @@ type templateVars struct {
 	ImageName     string
 	Hwaddr        string
 	Ipaddr        string
+	Ipaddr6       string
 	Port          string
 	KernelArgs    string
 	KernelVersion string
@@ -118,6 +119,7 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 			Cluster:       remoteNode.ClusterName,
 			Fqdn:          remoteNode.Id(),
 			Ipaddr:        conf.Ipaddr,
+			Ipaddr6:       conf.Ipaddr6,
 			Port:          strconv.Itoa(conf.Warewulf.Port),
 			Hostname:      remoteNode.Id(),
 			Hwaddr:        rinfo.hwaddr,
@@ -205,6 +207,7 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 				Cluster:       remoteNode.ClusterName,
 				Fqdn:          remoteNode.Id(),
 				Ipaddr:        conf.Ipaddr,
+				Ipaddr6:       conf.Ipaddr6,
 				Port:          strconv.Itoa(conf.Warewulf.Port),
 				Hostname:      remoteNode.Id(),
 				Hwaddr:        rinfo.hwaddr,


### PR DESCRIPTION
## Description of the Pull Request (PR):

This allow PXE using IPv6 IP address for the controller. 

Manual change needs to be done to the 

/etc/warewulf/ipxe/default.pxe:
e.g. set baseuri http://{{.Ipaddr6}}:{{.Port}}/provision/{{.Hwaddr}}

/etc/dhcp/dhcpd.conf: 
....
if exists user-class and option user-class = "iPXE" {
    filename "http://[.Ipaddr6]:9873/ipxe/${mac:hexhyp}";
} else 
...
/etc/dhcp/dhcpd6.conf:
....
if exists dhcp6.user-class and substring (option dhcp6.user-class, 2, 4) = "iPXE" {
       option dhcp6.bootfile-url "http://[.Ipaddr6]:9873/ipxe/${mac:hexhyp}";
}
else if exists dhcp6.client-arch-type and option dhcp6.client-arch-type = 00:07 {
       option dhcp6.bootfile-url "tftp://[.Ipaddr6]/warewulf/snponly.efi" ;
}
....


## This fixes or addresses the following GitHub issues:

- Fixes #


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
