### PR TITLE
fix(wwctl): Create overlay edit tempfile in tmpdir

### DIFF
--- a/internal/app/wwctl/overlay/edit/main.go
+++ b/internal/app/wwctl/overlay/edit/main.go
@@ -48,7 +48,7 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 		return fmt.Errorf("%s does not exist. Use '--parents' option to create automatically", overlayFileDir)
 	}
 
-	tempFile, tempFileErr := os.CreateTemp(overlay_.Path(), "ww-overlay-edit-")
+	tempFile, tempFileErr := os.CreateTemp("", "ww-overlay-edit-")
 	if tempFileErr != nil {
 		return fmt.Errorf("unable to create temporary file for editing: %s", tempFileErr)
 	}


### PR DESCRIPTION
## Description of the Pull Request (PR):

When editing an overlay, the temporary file was created within the overlay directory structure. This could lead to the temporary file being included in the overlay if not cleaned up properly.

This change modifies the behavior to create the temporary file in the system's default temporary directory, avoiding any potential issues with the overlay itself.

Not using this change the temporary file can be seen in the overlay:

 DEBUG  : Using temporary file /usr/share/warewulf/overlays/host/ww-overlay-edit-2879742493
 DEBUG  : Checking if path exists as a file: /usr/share/warewulf/overlays/host/rootfs/etc/hosts.ww
 DEBUG  : ExecInteractive(tee, [/usr/share/warewulf/overlays/host/ww-overlay-edit-2879742493])

 # find /srv | grep ww-overlay
 /srv/warewulf/overlays/host/ww-overlay-edit-2879742493

With this patch applied:

 DEBUG  : Using temporary file /tmp/ww-overlay-edit-266752840
 DEBUG  : Checking if path exists as a file: /usr/share/warewulf/overlays/host/rootfs/etc/hosts.ww
 DEBUG  : ExecInteractive(tee, [/tmp/ww-overlay-edit-266752840])

 # find /srv | grep ww-overlay


## This fixes or addresses the following GitHub issues:

- Fixes #


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
