### PR TITLE
Add IPv6 support for iPXE booting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added `DELETE /api/overlays/{name}/file?path={path}`
 - Added `wwctl configure warewulfd`
 - Added troubleshooting documentation regarding NUMA and tmpfs
+- Added support for IPv6 when booting with iPXE. #1852
 
 ### Changed
 
 - Restore default idempotency of `PUT /api/nodes/{id}`
 - `DELETE /api/overlays/{name}?force=true` can delete overlays that are in use
 - `warewulfd` overlay autobuild rebuilds overlays after node discovery. #1468
+
+### Fixed
+
 - Improved netplan support. #1873
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -47,3 +47,4 @@
 * Stephen Simpson [@ssimpson89](https://github.com/ssimpson89)
 * Rafael Lopez <raflopez1@gmail.com> @rafalop
 * Arian Cabrera [@acabrera86](https://github.com/acabrera86)
+* Dacian Reece-Stremtan <dacianstremtan@gmail.com> [@dacianstremtan](https://github.com/dacianstremtan)

--- a/etc/grub/grub.cfg.ww
+++ b/etc/grub/grub.cfg.ww
@@ -4,6 +4,7 @@ echo
 echo "Warewulf Server:"
 echo "* Ipaddr: {{.Ipaddr}}"
 echo "* Port: {{.Port}}"
+echo "* Authority: {{.Authority}}"
 echo
 echo "This node:"
 echo "* Fqdn: {{.Fqdn}}"
@@ -28,7 +29,7 @@ reboot
 echo "Reading asset key..."
 smbios --type 3 --get-string 8 --set assetkey
 
-uri="(http,{{.Ipaddr}}:{{.Port}})/provision/${net_default_mac}?assetkey=${assetkey}"
+uri="(http,{{.Authority}})/provision/${net_default_mac}?assetkey=${assetkey}"
 kernel="${uri}&stage=kernel"
 
 set default={{ or .Tags.GrubMenuEntry "single-stage" }}

--- a/etc/ipxe/default.ipxe
+++ b/etc/ipxe/default.ipxe
@@ -15,7 +15,7 @@ sleep 30
 reboot
 {{- end }}
 
-set baseuri http://{{.Ipaddr}}:{{.Port}}/provision/{{.Hwaddr}}
+set baseuri http://{{.Authority}}/provision/{{.Hwaddr}}
 set uri ${baseuri}?assetkey=${asset}&uuid=${uuid}
 
 echo Downloading kernel image...
@@ -115,6 +115,7 @@ goto menu
 echo Warewulf Server:
 echo * Ipaddr: {{.Ipaddr}}
 echo * Port: {{.Port}}
+echo * Authority: {{.Authority}}
 echo
 echo This node:
 echo * Fqdn: {{.Fqdn}}

--- a/internal/pkg/warewulfd/parser.go
+++ b/internal/pkg/warewulfd/parser.go
@@ -2,7 +2,7 @@ package warewulfd
 
 import (
 	"net/http"
-	"strconv"
+	"net/netip"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -44,9 +44,12 @@ func parseReq(req *http.Request) (parserInfo, error) {
 		ret.efifile = path_parts[2]
 	}
 	ret.hwaddr = hwaddr
-	ret.ipaddr = strings.Split(req.RemoteAddr, ":")[0]
-	ret.remoteport, _ = strconv.Atoi(strings.Split(req.RemoteAddr, ":")[1])
-
+	remoteAddrPort, err := netip.ParseAddrPort(req.RemoteAddr)
+	if err != nil {
+		return ret, errors.New("could not parse remote address")
+	}
+	ret.ipaddr = remoteAddrPort.Addr().String()
+	ret.remoteport = int(remoteAddrPort.Port())
 	if len(req.URL.Query()["assetkey"]) > 0 {
 		ret.assetkey = req.URL.Query()["assetkey"][0]
 	}

--- a/internal/pkg/warewulfd/parser_test.go
+++ b/internal/pkg/warewulfd/parser_test.go
@@ -1,0 +1,53 @@
+package warewulfd
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var parseReqTests = []struct {
+	description string
+	url         string
+	remoteAddr  string
+	result      parserInfo
+}{
+	{
+		description: "basic ipv4 request",
+		url:         "/provision/00:00:00:ff:ff:ff",
+		remoteAddr:  "10.5.1.1:9873",
+		result: parserInfo{
+			hwaddr:     "00:00:00:ff:ff:ff",
+			ipaddr:     "10.5.1.1",
+			remoteport: 9873,
+			stage:      "ipxe",
+		},
+	},
+	{
+		description: "basic ipv6 request",
+		url:         "/provision/00:00:00:ff:ff:ff",
+		remoteAddr:  "[fd00:5::1:1]:9873",
+		result: parserInfo{
+			hwaddr:     "00:00:00:ff:ff:ff",
+			ipaddr:     "fd00:5::1:1",
+			remoteport: 9873,
+			stage:      "ipxe",
+		},
+	},
+}
+
+func Test_ParseReq(t *testing.T) {
+	for _, tt := range parseReqTests {
+		t.Run(tt.description, func(t *testing.T) {
+			req := &http.Request{
+				URL:        &url.URL{Path: tt.url},
+				RemoteAddr: tt.remoteAddr,
+			}
+			result, err := parseReq(req)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.result, result)
+		})
+	}
+}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add preliminary/partial support for booting nodes via IPv6 PXE. This PR does not provide full IPv6 provisioning support, however, I believe the only thing missing is DHCP server support.  

Tested with Rocky9 on aarch64 on MacOS with QEMU.  Rocky9 iPXE did not work with IPv6, building iPXE from git fixed it.

Detailed Changes:
* This PR is based off of #1852 (rebased)
* Introduces a new provisioning (iPXE) template variable `Authority` which combines the IP address and port and provides the `[]` if the address is IPv6 according to RFC 3986.
* The value of Authority is set to the same address family as the requesting IP.  This can be used in a template regardless of address family.
* Unit tests added for parsing and Authority.
* default.ipxe has been updated and tested with Authority.
* Now uses netip address parsing for the requesting IP address (go 1.18+)
* Reverts PR #1852 config parser changes in favor of current version.
  * Note: `warewulf.conf` `Ipadd6` requires a subnet prefix and stored as such.
  * Note: If a subnet prefix is set in `warewulf.conf` `Ipaddr`, (IPv4) it is removed and the netmask and broadcast addresses are set from this.
  * The conf.Ipaddr6 is stored as a IPv6 with prefix, #1852 set `warewulf.conf` `Ipaddr6` value to the address without the prefix.
  * The provisioning template (iPXE) `IPaddr` is set to just the IPv6 value, same as #1852

## This fixes or addresses the following GitHub issues:

- Rework of #1852

## Reviewer  checklist

The original PR will have to be signed off.

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
