### PR TITLE
Preserve file permissions during wwctl overlay edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed sleep/rebooting on error during GRUB boot. #1894
 - Fixed IPMI VLAN configuration. #1892
 - Fixed `wwctl image shell --help` to fit properly within 80 columns.
+- Preserve existing permissions during `wwctl overlay edit`. #1886
 
 ### Changed
 

--- a/internal/app/wwctl/overlay/edit/main.go
+++ b/internal/app/wwctl/overlay/edit/main.go
@@ -111,16 +111,10 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 		}
 	}
 
-	// try renaming the tempfile to overlayfile first
-	err = os.Rename(tempFile.Name(), overlayFile)
-	if err != nil {
-		// if it fails, which probably means that they exists on different partitions
-		// fallback to data copy
-		wwlog.Debug("Unable to rename temp file: %s to overlay file: %s, try copying the data", tempFile.Name(), overlayFile)
-		cerr := util.CopyFile(tempFile.Name(), overlayFile)
-		if cerr != nil {
-			return fmt.Errorf("unable to copy data from temp file: %s to target file: %s, err: %s", tempFile.Name(), overlayFile, err)
-		}
+	// using CopyFile preserves target file permissions
+	cerr := util.CopyFile(tempFile.Name(), overlayFile)
+	if cerr != nil {
+		return fmt.Errorf("unable to copy data from temp file: %s to target file: %s, err: %s", tempFile.Name(), overlayFile, err)
 	}
 
 	return nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

Simplifies copying edited tmpfile back to original location, which also preserves permissions from the original file during the edit.

## This fixes or addresses the following GitHub issues:

- Fixes: #1886

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
