### PR TITLE
Fix width of wwctl image shell --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Do not let API add a node that exists
 - Fixed sleep/rebooting on error during GRUB boot. #1894
 - Fixed IPMI VLAN configuration. #1892
+- Fixed `wwctl image shell --help` to fit properly within 80 columns.
 
 ### Changed
 

--- a/internal/app/wwctl/image/shell/root.go
+++ b/internal/app/wwctl/image/shell/root.go
@@ -31,10 +31,12 @@ var (
 
 func init() {
 	baseCmd.PersistentFlags().StringArrayVarP(&binds, "bind", "b", []string{}, `source[:destination[:{ro|copy}]]
-Bind a local path which must exist into the image. If destination is not
-set, uses the same path as source. "ro" binds read-only. "copy" temporarily
+Bind a local path which must exist into the image.
+If destination is not set, uses the same path as
+source. "ro" binds read-only. "copy" temporarily
 copies the file into the image.`)
-	baseCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", "Create a read only view of the image for the given node")
+	baseCmd.PersistentFlags().StringVarP(&nodeName, "node", "n", "", `Create a read only view of the image for the given
+node`)
 	baseCmd.PersistentFlags().BoolVar(&syncUser, "syncuser", false, "Synchronize UIDs/GIDs from host to image")
 	baseCmd.PersistentFlags().BoolVar(&build, "build", true, "(Re)build the image automatically")
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Make `wwctl image shell --help` fit within 80 columns.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
