### PR TITLE
Fix wwctl upgrade nodes to handle kernel argument lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Restore default idempotency of `PUT /api/nodes/{id}`
 - `DELETE /api/overlays/{name}?force=true` can delete overlays that are in use
 - `warewulfd` overlay autobuild rebuilds overlays after node discovery. #1468
-### Fixed
-
 - Improved netplan support. #1873
 
 ### Fixed
 
 - Fixed a bug when cloning an overlay to site when parent is missing
+- Fixed `wwctl upgrade nodes` to properly handle kernel argument lists. #1938
 
 ## v4.6.2, 2025-07-09
 

--- a/internal/pkg/upgrade/node.go
+++ b/internal/pkg/upgrade/node.go
@@ -588,8 +588,15 @@ type KernelConf struct {
 func (legacy *KernelConf) Upgrade(imageName string) (upgraded *node.KernelConf) {
 	upgraded = new(node.KernelConf)
 	switch args := legacy.Args.(type) {
-	case []string:
-		upgraded.Args = args
+	case []interface{}:
+		for _, arg := range args {
+			switch arg.(type) {
+			case map[string]interface{}, []interface{}, map[interface{}]interface{}:
+				wwlog.Warn("unable to parse Kernel.Args: non-scalar value %v", arg)
+			default:
+				upgraded.Args = append(upgraded.Args, fmt.Sprintf("%v", arg))
+			}
+		}
 	case string:
 		if args != "" {
 			upgraded.Args = strings.Fields(args)

--- a/internal/pkg/upgrade/node_test.go
+++ b/internal/pkg/upgrade/node_test.go
@@ -254,6 +254,74 @@ nodes:
 `,
 	},
 	{
+		name:            "Kernel args as string",
+		addDefaults:     false,
+		replaceOverlays: false,
+		legacyYaml: `
+nodeprofiles:
+  default:
+    kernel:
+      version: "2.6"
+      args: quiet
+nodes:
+  n1:
+    kernel:
+      version: "2.6"
+      args: quiet
+`,
+		upgradedYaml: `
+nodeprofiles:
+  default:
+    kernel:
+      version: "2.6"
+      args:
+      - quiet
+nodes:
+  n1:
+    kernel:
+      version: "2.6"
+      args:
+      - quiet
+`,
+	},
+	{
+		name:            "Kernel args as list",
+		addDefaults:     false,
+		replaceOverlays: false,
+		legacyYaml: `
+nodeprofiles:
+  default:
+    kernel:
+      version: "2.6"
+      args:
+      - quiet
+      - 1
+nodes:
+  n1:
+    kernel:
+      version: "2.6"
+      args:
+      - quiet
+      - 2
+`,
+		upgradedYaml: `
+nodeprofiles:
+  default:
+    kernel:
+      version: "2.6"
+      args:
+      - quiet
+      - "1"
+nodes:
+  n1:
+    kernel:
+      version: "2.6"
+      args:
+      - quiet
+      - "2"
+`,
+	},
+	{
 		name:            "keys, tags, and resources",
 		addDefaults:     false,
 		replaceOverlays: false,


### PR DESCRIPTION
## Description of the Pull Request (PR):

`wwctl upgrade nodes` could convert legacy kernel argument formats to the new list format, but then wasn't properly parsing the new list format for repeat runs.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
