### PR TITLE
Update documentation to include instruction for using wwctl node import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Added override.conf for nm-wait-online-initrd.service with dracut.
+- Added userdocs for `wwctl node import` from yaml/csv.
 
 ### Fixed
 

--- a/userdocs/nodes/nodes.rst
+++ b/userdocs/nodes/nodes.rst
@@ -199,3 +199,81 @@ overlays.
              passno: 0
 
 Resources can only be managed with ``wwctl node edit``.
+
+Importing Nodes From a File
+===========================
+
+You can import nodes into Warewulf by using the ``wwctl node import`` command. The
+file used must be in YAML or CSV format. 
+
+.. warning::
+   Importing a node configuration will fully overwrite the existing settings, 
+   including any customizations not present in the import file. If the node 
+   already exists and you wish to update it, ensure that the import file 
+   includes all the options you want to retain.
+
+CSV Import
+----------
+
+.. note::
+   As of Warewulf v4.6.1, the csv import functionality is broken and an 
+   `issue <https://github.com/warewulf/warewulf/issues/1862>`_
+   has been created to track this.
+
+The CSV file must have a header where the first field must always be the nodename, 
+and the rest of the fields are the same as the long commandline options. Network 
+device must have the form ``net.$NETNAME.$NETOPTION``. (e.g., ``net.default.ipaddr``). 
+Tags are currently not supported and must be added separately after the import. 
+
+As an example, the following CSV file:
+
+.. code-block:: csv
+
+   nodename,net.default.hwaddr,net.default.ipaddr,net.default.netmask,net.default.gateway,discoverable,image
+   n1,00:00:00:00:00:01,10.0.2.1,255.255.255.0,10.0.2.254,false,rockylinux-9
+
+This can be imported with the following command:
+
+.. code-block:: shell
+
+   wwctl node import --csv /path/to/nodes.csv
+
+YAML Import
+-----------
+
+The YAML file must be a mapping of node names to their attributes, where each node is represented as a dictionary of attributes. 
+To simplify the creation of the YAML file, you can use the wwctl node export command to export the current node configuration to a YAML file. 
+This exported file can serve as a template for creating new nodes.
+
+A minimal example of a YAML file looks like this:
+
+.. code-block:: yaml
+
+   n1:
+      profiles:
+         - default
+      image name: rockylinux-9
+      ipxe template: default
+      kernel:
+         args:
+            - quiet
+            - crashkernel=no
+            - nosplash
+            - console=ttyS0,115200
+      network devices:
+         default:
+            type: ethernet
+            device: eno1
+            hwaddr: "00:00:00:00:00:01"
+            ipaddr: 10.0.2.1
+            netmask: 255.255.255.0
+            gateway: 172.16.131.1
+            tags:
+            DNS1: 1.1.1.1
+      primary network: default
+
+This can be imported with the following command:
+
+.. code-block:: shell
+
+   wwctl node import /path/to/nodes.yaml


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds a very basic overview on how to use `wwctl node import` for both CSV and YAML files. There is a note about a current bug that prevents CSV importing.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
