### PR TITLE
add deleting overlay file support to rest api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- Added `DELETE /api/overlays/{name}/file?path={path}`
+
 ## v4.6.2, 2025-07-09
 
 ### Added

--- a/internal/pkg/overlay/config.go
+++ b/internal/pkg/overlay/config.go
@@ -54,7 +54,7 @@ func (overlay Overlay) Create() error {
 	if util.IsDir(overlay.Path()) {
 		return fmt.Errorf("overlay already exists: %s", overlay)
 	}
-	return os.MkdirAll(overlay.Rootfs(), 0755)
+	return os.MkdirAll(overlay.Rootfs(), 0o755)
 }
 
 // Creates a site overlay from an existing distribution overlay.
@@ -69,7 +69,7 @@ func (overlay Overlay) CloneSiteOverlay() (siteOverlay Overlay, err error) {
 		return siteOverlay, fmt.Errorf("site overlay already exists: %s", siteOverlay.Name())
 	}
 	if !util.IsDir(filepath.Dir(overlay.Path())) {
-		if err := os.MkdirAll(filepath.Dir(overlay.Path()), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(overlay.Path()), 0o755); err != nil {
 			return siteOverlay, err
 		}
 	}

--- a/internal/pkg/warewulfd/api/api.go
+++ b/internal/pkg/warewulfd/api/api.go
@@ -71,6 +71,7 @@ func Handler(auth *config.Authentication, allowedNets []net.IPNet) *web.Service 
 			r.Method(http.MethodGet, "/{name}/file", nethttp.NewHandler(getOverlayFile()))
 			r.Method(http.MethodPut, "/{name}", nethttp.NewHandler(createOverlay()))
 			r.Method(http.MethodDelete, "/{name}", nethttp.NewHandler(deleteOverlay()))
+			r.Method(http.MethodDelete, "/{name}/file", nethttp.NewHandler(deleteOverlayFile()))
 		})
 	})
 

--- a/internal/pkg/warewulfd/api/overlay.go
+++ b/internal/pkg/warewulfd/api/overlay.go
@@ -252,3 +252,35 @@ func deleteOverlay() usecase.Interactor {
 	u.SetTags("Overlay")
 	return u
 }
+
+func deleteOverlayFile() usecase.Interactor {
+	type deleteOverlayFileInput struct {
+		Name    string `path:"name" required:"true" description:"Name of overlay to delete a file from"`
+		Path    string `query:"path" required:"true" description:"Path to file to delete from an overlay"`
+		Force   bool   `query:"force" default:"false" description:"Whether to forcefully delete an overlay file / directory, default:'false'"`
+		Cleanup bool   `query:"cleanup" default:"false" description:"Whether to cleanup empty parent directories, default:'false'"`
+	}
+
+	u := usecase.NewInteractor(func(ctx context.Context, input deleteOverlayFileInput, output *OverlayResponse) error {
+		wwlog.Debug("api.deleteOverlayFile(Name:%v, Path:%v)", input.Name, input.Path)
+		if input.Path == "" {
+			return status.Wrap(fmt.Errorf("must specify a path"), status.InvalidArgument)
+		}
+
+		if relPath, err := url.QueryUnescape(input.Path); err != nil {
+			return fmt.Errorf("failed to decode path: %v: %w", input.Path, err)
+		} else {
+			overlay_ := overlay.GetOverlay(input.Name)
+			err := overlay_.DeleteFile(relPath, input.Force, input.Cleanup)
+			if err != nil {
+				return fmt.Errorf("unable to delete overlay file %v: %v: %w", input.Name, relPath, err)
+			}
+		}
+		*output = *NewOverlayResponse(input.Name)
+		return nil
+	})
+	u.SetTitle("Delete a file from an overlay")
+	u.SetDescription("Delete a file from an overlay from the overlay name and file path")
+	u.SetTags("Overlay")
+	return u
+}

--- a/internal/pkg/warewulfd/api/overlay_test.go
+++ b/internal/pkg/warewulfd/api/overlay_test.go
@@ -117,6 +117,20 @@ func TestOverlayAPI(t *testing.T) {
 		assert.JSONEq(t, `{"test":{"files":null, "site":true},"testoverlay":{"files":["/email.ww"], "site":false}}`, string(body))
 	})
 
+	t.Run("test delete overlay file", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodDelete, srv.URL+"/api/overlays/testoverlay/file?path=email.ww&force=true", nil)
+		assert.NoError(t, err)
+
+		resp, err := http.DefaultTransport.RoundTrip(req)
+		assert.NoError(t, err)
+
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.NoError(t, resp.Body.Close())
+
+		assert.JSONEq(t, `{"files":null, "site":true}`, string(body))
+	})
+
 	t.Run("test delete overlays", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodDelete, srv.URL+"/api/overlays/test?force=true", nil)
 		assert.NoError(t, err)


### PR DESCRIPTION
## Description of the Pull Request (PR):

add api rest support for deleting overlay file


## This fixes or addresses the following GitHub issues:

- Fixes #


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
