### PR TITLE
Rebuild overlays for discovered nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Changed
+
+- `warewulfd` overlay autobuild rebuilds overlays after node discovery. #1468
+
 ## v4.6.2, 2025-07-09
 
 ### Added

--- a/internal/pkg/overlay/config.go
+++ b/internal/pkg/overlay/config.go
@@ -105,3 +105,19 @@ func OverlayImage(nodeName string, context string, overlayNames []string) string
 
 	return path.Join(config.Get().Paths.OverlayProvisiondir(), nodeName, name)
 }
+
+func ClearOverlayImage(nodeName string, context string, overlayNames []string) error {
+	imagePath := OverlayImage(nodeName, context, overlayNames)
+	if util.IsFile(imagePath) {
+		if err := os.Remove(imagePath); err != nil {
+			return fmt.Errorf("failed to remove overlay image: %w", err)
+		}
+	}
+	compressedImagePath := imagePath + ".gz"
+	if util.IsFile(compressedImagePath) {
+		if err := os.Remove(compressedImagePath); err != nil {
+			return fmt.Errorf("failed to remove compressed overlay image: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/pkg/warewulfd/provision.go
+++ b/internal/pkg/warewulfd/provision.go
@@ -76,7 +76,7 @@ func ProvisionSend(w http.ResponseWriter, req *http.Request) {
 	// TODO: when module version is upgraded to go1.18, should be 'any' type
 	var tmpl_data *templateVars
 
-	remoteNode, err := GetNodeOrSetDiscoverable(rinfo.hwaddr)
+	remoteNode, err := GetNodeOrSetDiscoverable(rinfo.hwaddr, conf.Warewulf.AutobuildOverlays())
 	if err != nil && err != node.ErrNoUnconfigured {
 		wwlog.ErrorExc(err, "")
 		w.WriteHeader(http.StatusServiceUnavailable)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Clear overlays for discovered nodes when autobuild is enabled so that they will be rebuilt with the discovered mac address.


## This fixes or addresses the following GitHub issues:

- Fixes: #1468


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
