### PR TITLE
Debian doc includes build option in import command (#1915)

### DIFF
--- a/userdocs/getting-started/debian-quickstart.rst
+++ b/userdocs/getting-started/debian-quickstart.rst
@@ -127,7 +127,7 @@ and set it for the "default" node profile.
 
 .. code-block:: bash
 
-   sudo wwctl image import docker://ghcr.io/warewulf/warewulf-debian:12.0 debian-12.0
+   sudo wwctl image import --build docker://ghcr.io/warewulf/warewulf-debian:12.0 debian-12.0
    sudo wwctl profile set default --image=debian-12.0
 
 Set up the default node profile


### PR DESCRIPTION
## Description of the Pull Request (PR):
add `--build` to import command in debian [quick start guide](https://warewulf.org/docs/main/getting-started/debian-quickstart.html)


## This fixes or addresses the following GitHub issues:

- Fixes #1915


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md) -- too small a change
- [ ] The test suite has been updated, if necessary
