### PR TITLE
additions to wwapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added system and runtime overlay built time to REST API.
 - Support If-None-Match header in `PUT /api/nodes/{id}`
+- Added `DELETE /api/overlays/{name}/file?path={path}`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Restore default idempotency of `PUT /api/nodes/{id}`
 - `DELETE /api/overlays/{name}?force=true` can delete overlays that are in use
-
-### Changed
-
 - `warewulfd` overlay autobuild rebuilds overlays after node discovery. #1468
 ### Fixed
 
 - Improved netplan support. #1873
+
+### Fixed
+
+- Fixed a bug when cloning an overlay to site when parent is missing
 
 ## v4.6.2, 2025-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added system and runtime overlay built time to REST API.
 - Support If-None-Match header in `PUT /api/nodes/{id}`
+- Added `PUT|DELETE /api/overlays/{name}/file?path={path}`
 - Added `DELETE /api/overlays/{name}/file?path={path}`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- Added system and runtime overlay built time to REST API.
+
 ### Changed
 
 - `warewulfd` overlay autobuild rebuilds overlays after node discovery. #1468

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Restore default idempotency of `PUT /api/nodes/{id}`
+- `DELETE /api/overlays/{name}?force=true` can delete overlays that are in use
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Added system and runtime overlay built time to REST API.
+- Support If-None-Match header in `PUT /api/nodes/{id}`
+
+### Changed
+
+- Restore default idempotency of `PUT /api/nodes/{id}`
 
 ### Changed
 

--- a/internal/pkg/overlay/config.go
+++ b/internal/pkg/overlay/config.go
@@ -68,8 +68,8 @@ func (overlay Overlay) CloneSiteOverlay() (siteOverlay Overlay, err error) {
 	if siteOverlay.Exists() {
 		return siteOverlay, fmt.Errorf("site overlay already exists: %s", siteOverlay.Name())
 	}
-	if !util.IsDir(filepath.Dir(overlay.Path())) {
-		if err := os.MkdirAll(filepath.Dir(overlay.Path()), 0o755); err != nil {
+	if !util.IsDir(filepath.Dir(siteOverlay.Path())) {
+		if err := os.MkdirAll(filepath.Dir(siteOverlay.Path()), 0o755); err != nil {
 			return siteOverlay, err
 		}
 	}

--- a/internal/pkg/overlay/config.go
+++ b/internal/pkg/overlay/config.go
@@ -54,7 +54,7 @@ func (overlay Overlay) Create() error {
 	if util.IsDir(overlay.Path()) {
 		return fmt.Errorf("overlay already exists: %s", overlay)
 	}
-	return os.MkdirAll(overlay.Rootfs(), 0755)
+	return os.MkdirAll(overlay.Rootfs(), 0o755)
 }
 
 // Creates a site overlay from an existing distribution overlay.
@@ -69,7 +69,7 @@ func (overlay Overlay) CloneSiteOverlay() (siteOverlay Overlay, err error) {
 		return siteOverlay, fmt.Errorf("site overlay already exists: %s", siteOverlay.Name())
 	}
 	if !util.IsDir(filepath.Dir(overlay.Path())) {
-		if err := os.MkdirAll(filepath.Dir(overlay.Path()), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(overlay.Path()), 0o755); err != nil {
 			return siteOverlay, err
 		}
 	}

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -66,8 +66,22 @@ func (overlay Overlay) Rootfs() string {
 //
 // Returns:
 //   - The full path to the specified file in the overlay's rootfs.
+//     If the specified path does not exist in the overlay, the empty string is returned.
 func (overlay Overlay) File(filePath string) string {
-	return path.Join(overlay.Rootfs(), filePath)
+	rootfs := overlay.Rootfs()
+	fullPath := path.Join(rootfs, filePath)
+	cleanPath := filepath.Clean(fullPath)
+	cleanRootfs := filepath.Clean(rootfs)
+	rel, err := filepath.Rel(cleanRootfs, cleanPath)
+	if err != nil {
+		return ""
+	}
+
+	if strings.HasPrefix(rel, "..") {
+		return ""
+	}
+
+	return cleanPath
 }
 
 // Exists checks whether the overlay path exists and is a directory.

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -116,6 +116,16 @@ func (overlay Overlay) IsDistributionOverlay() bool {
 
 func (overlay Overlay) AddFile(filePath string, content []byte, parents bool, force bool) error {
 	wwlog.Info("Creating file %s in overlay %s, force: %v", filePath, overlay.Name(), force)
+
+	if overlay.IsDistributionOverlay() {
+		siteOverlay, err := overlay.CloneSiteOverlay()
+		if err != nil {
+			return fmt.Errorf("failed to clone distribution overlay '%s' to site overlay: %w", overlay.Name(), err)
+		}
+		// replace the overlay with newly creatd siteOverlay
+		overlay = siteOverlay
+	}
+
 	fullPath := overlay.File(filePath)
 	// create necessary parent directories
 	if parents {

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -330,7 +330,7 @@ func FindOverlays() (overlayList []string) {
 		files = append(files, distfiles...)
 	}
 	if sitefiles, err := os.ReadDir(controller.Paths.SiteOverlaydir()); err != nil {
-		wwlog.Warn("error reading overalys from %s: %s", controller.Paths.SiteOverlaydir(), err)
+		wwlog.Warn("error reading overlays from %s: %s", controller.Paths.SiteOverlaydir(), err)
 	} else {
 		files = append(files, sitefiles...)
 	}

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -22,9 +22,7 @@ import (
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
-var (
-	ErrDoesNotExist = fmt.Errorf("overlay does not exist")
-)
+var ErrDoesNotExist = fmt.Errorf("overlay does not exist")
 
 // Overlay represents an overlay directory path.
 type Overlay string
@@ -100,6 +98,69 @@ func (overlay Overlay) IsSiteOverlay() bool {
 //   - true if the overlay is a distribution overlay; false otherwise.
 func (overlay Overlay) IsDistributionOverlay() bool {
 	return path.Dir(overlay.Path()) == config.Get().Paths.DistributionOverlaydir()
+}
+
+// DeleteFile deletes a file or the entire overlay directory.
+// If the file belongs to a distribution overlay, it will be cloned to a site overlay
+// before deletion.
+func (overlay Overlay) DeleteFile(filePath string, force, cleanup bool) error {
+	wwlog.Info("Deleting file %s from overlay %s, force: %v, cleanup: %v", filePath, overlay.Name(), force, cleanup)
+	if filePath == "" {
+		if force {
+			err := os.RemoveAll(overlay.Path())
+			if err != nil {
+				return fmt.Errorf("failed to delete overlay forcely: %w", err)
+			}
+		} else {
+			err := os.Remove(overlay.Path())
+			if err != nil {
+				return fmt.Errorf("failed to delete overlay: %w", err)
+			}
+		}
+	} else {
+		if overlay.IsDistributionOverlay() {
+			siteOverlay, err := overlay.CloneSiteOverlay()
+			if err != nil {
+				return fmt.Errorf("failed to clone distribution overlay '%s' to site overlay: %w", overlay.Name(), err)
+			}
+			// replace the overlay with newly creatd siteOverlay
+			overlay = siteOverlay
+		}
+
+		fullPath := overlay.File(filePath)
+		if !util.IsFile(fullPath) {
+			return fmt.Errorf("file %s does not exist in overlay %s", filePath, overlay.Name())
+		}
+
+		if force {
+			if err := os.RemoveAll(fullPath); err != nil {
+				return fmt.Errorf("failed to delete file %s from overlay %s: %w", filePath, overlay.Name(), err)
+			}
+		} else {
+			if err := os.Remove(fullPath); err != nil {
+				return fmt.Errorf("failed to delete file %s from overlay %s: %w", filePath, overlay.Name(), err)
+			}
+		}
+
+		if cleanup {
+			// cleanup the empty parents
+			i := path.Dir(fullPath)
+			for i != overlay.Rootfs() {
+				wwlog.Debug("Evaluating directory to remove: %s", i)
+				err := os.Remove(i)
+				if err != nil {
+					// if the directory is not empty, we stop here
+					if !os.IsNotExist(err) {
+						wwlog.Debug("Could not remove directory %s: %v", i, err)
+					}
+					break
+				}
+				wwlog.Debug("Removed empty directory: %s", i)
+				i = path.Dir(i)
+			}
+		}
+	}
+	return nil
 }
 
 func BuildAllOverlays(nodes []node.Node, allNodes []node.Node, workerCount int) error {
@@ -196,7 +257,7 @@ func BuildHostOverlay() error {
 	if err != nil {
 		return fmt.Errorf("could not build host overlay: %w ", err)
 	}
-	if !(stats.Mode() == os.FileMode(0750|os.ModeDir) || stats.Mode() == os.FileMode(0700|os.ModeDir)) {
+	if !(stats.Mode() == os.FileMode(0o750|os.ModeDir) || stats.Mode() == os.FileMode(0o700|os.ModeDir)) {
 		wwlog.SecWarn("Permissions of host overlay dir %s are %s (750 is considered as secure)", hostdir, stats.Mode())
 	}
 	registry, err := node.New()
@@ -257,7 +318,7 @@ func BuildOverlay(nodeConf node.Node, allNodes []node.Node, context string, over
 	overlayImage := OverlayImage(nodeConf.Id(), context, overlayNames)
 	overlayImageDir := path.Dir(overlayImage)
 
-	err := os.MkdirAll(overlayImageDir, 0750)
+	err := os.MkdirAll(overlayImageDir, 0o750)
 	if err != nil {
 		return fmt.Errorf("failed to create directory for %s: %s: %w", name, overlayImageDir, err)
 	}
@@ -292,8 +353,10 @@ func BuildOverlay(nodeConf node.Node, allNodes []node.Node, context string, over
 	return err
 }
 
-var regFile *regexp.Regexp
-var regLink *regexp.Regexp
+var (
+	regFile *regexp.Regexp
+	regLink *regexp.Regexp
+)
 
 func init() {
 	regFile = regexp.MustCompile(`.*{{\s*/\*\s*file\s*["'](.*)["']\s*\*/\s*}}.*`)
@@ -450,7 +513,6 @@ func BuildOverlayIndir(nodeData node.Node, allNodes []node.Node, overlayNames []
 
 			return nil
 		})
-
 		if err != nil {
 			return fmt.Errorf("failed to build overlay image directory: %w", err)
 		}
@@ -471,7 +533,6 @@ func CarefulWriteBuffer(destFile string, buffer bytes.Buffer, backupFile bool, p
 				return fmt.Errorf("failed to create backup: %s -> %s.wwbackup %w", destFile, destFile, err)
 			}
 		}
-
 	}
 	w, err := os.OpenFile(destFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {
@@ -491,7 +552,8 @@ func RenderTemplateFile(fileName string, data TemplateStruct) (
 	buffer bytes.Buffer,
 	backupFile bool,
 	writeFile bool,
-	err error) {
+	err error,
+) {
 	backupFile = true
 	writeFile = true
 	// Build our FuncMap

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -114,12 +114,14 @@ func (overlay Overlay) IsDistributionOverlay() bool {
 	return path.Dir(overlay.Path()) == config.Get().Paths.DistributionOverlaydir()
 }
 
-func (overlay Overlay) CreateOverlayFile(filePath string, content []byte, force bool) error {
+func (overlay Overlay) AddFile(filePath string, content []byte, parents bool, force bool) error {
 	wwlog.Info("Creating file %s in overlay %s, force: %v", filePath, overlay.Name(), force)
 	fullPath := overlay.File(filePath)
 	// create necessary parent directories
-	if err := os.MkdirAll(path.Dir(fullPath), 0o755); err != nil {
-		return fmt.Errorf("failed to create parent directories for %s: %w", fullPath, err)
+	if parents {
+		if err := os.MkdirAll(path.Dir(fullPath), 0o755); err != nil {
+			return fmt.Errorf("failed to create parent directories for %s: %w", fullPath, err)
+		}
 	}
 
 	// if the file already exists and force is false, return an error

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -66,7 +66,7 @@ func (overlay Overlay) Rootfs() string {
 //
 // Returns:
 //   - The full path to the specified file in the overlay's rootfs.
-//     If the specified path does not exist in the overlay, the empty string is returned.
+//     If the specified path is not contained within the overlay, the empty string is returned.
 func (overlay Overlay) File(filePath string) string {
 	rootfs := overlay.Rootfs()
 	fullPath := path.Join(rootfs, filePath)
@@ -122,7 +122,7 @@ func (overlay Overlay) AddFile(filePath string, content []byte, parents bool, fo
 		if err != nil {
 			return fmt.Errorf("failed to clone distribution overlay '%s' to site overlay: %w", overlay.Name(), err)
 		}
-		// replace the overlay with newly creatd siteOverlay
+		// replace the overlay with newly created siteOverlay
 		overlay = siteOverlay
 	}
 
@@ -168,7 +168,7 @@ func (overlay Overlay) DeleteFile(filePath string, force, cleanup bool) error {
 			if err != nil {
 				return fmt.Errorf("failed to clone distribution overlay '%s' to site overlay: %w", overlay.Name(), err)
 			}
-			// replace the overlay with newly creatd siteOverlay
+			// replace the overlay with newly created siteOverlay
 			overlay = siteOverlay
 		}
 

--- a/internal/pkg/overlay/overlay_test.go
+++ b/internal/pkg/overlay/overlay_test.go
@@ -732,7 +732,7 @@ func Test_CreateOverlayFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			newOverlay := GetSiteOverlay(tt.overlayName)
-			err := newOverlay.CreateOverlayFile(tt.filePath, tt.content, tt.force)
+			err := newOverlay.AddFile(tt.filePath, tt.content, true, tt.force)
 			assert.NoError(t, err)
 
 			newFile := newOverlay.File(tt.filePath)

--- a/internal/pkg/overlay/overlay_test.go
+++ b/internal/pkg/overlay/overlay_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func Test_FindOverlays(t *testing.T) {
-	var tests = map[string]struct {
+	tests := map[string]struct {
 		distOverlays []string
 		siteOverlays []string
 		overlayList  []string
@@ -75,7 +75,7 @@ func Test_OverlayMethods(t *testing.T) {
 	env.WriteFile(path.Join(sitedir, "both/rootfs/testfile"), "the site version")
 	env.WriteFile(path.Join(distdir, "both/rootfs/testfile"), "the distribution version")
 
-	var tests = map[string]struct {
+	tests := map[string]struct {
 		name    string
 		path    string
 		rootfs  string
@@ -157,7 +157,7 @@ func Test_OverlayMethods(t *testing.T) {
 }
 
 func Test_BuildOverlayIndir(t *testing.T) {
-	var tests = map[string]struct {
+	tests := map[string]struct {
 		node            node.Node
 		overlays        []string
 		overlayFiles    map[string]string
@@ -336,7 +336,7 @@ Tags:map[]
 }
 
 func Test_BuildOverlay(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		description string
 		nodeName    string
 		context     string
@@ -377,7 +377,7 @@ func Test_BuildOverlay(t *testing.T) {
 			overlays:    []string{"o1"},
 			image:       "o1.img",
 			contents:    []string{"o1.txt"},
-			perms:       []int{0644},
+			perms:       []int{0o644},
 		},
 		{
 			description: "if multiple overlays are specified without a node, then the combined overlay is built directly in the overlay directory",
@@ -386,7 +386,7 @@ func Test_BuildOverlay(t *testing.T) {
 			overlays:    []string{"o1", "o2"},
 			image:       "o1-o2.img",
 			contents:    []string{"o1.txt", "o2.txt"},
-			perms:       []int{0644, 0644},
+			perms:       []int{0o644, 0o644},
 		},
 		{
 			description: "if a single node overlay is specified, then the overlay is built in a node overlay directory",
@@ -395,7 +395,7 @@ func Test_BuildOverlay(t *testing.T) {
 			overlays:    []string{"o1"},
 			image:       "node1/o1.img",
 			contents:    []string{"o1.txt"},
-			perms:       []int{0644},
+			perms:       []int{0o644},
 		},
 		{
 			description: "if multiple node overlays are specified, then the combined overlay is built in a node overlay directory",
@@ -404,7 +404,7 @@ func Test_BuildOverlay(t *testing.T) {
 			overlays:    []string{"o1", "o2"},
 			image:       "node1/o1-o2.img",
 			contents:    []string{"o1.txt", "o2.txt"},
-			perms:       []int{0644, 0644},
+			perms:       []int{0o644, 0o644},
 		},
 		{
 			description: "if no node system overlays are specified, then context pointed overlay is generated",
@@ -429,7 +429,7 @@ func Test_BuildOverlay(t *testing.T) {
 			overlays:    []string{"o1"},
 			image:       "node1/__SYSTEM__.img",
 			contents:    []string{"o1.txt"},
-			perms:       []int{0644},
+			perms:       []int{0o644},
 		},
 		{
 			description: "if a single node runtime overlay is specified, then a runtime overlay image is generated in a node overlay directory",
@@ -438,7 +438,7 @@ func Test_BuildOverlay(t *testing.T) {
 			overlays:    []string{"o1"},
 			image:       "node1/__RUNTIME__.img",
 			contents:    []string{"o1.txt"},
-			perms:       []int{0644},
+			perms:       []int{0o644},
 		},
 		{
 			description: "if multiple node system overlays are specified, then a system overlay image is generated with the contents of both overlays",
@@ -447,7 +447,7 @@ func Test_BuildOverlay(t *testing.T) {
 			overlays:    []string{"o1", "o2"},
 			image:       "node1/__SYSTEM__.img",
 			contents:    []string{"o1.txt", "o2.txt"},
-			perms:       []int{0644, 0644},
+			perms:       []int{0o644, 0o644},
 		},
 		{
 			description: "if multiple node runtime overlays are specified, then a runtime overlay image is generated with the contents of both overlays",
@@ -456,7 +456,7 @@ func Test_BuildOverlay(t *testing.T) {
 			overlays:    []string{"o1", "o2"},
 			image:       "node1/__RUNTIME__.img",
 			contents:    []string{"o1.txt", "o2.txt"},
-			perms:       []int{0644, 0644},
+			perms:       []int{0o644, 0o644},
 		},
 		{
 			description: "validating altered permissions are retained",
@@ -465,7 +465,7 @@ func Test_BuildOverlay(t *testing.T) {
 			overlays:    []string{"o3"},
 			image:       "node1/__RUNTIME__.img",
 			contents:    []string{"subdir", "subdir/o3.txt"},
-			perms:       []int{0700, 0600},
+			perms:       []int{0o700, 0o600},
 		},
 	}
 
@@ -473,12 +473,12 @@ func Test_BuildOverlay(t *testing.T) {
 	defer env.RemoveAll()
 
 	env.CreateFile("var/lib/warewulf/overlays/o1/rootfs/o1.txt")
-	env.Chmod("var/lib/warewulf/overlays/o1/rootfs/o1.txt", 0644)
+	env.Chmod("var/lib/warewulf/overlays/o1/rootfs/o1.txt", 0o644)
 	env.CreateFile("var/lib/warewulf/overlays/o2/rootfs/o2.txt")
-	env.Chmod("var/lib/warewulf/overlays/o2/rootfs/o2.txt", 0644)
+	env.Chmod("var/lib/warewulf/overlays/o2/rootfs/o2.txt", 0o644)
 	env.CreateFile("var/lib/warewulf/overlays/o3/rootfs/subdir/o3.txt.ww")
-	env.Chmod("var/lib/warewulf/overlays/o3/rootfs/subdir", 0700)
-	env.Chmod("var/lib/warewulf/overlays/o3/rootfs/subdir/o3.txt.ww", 0600)
+	env.Chmod("var/lib/warewulf/overlays/o3/rootfs/subdir", 0o700)
+	env.Chmod("var/lib/warewulf/overlays/o3/rootfs/subdir/o3.txt.ww", 0o600)
 
 	for _, tt := range tests {
 		nodeInfo := node.NewNode(tt.nodeName)
@@ -508,7 +508,7 @@ func Test_BuildOverlay(t *testing.T) {
 }
 
 func Test_BuildAllOverlays(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		description     string
 		nodes           []string
 		systemOverlays  [][]string
@@ -585,8 +585,8 @@ func Test_BuildAllOverlays(t *testing.T) {
 	assert.NoError(t, overlayDirErr)
 	defer os.RemoveAll(overlayDir)
 	conf.Paths.WWOverlaydir = overlayDir
-	assert.NoError(t, os.Mkdir(path.Join(overlayDir, "o1"), 0700))
-	assert.NoError(t, os.Mkdir(path.Join(overlayDir, "o2"), 0700))
+	assert.NoError(t, os.Mkdir(path.Join(overlayDir, "o1"), 0o700))
+	assert.NoError(t, os.Mkdir(path.Join(overlayDir, "o2"), 0o700))
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
@@ -620,7 +620,7 @@ func Test_BuildAllOverlays(t *testing.T) {
 }
 
 func Test_BuildSpecificOverlays(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		description string
 		nodes       []string
 		overlays    []string
@@ -683,8 +683,8 @@ func Test_BuildSpecificOverlays(t *testing.T) {
 	assert.NoError(t, overlayDirErr)
 	defer os.RemoveAll(overlayDir)
 	conf.Paths.WWOverlaydir = overlayDir
-	assert.NoError(t, os.Mkdir(path.Join(overlayDir, "o1"), 0700))
-	assert.NoError(t, os.Mkdir(path.Join(overlayDir, "o2"), 0700))
+	assert.NoError(t, os.Mkdir(path.Join(overlayDir, "o1"), 0o700))
+	assert.NoError(t, os.Mkdir(path.Join(overlayDir, "o2"), 0o700))
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
@@ -707,6 +707,39 @@ func Test_BuildSpecificOverlays(t *testing.T) {
 					assert.FileExists(t, path.Join(provisionDir, "overlays", image))
 				}
 			}
+		})
+	}
+}
+
+func Test_CreateOverlayFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		overlayName string
+		filePath    string
+		content     []byte
+		force       bool
+	}{
+		{"create file", "test", "newfile.ww", []byte("new file"), false},
+		{"overwrite existing file", "test", "existingfile.ww", []byte("overwrite file"), true},
+	}
+
+	conf := warewulfconf.Get()
+	overlayDir, overlayDirErr := os.MkdirTemp(os.TempDir(), "ww-test-overlay-*")
+	assert.NoError(t, overlayDirErr)
+	defer os.RemoveAll(overlayDir)
+	conf.Paths.WWOverlaydir = overlayDir
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newOverlay := GetSiteOverlay(tt.overlayName)
+			err := newOverlay.CreateOverlayFile(tt.filePath, tt.content, tt.force)
+			assert.NoError(t, err)
+
+			newFile := newOverlay.File(tt.filePath)
+			assert.FileExists(t, newFile)
+			readContent, err := os.ReadFile(newFile)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.content, readContent)
 		})
 	}
 }

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -362,21 +362,6 @@ func AppendLines(fileName string, lines []string) error {
 	return nil
 }
 
-func OverwriteFile(fileName string, content []byte) error {
-	wwlog.Verbose("overwrite file %s", fileName)
-	file, err := os.OpenFile(fileName, os.O_RDWR|os.O_TRUNC, 0o644)
-	if err != nil {
-		return fmt.Errorf("failed to open file: %s, err: %w", fileName, err)
-	}
-	defer file.Close()
-
-	_, err = file.Write(content)
-	if err != nil {
-		return fmt.Errorf("while writing file: %s, err: %w", fileName, err)
-	}
-	return file.Sync()
-}
-
 /*
 ******************************************************************************
 

--- a/internal/pkg/util/util_test.go
+++ b/internal/pkg/util/util_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Test_FindFiles(t *testing.T) {
-	var tests = map[string]struct {
+	tests := map[string]struct {
 		createFiles []string
 		findFiles   []string
 	}{
@@ -43,7 +43,7 @@ func Test_FindFiles(t *testing.T) {
 }
 
 func Test_FindFilterFiles(t *testing.T) {
-	var tests = map[string]struct {
+	tests := map[string]struct {
 		createFiles []string
 		include     []string
 		exclude     []string
@@ -91,4 +91,20 @@ func Test_FindFilterFiles(t *testing.T) {
 			assert.Equal(t, tt.findFiles, files)
 		})
 	}
+}
+
+func Test_Overwrite(t *testing.T) {
+	t.Run("overwrite a file", func(t *testing.T) {
+		env := testenv.New(t)
+		defer env.RemoveAll()
+		env.CreateFile("file")
+		env.WriteFile("file", "hello world")
+
+		assert.Equal(t, "hello world", env.ReadFile("file"))
+
+		err := OverwriteFile(env.GetPath("file"), []byte("hello warewulf"))
+		assert.NoError(t, err)
+
+		assert.Equal(t, "hello warewulf", env.ReadFile("file"))
+	})
 }

--- a/internal/pkg/util/util_test.go
+++ b/internal/pkg/util/util_test.go
@@ -92,19 +92,3 @@ func Test_FindFilterFiles(t *testing.T) {
 		})
 	}
 }
-
-func Test_Overwrite(t *testing.T) {
-	t.Run("overwrite a file", func(t *testing.T) {
-		env := testenv.New(t)
-		defer env.RemoveAll()
-		env.CreateFile("file")
-		env.WriteFile("file", "hello world")
-
-		assert.Equal(t, "hello world", env.ReadFile("file"))
-
-		err := OverwriteFile(env.GetPath("file"), []byte("hello warewulf"))
-		assert.NoError(t, err)
-
-		assert.Equal(t, "hello warewulf", env.ReadFile("file"))
-	})
-}

--- a/internal/pkg/warewulfd/api/api.go
+++ b/internal/pkg/warewulfd/api/api.go
@@ -71,10 +71,9 @@ func Handler(auth *config.Authentication, allowedNets []net.IPNet) *web.Service 
 			r.Method(http.MethodGet, "/{name}", nethttp.NewHandler(getOverlayByName()))
 			r.Method(http.MethodGet, "/{name}/file", nethttp.NewHandler(getOverlayFile()))
 			r.Method(http.MethodPut, "/{name}", nethttp.NewHandler(createOverlay()))
-			r.Method(http.MethodPut, "/{name}/file", nethttp.NewHandler(createOverlayFile()))
+			r.Method(http.MethodPut, "/{name}/file", nethttp.NewHandler(addOverlayFile()))
 			r.Method(http.MethodDelete, "/{name}", nethttp.NewHandler(deleteOverlay()))
 			r.Method(http.MethodDelete, "/{name}/file", nethttp.NewHandler(deleteOverlayFile()))
-			r.Method(http.MethodPut, "/{name}/file", nethttp.NewHandler(updateOverlayFile()))
 		})
 	})
 

--- a/internal/pkg/warewulfd/api/api.go
+++ b/internal/pkg/warewulfd/api/api.go
@@ -71,8 +71,10 @@ func Handler(auth *config.Authentication, allowedNets []net.IPNet) *web.Service 
 			r.Method(http.MethodGet, "/{name}", nethttp.NewHandler(getOverlayByName()))
 			r.Method(http.MethodGet, "/{name}/file", nethttp.NewHandler(getOverlayFile()))
 			r.Method(http.MethodPut, "/{name}", nethttp.NewHandler(createOverlay()))
+			r.Method(http.MethodPut, "/{name}/file", nethttp.NewHandler(createOverlayFile()))
 			r.Method(http.MethodDelete, "/{name}", nethttp.NewHandler(deleteOverlay()))
 			r.Method(http.MethodDelete, "/{name}/file", nethttp.NewHandler(deleteOverlayFile()))
+			r.Method(http.MethodPut, "/{name}/file", nethttp.NewHandler(updateOverlayFile()))
 		})
 	})
 

--- a/internal/pkg/warewulfd/api/api.go
+++ b/internal/pkg/warewulfd/api/api.go
@@ -34,7 +34,7 @@ func Handler(auth *config.Authentication, allowedNets []net.IPNet) *web.Service 
 			r.Method(http.MethodGet, "/{id}/fields", nethttp.NewHandler(getNodeFields()))
 			r.Method(http.MethodPost, "/overlays/build", nethttp.NewHandler(buildAllOverlays()))
 			r.Method(http.MethodPost, "/{id}/overlays/build", nethttp.NewHandler(buildOverlays()))
-			r.Method(http.MethodGet, "/{id}/overlays", nethttp.NewHandler(getNodeOverlays()))
+			r.Method(http.MethodGet, "/{id}/overlays", nethttp.NewHandler(getNodeOverlayInfo()))
 		})
 	})
 

--- a/internal/pkg/warewulfd/api/api.go
+++ b/internal/pkg/warewulfd/api/api.go
@@ -34,6 +34,7 @@ func Handler(auth *config.Authentication, allowedNets []net.IPNet) *web.Service 
 			r.Method(http.MethodGet, "/{id}/fields", nethttp.NewHandler(getNodeFields()))
 			r.Method(http.MethodPost, "/overlays/build", nethttp.NewHandler(buildAllOverlays()))
 			r.Method(http.MethodPost, "/{id}/overlays/build", nethttp.NewHandler(buildOverlays()))
+			r.Method(http.MethodGet, "/{id}/overlays", nethttp.NewHandler(getNodeOverlays()))
 		})
 	})
 

--- a/internal/pkg/warewulfd/api/api.go
+++ b/internal/pkg/warewulfd/api/api.go
@@ -72,6 +72,7 @@ func Handler(auth *config.Authentication, allowedNets []net.IPNet) *web.Service 
 			r.Method(http.MethodGet, "/{name}/file", nethttp.NewHandler(getOverlayFile()))
 			r.Method(http.MethodPut, "/{name}", nethttp.NewHandler(createOverlay()))
 			r.Method(http.MethodDelete, "/{name}", nethttp.NewHandler(deleteOverlay()))
+			r.Method(http.MethodDelete, "/{name}/file", nethttp.NewHandler(deleteOverlayFile()))
 		})
 	})
 

--- a/internal/pkg/warewulfd/api/image_test.go
+++ b/internal/pkg/warewulfd/api/image_test.go
@@ -2,143 +2,173 @@ package api
 
 import (
 	"bytes"
-	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"path"
 	"testing"
 
+	"github.com/kinbiko/jsonassert"
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
+	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 )
 
-func TestImageAPI(t *testing.T) {
-	env := testenv.New(t)
-	defer env.RemoveAll()
+var imageTests = map[string]struct {
+	initFiles         []string
+	request           func(serverURL string) (*http.Request, error)
+	response          string
+	status            int
+	resultFiles       []string
+	resultAbsentFiles []string
+	authenticate      bool
+}{
+	"test no authentication": {
+		initFiles: []string{
+			"/var/lib/warewulf/chroots/test-image/rootfs/file",
+		},
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodGet, serverURL+"/api/images", nil)
+		},
+		response:     fmt.Sprintln("Unauthorized"),
+		status:       http.StatusUnauthorized,
+		authenticate: false,
+	},
 
+	"test get all images": {
+		initFiles: []string{
+			"/var/lib/warewulf/chroots/test-image/rootfs/file",
+		},
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodGet, serverURL+"/api/images", nil)
+		},
+		response:     `{"test-image": {"kernels":[], "size":0, "buildtime":0, "writable":true}}`,
+		authenticate: true,
+	},
+
+	"test get single image": {
+		initFiles: []string{
+			"/var/lib/warewulf/chroots/test-image/rootfs/file",
+		},
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodGet, serverURL+"/api/images/test-image", nil)
+		},
+		response:     `{"kernels":[], "size":0, "buildtime":0, "writable":true}`,
+		authenticate: true,
+	},
+
+	"test build image": {
+		initFiles: []string{
+			"/var/lib/warewulf/chroots/test-image/rootfs/file",
+		},
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodPost, serverURL+"/api/images/test-image/build?force=true&default=true", nil)
+		},
+		response: `{"kernels":[], "size":512, "buildtime":"<<PRESENCE>>", "writable":true}`,
+		resultFiles: []string{
+			"/srv/warewulf/images/test-image.img",
+			"/srv/warewulf/images/test-image.img.gz",
+		},
+		authenticate: true,
+	},
+
+	"test rename image": {
+		initFiles: []string{
+			"/var/lib/warewulf/chroots/test-image/rootfs/file",
+		},
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodPatch, serverURL+"/api/images/test-image?build=true", bytes.NewBuffer([]byte(`{"name": "new-image"}`)))
+		},
+		response:     `{"kernels":[], "size":512, "buildtime":"<<PRESENCE>>", "writable":true}`,
+		authenticate: true,
+	},
+
+	"test delete image": {
+		initFiles: []string{
+			"/var/lib/warewulf/chroots/new-image/rootfs/file",
+		},
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodDelete, serverURL+"/api/images/new-image", nil)
+		},
+		response: `{"kernels":[], "size":0, "buildtime":"<<PRESENCE>>", "writable":true}`,
+		resultAbsentFiles: []string{
+			"/var/lib/warewulf/chroots/new-image",
+			"/srv/warewulf/images/new-image.img",
+			"/srv/warewulf/images/new-image.img.gz",
+		},
+		authenticate: true,
+	},
+}
+
+func TestImageAPI(t *testing.T) {
 	authData := `
 users:
 - name: admin
   password hash: $2b$05$5QVWDpiWE7L4SDL9CYdi3O/l6HnbNOLoXgY2sa1bQQ7aSBKdSqvsC
 `
-	auth := config.NewAuthentication()
-	err := auth.ParseFromRaw([]byte(authData))
-	assert.NoError(t, err)
 
-	allowedNets := []net.IPNet{
-		{
-			IP:   net.IPv4(127, 0, 0, 0),
-			Mask: net.CIDRMask(8, 32),
-		},
+	for name, tt := range imageTests {
+		t.Run(name, func(t *testing.T) {
+			warewulfd.SetNoDaemon()
+			env := testenv.New(t)
+			defer env.RemoveAll()
+
+			// Create test files
+			for _, fileName := range tt.initFiles {
+				env.CreateFile(fileName)
+			}
+
+			auth := config.NewAuthentication()
+			err := auth.ParseFromRaw([]byte(authData))
+			assert.NoError(t, err)
+
+			allowedNets := []net.IPNet{
+				{
+					IP:   net.IPv4(127, 0, 0, 0),
+					Mask: net.CIDRMask(8, 32),
+				},
+			}
+			srv := httptest.NewServer(Handler(auth, allowedNets))
+			defer srv.Close()
+
+			req, err := tt.request(srv.URL)
+			assert.NoError(t, err)
+
+			if tt.authenticate {
+				req.SetBasicAuth("admin", "admin")
+			}
+
+			resp, err := http.DefaultTransport.RoundTrip(req)
+			assert.NoError(t, err)
+
+			expectedStatus := tt.status
+			if expectedStatus == 0 {
+				expectedStatus = http.StatusOK
+			}
+			assert.Equal(t, expectedStatus, resp.StatusCode)
+
+			body, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			assert.NoError(t, resp.Body.Close())
+
+			if expectedStatus == http.StatusUnauthorized {
+				// For plain text responses like Unauthorized
+				assert.Equal(t, tt.response, string(body))
+			} else {
+				// For JSON responses
+				ja := jsonassert.New(t)
+				ja.Assertf(string(body), tt.response) //nolint:govet
+			}
+
+			for _, fileName := range tt.resultFiles {
+				assert.FileExists(t, env.GetPath(fileName))
+			}
+
+			for _, fileName := range tt.resultAbsentFiles {
+				assert.NoFileExists(t, env.GetPath(fileName))
+			}
+		})
 	}
-	srv := httptest.NewServer(Handler(auth, allowedNets))
-	defer srv.Close()
-	env.WriteFile(path.Join(testenv.WWChrootdir, "test-image/rootfs/file"), `test`)
-
-	t.Run("test no authentication", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/images", nil)
-		assert.NoError(t, err)
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.Equal(t, resp.StatusCode, http.StatusUnauthorized)
-		assert.NoError(t, resp.Body.Close())
-		assert.NoError(t, err)
-		assert.Equal(t, "Unauthorized\n", string(body))
-	})
-
-	t.Run("test get all images", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/images", nil)
-		assert.NoError(t, err)
-		req.SetBasicAuth("admin", "admin")
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, resp.Body.Close())
-		assert.NoError(t, err)
-		assert.JSONEq(t, `{"test-image": {"kernels":[], "size":0, "buildtime":0, "writable":true}}`, string(body))
-	})
-
-	t.Run("test get single image", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/images/test-image", nil)
-		assert.NoError(t, err)
-		req.SetBasicAuth("admin", "admin")
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, resp.Body.Close())
-		assert.NoError(t, err)
-		assert.JSONEq(t, `{"kernels":[] ,"size":0, "buildtime":0, "writable":true}`, string(body))
-	})
-
-	t.Run("test build image", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/images/test-image/build?force=true&default=true", nil)
-		assert.NoError(t, err)
-		req.SetBasicAuth("admin", "admin")
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, resp.Body.Close())
-		assert.NoError(t, err)
-
-		var bodyData map[string]interface{}
-		assert.NoError(t, json.Unmarshal([]byte(body), &bodyData))
-		assert.True(t, bodyData["buildtime"].(float64) > 0.0)
-
-		bodyData["buildtime"] = 0.0
-		assert.Equal(t, map[string]interface{}{"kernels": []interface{}{}, "size": 512.0, "buildtime": 0.0, "writable": true}, bodyData)
-	})
-
-	t.Run("test rename image", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodPatch, srv.URL+"/api/images/test-image?build=true", bytes.NewBuffer([]byte(`{"name": "new-image"}`)))
-		assert.NoError(t, err)
-		req.SetBasicAuth("admin", "admin")
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, resp.Body.Close())
-		assert.NoError(t, err)
-
-		var bodyData map[string]interface{}
-		assert.NoError(t, json.Unmarshal([]byte(body), &bodyData))
-		assert.True(t, bodyData["buildtime"].(float64) > 0.0)
-
-		bodyData["buildtime"] = 0.0
-		assert.Equal(t, map[string]interface{}{"kernels": []interface{}{}, "size": 512.0, "buildtime": 0.0, "writable": true}, bodyData)
-	})
-
-	t.Run("test delete image", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodDelete, srv.URL+"/api/images/new-image", nil)
-		assert.NoError(t, err)
-		req.SetBasicAuth("admin", "admin")
-
-		// send request
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		// validate the resp
-		body, err := io.ReadAll(resp.Body)
-		assert.Equal(t, resp.StatusCode, http.StatusOK)
-		assert.NoError(t, err)
-
-		var bodyData map[string]interface{}
-		assert.NoError(t, json.Unmarshal([]byte(body), &bodyData))
-		assert.True(t, bodyData["buildtime"].(float64) > 0.0)
-
-		bodyData["buildtime"] = 0.0
-		assert.Equal(t, map[string]interface{}{"kernels": []interface{}{}, "size": 512.0, "buildtime": 0.0, "writable": true}, bodyData)
-	})
 }

--- a/internal/pkg/warewulfd/api/node_test.go
+++ b/internal/pkg/warewulfd/api/node_test.go
@@ -2,13 +2,11 @@ package api
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/kinbiko/jsonassert"
 	"github.com/stretchr/testify/assert"
@@ -16,26 +14,23 @@ import (
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 )
 
-func TestNodeAPI(t *testing.T) {
-	warewulfd.SetNoDaemon()
-	env := testenv.New(t)
-	env.MkdirAll("/var/lib/warewulf/overlays/so1")
-	env.MkdirAll("/var/lib/warewulf/overlays/ro1")
-	defer env.RemoveAll()
-
-	allowedNets := []net.IPNet{
-		{
-			IP:   net.IPv4(127, 0, 0, 0),
-			Mask: net.CIDRMask(8, 32),
+var nodeTests = map[string]struct {
+	initConf    string
+	initFiles   []string
+	request     func(serverURL string) (*http.Request, error)
+	response    string
+	status      int
+	resultConf  string
+	resultFiles []string
+}{
+	"add a node": {
+		initConf: "",
+		initFiles: []string{
+			"/var/lib/warewulf/overlays/so1/rootfs/file",
+			"/var/lib/warewulf/overlays/ro1/rootfs/file",
 		},
-	}
-	srv := httptest.NewServer(Handler(nil, allowedNets))
-	defer srv.Close()
-
-	t.Run("add a node", func(t *testing.T) {
-		// prepareration
-
-		testNode := `{
+		request: func(serverURL string) (*http.Request, error) {
+			testNode := `{
   "node":{
     "system overlay": ["so1"],
 	"runtime overlay": ["ro1"],
@@ -45,221 +40,251 @@ func TestNodeAPI(t *testing.T) {
     }
   }
 }`
-		req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/nodes/test", bytes.NewBuffer([]byte(testNode)))
-		assert.NoError(t, err)
+			return http.NewRequest(http.MethodPut, serverURL+"/api/nodes/n1", bytes.NewBuffer([]byte(testNode)))
+		},
+		response: `{"system overlay": ["so1"], "runtime overlay": ["ro1"], "kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`,
+		resultConf: `
+nodeprofiles: {}
+nodes:
+  n1:
+    system overlay:
+      - so1
+    runtime overlay:
+      - ro1
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+`,
+	},
 
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
+	"read all nodes": {
+		initConf: `
+nodeprofiles: {}
+nodes:
+  n1:
+    system overlay:
+      - so1
+    runtime overlay:
+      - ro1
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+`,
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodGet, serverURL+"/api/nodes", nil)
+		},
+		response: `{"n1": {"system overlay": ["so1"], "runtime overlay": ["ro1"], "kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}}`,
+	},
 
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, resp.Body.Close())
-
-		assert.JSONEq(t, `{"system overlay": ["so1"], "runtime overlay": ["ro1"], "kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`, string(body))
-	})
-
-	t.Run("read all nodes", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/nodes", nil)
-		assert.NoError(t, err)
-
-		// send request
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		// validate the resp
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, resp.Body.Close())
-
-		assert.JSONEq(t, `{"node1": {}, "test": {"system overlay": ["so1"], "runtime overlay": ["ro1"], "kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}}`, string(body))
-	})
-
-	t.Run("test idempotency (put same node again)", func(t *testing.T) {
-		// prepareration
-
-		testNode := `{
+	"test idempotency (replacing existing node)": {
+		initConf: `
+nodeprofiles: {}
+nodes:
+  n1:
+    system overlay:
+      - so1
+    runtime overlay:
+      - ro1
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+`,
+		initFiles: []string{
+			"/var/lib/warewulf/overlays/so2/rootfs/file",
+			"/var/lib/warewulf/overlays/ro2/rootfs/file",
+		},
+		request: func(serverURL string) (*http.Request, error) {
+			testNode := `{
   "node":{
-    "system overlay": ["so1"],
-	"runtime overlay": ["ro1"],
+    "system overlay": ["so2"],
+	"runtime overlay": ["ro2"],
     "kernel": {
       "version": "v1.0.0",
       "args": ["kernel-args"]
     }
   }
 }`
-		req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/nodes/test", bytes.NewBuffer([]byte(testNode)))
-		assert.NoError(t, err)
+			return http.NewRequest(http.MethodPut, serverURL+"/api/nodes/n1", bytes.NewBuffer([]byte(testNode)))
+		},
+		response: `{"system overlay": ["so2"], "runtime overlay": ["ro2"], "kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`,
+		resultConf: `
+nodeprofiles: {}
+nodes:
+  n1:
+    system overlay:
+      - so2
+    runtime overlay:
+      - ro2
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+`,
+	},
 
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, resp.Body.Close())
-
-		assert.JSONEq(t, `{"system overlay": ["so1"], "runtime overlay": ["ro1"], "kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`, string(body))
-	})
-
-	t.Run("fail if node already exists (given appropriate header)", func(t *testing.T) {
-		// prepareration
-
-		testNode := `{
+	"test preventing replacing a node": {
+		initConf: `
+nodeprofiles: {}
+nodes:
+  n1:
+    system overlay:
+      - so1
+    runtime overlay:
+      - ro1
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+`,
+		initFiles: []string{
+			"/var/lib/warewulf/overlays/so2/rootfs/file",
+			"/var/lib/warewulf/overlays/ro2/rootfs/file",
+		},
+		request: func(serverURL string) (*http.Request, error) {
+			testNode := `{
   "node":{
-    "system overlay": ["so1"],
-	"runtime overlay": ["ro1"],
+    "system overlay": ["so2"],
+	"runtime overlay": ["ro2"],
     "kernel": {
       "version": "v1.0.0",
       "args": ["kernel-args"]
     }
   }
 }`
-		req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/nodes/test", bytes.NewBuffer([]byte(testNode)))
-		assert.NoError(t, err)
-		req.Header.Set("If-None-Match", "*")
+			req, err := http.NewRequest(http.MethodPut, serverURL+"/api/nodes/n1", bytes.NewBuffer([]byte(testNode)))
+			req.Header.Set("If-None-Match", "*")
+			return req, err
+		},
+		response: `{"error": "invalid argument: node 'n1' already exists", "status": "INVALID_ARGUMENT"}`,
+		status:   http.StatusBadRequest,
+		resultConf: `
+nodeprofiles: {}
+nodes:
+  n1:
+    system overlay:
+      - so1
+    runtime overlay:
+      - ro1
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+`,
+	},
 
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
+	"get one specific node": {
+		initConf: `
+nodeprofiles: {}
+nodes:
+  n1:
+    system overlay:
+      - so1
+    runtime overlay:
+      - ro1
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+`,
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodGet, serverURL+"/api/nodes/n1", nil)
+		},
+		response: `{"system overlay": ["so1"], "runtime overlay": ["ro1"], "kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`,
+	},
 
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, resp.Body.Close())
+	"get one specific node with a profile": {
+		initConf: `
+nodeprofiles:
+  default:
+    system overlay:
+      - so1
+    runtime overlay:
+      - ro1
+nodes:
+  n1:
+    profiles:
+      - default
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+`,
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodGet, serverURL+"/api/nodes/n1", nil)
+		},
+		response: `{"profiles": ["default"], "system overlay": ["so1"], "runtime overlay": ["ro1"], "kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`,
+	},
 
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		assert.Contains(t, string(body), "node 'test' already exists")
-	})
+	"get one specific raw node with a profile": {
+		initConf: `
+nodeprofiles:
+  default:
+    system overlay:
+      - so1
+    runtime overlay:
+      - ro1
+nodes:
+  n1:
+    profiles:
+      - default
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+`,
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodGet, serverURL+"/api/nodes/n1/raw", nil)
+		},
+		response: `{"profiles": ["default"], "kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`,
+	},
 
-	t.Run("get one specific node", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/nodes/test", nil)
-		assert.NoError(t, err)
+	"get unbuilt overlay info for the node": {
+		initConf: `
+nodeprofiles: {}
+nodes:
+  n1:
+    system overlay:
+      - so1
+    runtime overlay:
+      - ro1
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+`,
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodGet, serverURL+"/api/nodes/n1/overlays", nil)
+		},
+		response: `{"system overlay": { "overlays": ["so1"] }, "runtime overlay": { "overlays": ["ro1"] }}`,
+	},
 
-		// send request
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		// validate the resp
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, resp.Body.Close())
-
-		assert.JSONEq(t, `{"system overlay": ["so1"], "runtime overlay": ["ro1"], "kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`, string(body))
-	})
-
-	t.Run("get unbuilt overlay info for the node", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/nodes/test/overlays", nil)
-		assert.NoError(t, err)
-
-		// send request
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		// validate the response
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, resp.Body.Close())
-
-		ja := jsonassert.New(t)
-		ja.Assertf(string(body), `{
-			"system overlay": {
-				"overlays": ["so1"]
-			},
-			"runtime overlay": {
-				"overlays": ["ro1"]
-			}
-		}`)
-	})
-
-	t.Run("update the node", func(t *testing.T) {
-		updateNode := `{
-  "node":{
-    "kernel": {
-      "version": "v1.0.1-newversion"
-    }
-  }
-}`
-		req, err := http.NewRequest(http.MethodPatch, srv.URL+"/api/nodes/test", bytes.NewBuffer([]byte(updateNode)))
-		assert.NoError(t, err)
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, resp.Body.Close())
-
-		assert.JSONEq(t, `{"system overlay": ["so1"], "runtime overlay": ["ro1"], "kernel": {"version": "v1.0.1-newversion", "args": ["kernel-args"]}}`, string(body))
-	})
-
-	t.Run("get one specific node (again)", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/nodes/test", nil)
-		assert.NoError(t, err)
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, resp.Body.Close())
-
-		assert.JSONEq(t, `{"system overlay": ["so1"], "runtime overlay": ["ro1"], "kernel": {"version": "v1.0.1-newversion", "args": ["kernel-args"]}}`, string(body))
-	})
-
-	t.Run("get one specific (raw) node", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/nodes/test/raw", nil)
-		assert.NoError(t, err)
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, resp.Body.Close())
-
-		assert.JSONEq(t, `{"system overlay": ["so1"], "runtime overlay": ["ro1"], "kernel": {"version": "v1.0.1-newversion", "args": ["kernel-args"]}}`, string(body))
-	})
-
-	t.Run("test build all nodes overlays", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/nodes/overlays/build", nil)
-		assert.NoError(t, err)
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, resp.Body.Close())
-
-		assert.JSONEq(t, `["node1", "test"]`, string(body))
-	})
-
-	t.Run("test build one node's overlays", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/nodes/test/overlays/build", nil)
-		assert.NoError(t, err)
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, resp.Body.Close())
-
-		assert.JSONEq(t, `"test"`, string(body))
-	})
-
-	t.Run("get built overlay info for the node", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/nodes/test/overlays", nil)
-		assert.NoError(t, err)
-
-		// send request
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		// validate the response
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, resp.Body.Close())
-
-		ja := jsonassert.New(t)
-		ja.Assertf(string(body), `{
+	"get built overlay info for the node": {
+		initConf: `
+nodeprofiles: {}
+nodes:
+  n1:
+    system overlay:
+      - so1
+    runtime overlay:
+      - ro1
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+`,
+		initFiles: []string{
+			"/srv/warewulf/overlays/n1/__SYSTEM__.img",
+			"/srv/warewulf/overlays/n1/__SYSTEM__.img.gz",
+			"/srv/warewulf/overlays/n1/__RUNTIME__.img",
+			"/srv/warewulf/overlays/n1/__RUNTIME__.img.gz",
+		},
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodGet, serverURL+"/api/nodes/n1/overlays", nil)
+		},
+		response: `{
 			"system overlay": {
 				"overlays": ["so1"],
 				"mtime": "<<PRESENCE>>"
@@ -268,57 +293,187 @@ func TestNodeAPI(t *testing.T) {
 				"overlays": ["ro1"],
 				"mtime": "<<PRESENCE>>"
 			}
-		}`)
+		}`,
+	},
 
-		data := map[string]any{}
-		assert.NoError(t, json.Unmarshal(body, &data))
-		{
-			_, err := time.Parse(time.RFC3339, data["system overlay"].(map[string]any)["mtime"].(string))
-			assert.NoError(t, err)
-		}
-		{
-			_, err := time.Parse(time.RFC3339, data["runtime overlay"].(map[string]any)["mtime"].(string))
-			assert.NoError(t, err)
-		}
-	})
-
-	t.Run("replace a node", func(t *testing.T) {
-		// prepareration
-
-		testNode := `{
+	"update a node": {
+		initConf: `
+nodeprofiles: {}
+nodes:
+  n1:
+    system overlay:
+      - so1
+    runtime overlay:
+      - ro1
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+`,
+		request: func(serverURL string) (*http.Request, error) {
+			updateNode := `{
   "node":{
-    "system overlay": ["so1"],
-	"runtime overlay": ["ro1"],
     "kernel": {
-      "version": "v1.0.0",
-      "args": ["kernel-args"]
+      "version": "v1.0.1-newversion"
     }
   }
 }`
-		req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/nodes/test", bytes.NewBuffer([]byte(testNode)))
-		assert.NoError(t, err)
+			return http.NewRequest(http.MethodPatch, serverURL+"/api/nodes/n1", bytes.NewBuffer([]byte(updateNode)))
+		},
+		response: `{"system overlay": ["so1"], "runtime overlay": ["ro1"], "kernel": {"version": "v1.0.1-newversion", "args": ["kernel-args"]}}`,
+		resultConf: `
+nodeprofiles: {}
+nodes:
+  n1:
+    system overlay:
+      - so1
+    runtime overlay:
+      - ro1
+    kernel:
+      version: "v1.0.1-newversion"
+      args:
+        - "kernel-args"
+`,
+	},
 
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
+	"test build all nodes overlays": {
+		initConf: `
+nodeprofiles:
+  default:
+    system overlay:
+      - so1
+    runtime overlay:
+      - ro1
+nodes:
+  n1:
+    profiles:
+      - default
+  n2:
+    profiles:
+      - default
+`,
+		initFiles: []string{
+			"/var/lib/warewulf/overlays/so1/rootfs/file",
+			"/var/lib/warewulf/overlays/ro1/rootfs/file",
+		},
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodPost, serverURL+"/api/nodes/overlays/build", nil)
+		},
+		response: `["n1", "n2"]`,
+		resultFiles: []string{
+			"/srv/warewulf/overlays/n1/__SYSTEM__.img",
+			"/srv/warewulf/overlays/n1/__SYSTEM__.img.gz",
+			"/srv/warewulf/overlays/n1/__RUNTIME__.img",
+			"/srv/warewulf/overlays/n1/__RUNTIME__.img.gz",
+			"/srv/warewulf/overlays/n2/__SYSTEM__.img",
+			"/srv/warewulf/overlays/n2/__SYSTEM__.img.gz",
+			"/srv/warewulf/overlays/n2/__RUNTIME__.img",
+			"/srv/warewulf/overlays/n2/__RUNTIME__.img.gz",
+		},
+	},
 
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, resp.Body.Close())
+	"test build one node's overlays": {
+		initConf: `
+nodeprofiles: {}
+nodes:
+  n1:
+    system overlay:
+      - so1
+    runtime overlay:
+      - ro1
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+`,
+		initFiles: []string{
+			"/var/lib/warewulf/overlays/so1/rootfs/file",
+			"/var/lib/warewulf/overlays/ro1/rootfs/file",
+		},
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodPost, serverURL+"/api/nodes/n1/overlays/build", nil)
+		},
+		response: `"n1"`,
+		resultFiles: []string{
+			"/srv/warewulf/overlays/n1/__SYSTEM__.img",
+			"/srv/warewulf/overlays/n1/__SYSTEM__.img.gz",
+			"/srv/warewulf/overlays/n1/__RUNTIME__.img",
+			"/srv/warewulf/overlays/n1/__RUNTIME__.img.gz",
+		},
+	},
 
-		assert.JSONEq(t, `{"system overlay": ["so1"], "runtime overlay": ["ro1"], "kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`, string(body))
-	})
+	"test delete nodes": {
+		initConf: `
+nodeprofiles: {}
+nodes:
+  n1:
+    system overlay:
+      - so1
+    runtime overlay:
+      - ro1
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+`,
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodDelete, serverURL+"/api/nodes/n1", nil)
+		},
+		response: `{"system overlay": ["so1"], "runtime overlay": ["ro1"], "kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`,
+		resultConf: `
+nodeprofiles: {}
+nodes: {}
+`,
+	},
+}
 
-	t.Run("test delete nodes", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodDelete, srv.URL+"/api/nodes/test", nil)
-		assert.NoError(t, err)
+func TestNodeAPI(t *testing.T) {
+	for name, tt := range nodeTests {
+		t.Run(name, func(t *testing.T) {
+			warewulfd.SetNoDaemon()
+			env := testenv.New(t)
+			defer env.RemoveAll()
 
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
+			env.WriteFile("/etc/warewulf/nodes.conf", tt.initConf)
+			for _, fileName := range tt.initFiles {
+				env.CreateFile(fileName)
+			}
 
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
-		assert.NoError(t, resp.Body.Close())
+			allowedNets := []net.IPNet{
+				{
+					IP:   net.IPv4(127, 0, 0, 0),
+					Mask: net.CIDRMask(8, 32),
+				},
+			}
+			srv := httptest.NewServer(Handler(nil, allowedNets))
+			defer srv.Close()
 
-		assert.JSONEq(t, `{"system overlay": ["so1"], "runtime overlay": ["ro1"], "kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`, string(body))
-	})
+			req, err := tt.request(srv.URL)
+			assert.NoError(t, err)
+
+			resp, err := http.DefaultTransport.RoundTrip(req)
+			assert.NoError(t, err)
+
+			expectedStatus := tt.status
+			if expectedStatus == 0 {
+				expectedStatus = http.StatusOK
+			}
+			assert.Equal(t, expectedStatus, resp.StatusCode)
+
+			body, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			assert.NoError(t, resp.Body.Close())
+
+			ja := jsonassert.New(t)
+			ja.Assertf(string(body), tt.response) //nolint:govet
+
+			if tt.resultConf != "" {
+				assert.YAMLEq(t, tt.resultConf, env.ReadFile("/etc/warewulf/nodes.conf"))
+			}
+
+			for _, fileName := range tt.resultFiles {
+				assert.FileExists(t, env.GetPath(fileName))
+			}
+		})
+	}
 }

--- a/internal/pkg/warewulfd/api/overlay.go
+++ b/internal/pkg/warewulfd/api/overlay.go
@@ -302,9 +302,6 @@ func addOverlayFile() usecase.Interactor {
 		if input.Path == "" {
 			return status.Wrap(fmt.Errorf("must specify a path"), status.InvalidArgument)
 		}
-		if input.Content == "" {
-			return status.Wrap(fmt.Errorf("content should not be empty"), status.InvalidArgument)
-		}
 		if relPath, err := url.QueryUnescape(input.Path); err != nil {
 			return fmt.Errorf("failed to decode path: %v: %w", input.Path, err)
 		} else {

--- a/internal/pkg/warewulfd/api/overlay.go
+++ b/internal/pkg/warewulfd/api/overlay.go
@@ -259,9 +259,9 @@ func deleteOverlay() usecase.Interactor {
 
 func deleteOverlayFile() usecase.Interactor {
 	type deleteOverlayFileInput struct {
-		Name    string `path:"name" required:"true" description:"Name of overlay to get a file from"`
-		Path    string `query:"path" required:"true" description:"Path to file to get from an overlay"`
-		Force   bool   `query:"force" default:"false" description:"Whether to forcely delete a overlay, default:'false'"`
+		Name    string `path:"name" required:"true" description:"Name of overlay to delete a file from"`
+		Path    string `query:"path" required:"true" description:"Path to file to delete from an overlay"`
+		Force   bool   `query:"force" default:"false" description:"Whether to forcefully delete an overlay file, default:'false'"`
 		Cleanup bool   `query:"cleanup" default:"false" description:"Whether to cleanup empty parent directories, default:'false'"`
 	}
 

--- a/internal/pkg/warewulfd/api/overlay_test.go
+++ b/internal/pkg/warewulfd/api/overlay_test.go
@@ -103,7 +103,7 @@ func TestOverlayAPI(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, resp.Body.Close())
 
-		assert.JSONEq(t, `{"files":["/email.ww"], "site":false}`, string(body))
+		assert.JSONEq(t, `{"files":["/email.ww"], "site":true}`, string(body))
 
 		// get again
 		req, err = http.NewRequest(http.MethodGet, srv.URL+"/api/overlays/testoverlay/file?path=email.ww", nil)
@@ -155,7 +155,7 @@ func TestOverlayAPI(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, resp.Body.Close())
 
-		assert.JSONEq(t, `{"test":{"files":null, "site":true},"testoverlay":{"files":["/email.ww"], "site":false}}`, string(body))
+		assert.JSONEq(t, `{"test":{"files":null, "site":true},"testoverlay":{"files":["/email.ww"], "site":true}}`, string(body))
 	})
 
 	t.Run("test delete overlay file", func(t *testing.T) {

--- a/internal/pkg/warewulfd/api/overlay_test.go
+++ b/internal/pkg/warewulfd/api/overlay_test.go
@@ -128,6 +128,6 @@ func TestOverlayAPI(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, resp.Body.Close())
 
-		assert.JSONEq(t, `{"files":null, "site":true}`, string(body))
+		assert.JSONEq(t, `{"files":[], "site":true}`, string(body))
 	})
 }

--- a/internal/pkg/warewulfd/api/overlay_test.go
+++ b/internal/pkg/warewulfd/api/overlay_test.go
@@ -117,6 +117,20 @@ func TestOverlayAPI(t *testing.T) {
 		assert.JSONEq(t, `{"test":{"files":null, "site":true},"testoverlay":{"files":["/email.ww"], "site":false}}`, string(body))
 	})
 
+	t.Run("test delete overlay file", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodDelete, srv.URL+"/api/overlays/testoverlay/file?path=email.ww&force=true", nil)
+		assert.NoError(t, err)
+
+		resp, err := http.DefaultTransport.RoundTrip(req)
+		assert.NoError(t, err)
+
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.NoError(t, resp.Body.Close())
+
+		assert.JSONEq(t, `{"files":null, "site":true}`, string(body))
+	})
+
 	t.Run("test delete overlays", func(t *testing.T) {
 		req, err := http.NewRequest(http.MethodDelete, srv.URL+"/api/overlays/test?force=true", nil)
 		assert.NoError(t, err)

--- a/internal/pkg/warewulfd/api/profile_test.go
+++ b/internal/pkg/warewulfd/api/profile_test.go
@@ -8,160 +8,225 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/kinbiko/jsonassert"
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 )
 
-func TestProfileAPI(t *testing.T) {
-	warewulfd.SetNoDaemon()
-	env := testenv.New(t)
-	defer env.RemoveAll()
-
-	allowedNets := []net.IPNet{
-		{
-			IP:   net.IPv4(127, 0, 0, 0),
-			Mask: net.CIDRMask(8, 32),
+var profileTests = map[string]struct {
+	initConf   string
+	initFiles  []string
+	request    func(serverURL string) (*http.Request, error)
+	response   string
+	status     int
+	resultConf string
+}{
+	"get all profiles": {
+		initConf: `
+nodeprofiles:
+  default: {}
+nodes: {}
+`,
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodGet, serverURL+"/api/profiles", nil)
 		},
+		response: `{"default": {}}`,
+	},
+
+	"add a new profile": {
+		initConf: `
+nodeprofiles:
+  default: {}
+nodes: {}
+`,
+		request: func(serverURL string) (*http.Request, error) {
+			testProfile := `{"profile": {"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}}`
+			return http.NewRequest(http.MethodPut, serverURL+"/api/profiles/p1", bytes.NewBuffer([]byte(testProfile)))
+		},
+		response: `{"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`,
+		resultConf: `
+nodeprofiles:
+  default: {}
+  p1:
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+nodes: {}
+`,
+	},
+
+	"test idempotency (replacing existing profile)": {
+		initConf: `
+nodeprofiles:
+  default: {}
+  p1:
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+nodes: {}
+`,
+		request: func(serverURL string) (*http.Request, error) {
+			testProfile := `{"profile": {"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}}`
+			return http.NewRequest(http.MethodPut, serverURL+"/api/profiles/p1", bytes.NewBuffer([]byte(testProfile)))
+		},
+		response: `{"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`,
+		resultConf: `
+nodeprofiles:
+  default: {}
+  p1:
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+nodes: {}
+`,
+	},
+
+	"test preventing replacing a profile": {
+		initConf: `
+nodeprofiles:
+  default: {}
+  p1:
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+nodes: {}
+`,
+		request: func(serverURL string) (*http.Request, error) {
+			testProfile := `{"profile": {"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}}`
+			req, err := http.NewRequest(http.MethodPut, serverURL+"/api/profiles/p1", bytes.NewBuffer([]byte(testProfile)))
+			req.Header.Set("If-None-Match", "*")
+			return req, err
+		},
+		response: `{"error": "invalid argument: profile 'p1' already exists", "status": "INVALID_ARGUMENT"}`,
+		status:   http.StatusBadRequest,
+		resultConf: `
+nodeprofiles:
+  default: {}
+  p1:
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+nodes: {}
+`,
+	},
+
+	"get one specific profile": {
+		initConf: `
+nodeprofiles:
+  default: {}
+  p1:
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+nodes: {}
+`,
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodGet, serverURL+"/api/profiles/p1", nil)
+		},
+		response: `{"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`,
+	},
+
+	"update a profile": {
+		initConf: `
+nodeprofiles:
+  default: {}
+  p1:
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+nodes: {}
+`,
+		request: func(serverURL string) (*http.Request, error) {
+			updateProfile := `{"profile": {"kernel": {"version": "v1.0.1-newversion"}}}`
+			return http.NewRequest(http.MethodPatch, serverURL+"/api/profiles/p1", bytes.NewBuffer([]byte(updateProfile)))
+		},
+		response: `{"kernel": {"version": "v1.0.1-newversion", "args": ["kernel-args"]}}`,
+		resultConf: `
+nodeprofiles:
+  default: {}
+  p1:
+    kernel:
+      version: "v1.0.1-newversion"
+      args:
+        - "kernel-args"
+nodes: {}
+`,
+	},
+
+	"test delete a profile": {
+		initConf: `
+nodeprofiles:
+  default: {}
+  p1:
+    kernel:
+      version: "v1.0.0"
+      args:
+        - "kernel-args"
+nodes: {}
+`,
+		request: func(serverURL string) (*http.Request, error) {
+			return http.NewRequest(http.MethodDelete, serverURL+"/api/profiles/p1", nil)
+		},
+		response: `{"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`,
+		resultConf: `
+nodeprofiles:
+  default: {}
+nodes: {}
+`,
+	},
+}
+
+func TestProfileAPI(t *testing.T) {
+	for name, tt := range profileTests {
+		t.Run(name, func(t *testing.T) {
+			warewulfd.SetNoDaemon()
+			env := testenv.New(t)
+			defer env.RemoveAll()
+
+			env.WriteFile("/etc/warewulf/nodes.conf", tt.initConf)
+			for _, fileName := range tt.initFiles {
+				env.CreateFile(fileName)
+			}
+
+			allowedNets := []net.IPNet{
+				{
+					IP:   net.IPv4(127, 0, 0, 0),
+					Mask: net.CIDRMask(8, 32),
+				},
+			}
+			srv := httptest.NewServer(Handler(nil, allowedNets))
+			defer srv.Close()
+
+			req, err := tt.request(srv.URL)
+			assert.NoError(t, err)
+
+			resp, err := http.DefaultTransport.RoundTrip(req)
+			assert.NoError(t, err)
+
+			expectedStatus := tt.status
+			if expectedStatus == 0 {
+				expectedStatus = http.StatusOK
+			}
+			assert.Equal(t, expectedStatus, resp.StatusCode)
+
+			body, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			assert.NoError(t, resp.Body.Close())
+
+			ja := jsonassert.New(t)
+			ja.Assertf(string(body), tt.response) //nolint:govet
+
+			if tt.resultConf != "" {
+				assert.YAMLEq(t, tt.resultConf, env.ReadFile("/etc/warewulf/nodes.conf"))
+			}
+		})
 	}
-	srv := httptest.NewServer(Handler(nil, allowedNets))
-	defer srv.Close()
-
-	t.Run("get all profiles", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/profiles", nil)
-		assert.NoError(t, err)
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, resp.Body.Close())
-		assert.NoError(t, err)
-		assert.JSONEq(t, `{"default": {}}`, string(body))
-	})
-
-	t.Run("add a new profile", func(t *testing.T) {
-		testProfile := `{"profile": {"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}}`
-		req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/profiles/test", bytes.NewBuffer([]byte(testProfile)))
-		assert.NoError(t, err)
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, resp.Body.Close())
-		assert.NoError(t, err)
-		assert.JSONEq(t, `{"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`, string(body))
-	})
-
-	t.Run("test idempotency", func(t *testing.T) {
-		testProfile := `{"profile": {"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}}`
-		req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/profiles/test", bytes.NewBuffer([]byte(testProfile)))
-		assert.NoError(t, err)
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, resp.Body.Close())
-		assert.NoError(t, err)
-		assert.JSONEq(t, `{"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`, string(body))
-	})
-
-	t.Run("fail if profile already exists (given appropriate header)", func(t *testing.T) {
-		testProfile := `{"profile": {"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}}`
-		req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/profiles/test", bytes.NewBuffer([]byte(testProfile)))
-		assert.NoError(t, err)
-		req.Header.Set("If-None-Match", "*")
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, resp.Body.Close())
-		assert.NoError(t, err)
-
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		assert.Contains(t, string(body), "profile 'test' already exists")
-	})
-
-	t.Run("re-read all profiles", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/profiles", nil)
-		assert.NoError(t, err)
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, resp.Body.Close())
-		assert.NoError(t, err)
-		assert.JSONEq(t, `{"default": {}, "test": {"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}}`, string(body))
-	})
-
-	t.Run("get one specific profile (that was just added)", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/profiles/test", nil)
-		assert.NoError(t, err)
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, resp.Body.Close())
-		assert.NoError(t, err)
-		assert.JSONEq(t, `{"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`, string(body))
-	})
-
-	t.Run("update the profile", func(t *testing.T) {
-		updateProfile := `{"profile": {"kernel": {"version": "v1.0.1-newversion"}}}`
-		req, err := http.NewRequest(http.MethodPatch, srv.URL+"/api/profiles/test", bytes.NewBuffer([]byte(updateProfile)))
-		assert.NoError(t, err)
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, resp.Body.Close())
-		assert.NoError(t, err)
-		assert.JSONEq(t, `{"kernel": {"version": "v1.0.1-newversion", "args": ["kernel-args"]}}`, string(body))
-	})
-
-	t.Run("get one specific profile (that was just updated)", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, srv.URL+"/api/profiles/test", nil)
-		assert.NoError(t, err)
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, resp.Body.Close())
-		assert.NoError(t, err)
-		assert.JSONEq(t, `{"kernel": {"version": "v1.0.1-newversion", "args": ["kernel-args"]}}`, string(body))
-	})
-
-	t.Run("test overwrite", func(t *testing.T) {
-		testProfile := `{"profile": {"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}}`
-		req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/profiles/test", bytes.NewBuffer([]byte(testProfile)))
-		assert.NoError(t, err)
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, resp.Body.Close())
-		assert.NoError(t, err)
-		assert.JSONEq(t, `{"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`, string(body))
-	})
-
-	t.Run("test delete a profile", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodDelete, srv.URL+"/api/profiles/test", nil)
-		assert.NoError(t, err)
-
-		resp, err := http.DefaultTransport.RoundTrip(req)
-		assert.NoError(t, err)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, resp.Body.Close())
-		assert.NoError(t, err)
-		assert.JSONEq(t, `{"kernel": {"version": "v1.0.0", "args": ["kernel-args"]}}`, string(body))
-	})
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

- Added system and runtime overlay built time.
- Support If-None-Match header in `PUT /api/nodes/{id}`
- Added `PUT|DELETE /api/overlays/{name}/file?path={path}`
- Added `DELETE /api/overlays/{name}/file?path={path}`
- Restore default idempotency of `PUT /api/nodes/{id}`
- `DELETE /api/overlays/{name}?force=true` can delete overlays that are in use

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
