### PR TITLE
Fixed a regression in SELinux support by restoring the `/run` mount during wwinit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Updated 70-persistent-net.rules.ww to use `(lower $netdev.Type)` for case-insensitive comparison of "infiniband".
+- Fixed a regression in SELinux support by restoring the `/run` mount during wwinit. #1910
 
 ### Removed
 

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -6,6 +6,8 @@ echo "Mounting kernel file systems..."
 mountpoint -q /proc || (mkdir -p /proc && mount -t proc proc /proc && echo "Mounted /proc")
 mountpoint -q /dev || (mkdir -p /dev && mount -t devtmpfs devtmpfs /dev && echo "Mounted /dev")
 mountpoint -q /sys || (mkdir -p /sys && mount -t sysfs sysfs /sys && echo "Mounted /sys")
+# https://systemd.io/INITRD_INTERFACE/
+mountpoint -q /run || (mkdir -p /run && mount -t tmpfs -o mode=0755,nodev,nosuid,strictatime tmpfs /run && echo "Mounted /run")
 echo
 echo "Loading /warewulf/config..."
 if [ -f "/warewulf/config" ]; then


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fixed a regression in SELinux support by restoring the `/run` mount during wwinit.

https://systemd.io/INITRD_INTERFACE/

## This fixes or addresses the following GitHub issues:

- Fixes: #1910


## Reviewer checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
