### PR TITLE
Move the wwclient binary to wwclient overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Added `-l` flag to `wwctl image list` within the sos plugin for better reporting. #1855
+- Moved `wwclient` binary to the `wwclient` overlay.
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,6 @@ install: build docs ## Install Warewulf from source
 	install -d -m 0755 $(DESTDIR)$(WWCHROOTDIR)
 	install -d -m 0755 $(DESTDIR)$(WWOVERLAYDIR)
 	install -d -m 0755 $(DESTDIR)$(WWPROVISIONDIR)
-	install -d -m 0755 $(DESTDIR)$(DATADIR)/warewulf/overlays/wwinit/rootfs/$(WWCLIENTDIR)
 	install -d -m 0755 $(DESTDIR)$(DATADIR)/warewulf/overlays/wwclient/rootfs/$(WWCLIENTDIR)
 	install -d -m 0755 $(DESTDIR)$(DATADIR)/warewulf/overlays/host/rootfs/$(TFTPDIR)/warewulf/
 	install -d -m 0755 $(DESTDIR)$(WWCONFIGDIR)/examples
@@ -207,7 +206,7 @@ install: build docs ## Install Warewulf from source
 	chmod 0600 $(DESTDIR)$(DATADIR)/warewulf/overlays/NetworkManager/rootfs/etc/NetworkManager/system-connections/ww4-managed.ww
 	chmod 0750 $(DESTDIR)$(DATADIR)/warewulf/overlays/host/rootfs
 	install -m 0755 wwctl $(DESTDIR)$(BINDIR)
-	install -m 0755 wwclient $(DESTDIR)$(DATADIR)/warewulf/overlays/wwinit/rootfs/$(WWCLIENTDIR)/wwclient
+	install -m 0755 wwclient $(DESTDIR)$(DATADIR)/warewulf/overlays/wwclient/rootfs/$(WWCLIENTDIR)/wwclient
 	install -m 0644 include/firewalld/warewulf.xml $(DESTDIR)$(FIREWALLDDIR)
 	install -m 0644 include/systemd/warewulfd.service $(DESTDIR)$(SYSTEMDDIR)
 	install -m 0644 LICENSE.md $(DESTDIR)$(WWDOCDIR)


### PR DESCRIPTION
## Description of the Pull Request (PR):

When splitting overlays, we missed the wwclient binary because it isn't in the overlay source, but placed in the overlay by `make install`. Now it is placed in the wwclient overlay rather than wwinit.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
