### PR TITLE
Fix typo in rpm github action

### DIFF
--- a/.github/actions/rpm/action.yml
+++ b/.github/actions/rpm/action.yml
@@ -59,7 +59,7 @@ runs:
         GENERIC_RELEASE=$(rpm -q --qf "%{RELEASE}\n" --specfile warewulf.spec | cut -d. -f1 | head -1)
         RPM=warewulf-${VERSION}-${GENERIC_RELEASE}.${{ inputs.dist }}.${{ inputs.arch }}.rpm
         SRPM=warewulf-${VERSION}-${GENERIC_RELEASE}.${{ inputs.dist }}.src.rpm
-        DRACUT=wareful-dracut-${VERSION}-${GENERIC_RELEASE}.${{ inputs.dist }}.noarch.rpm
+        DRACUT=warewulf-dracut-${VERSION}-${GENERIC_RELEASE}.${{ inputs.dist }}.noarch.rpm
         echo "RPM=${RPM}" >> $GITHUB_ENV
         echo "SRPM=${SRPM}" >> $GITHUB_ENV
         echo "DRACUT=${DRACUT}" >> $GITHUB_ENV


### PR DESCRIPTION
## Description of the Pull Request (PR):

Seemed like a typo. No changelog.


## This fixes or addresses the following GitHub issues:

- Fixes # N/A


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
