### PR TITLE
Additional nettag documentation in userdocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added systemd.mount and systemd.swap overlays. #1894
 - Support configuring Ignition with resources. #1894
 - Added `wwctl <node|partition> set --parttype`. #1894
+- Added additional documentation for network tags. #1856
 
 ### Fixed
 

--- a/userdocs/nodes/network.rst
+++ b/userdocs/nodes/network.rst
@@ -34,6 +34,17 @@ specifying  ``--netname``.
    an interface may fail to be named correct if its desired name conflicts with
    the kernel-assigned name of another interface during the boot process.
 
+.. _nettags:
+
+Network Tags
+============
+
+Each network device can optionally have one or more key-value pair tags.
+
+.. code-block:: shell
+
+   wwctl node set n1 --nettagadd="DNS1=1.1.1.1"
+
 .. _bonding:
 
 Bonding

--- a/userdocs/overlays/overlays.rst
+++ b/userdocs/overlays/overlays.rst
@@ -260,8 +260,13 @@ The **issue** overlay configures a standard Warewulf status message for display
 during login.
 
 The **resolv** overlay configures ``/etc/resolv.conf`` based on the value of
-"DNS" nettags. (In most situations this should be unnecessary, as the network
-interface configuration should handle this dynamically.)
+"DNS" :ref:`nettags <nettags>`. (In most situations this should be unnecessary,
+as the network interface configuration should handle this dynamically.)
+
+.. code-block:: shell
+
+   wwctl node set n1 --nettagadd="DNS1=1.1.1.1"
+   wwctl node set n1 --nettagadd="DNS2=1.0.0.1"
 
 fstab
 -----


### PR DESCRIPTION
## This fixes or addresses the following GitHub issues:

- Fixes #1856


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
