### PR TITLE
Move reexec.Init() to beginning of wwctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed a bug when cloning an overlay to site when parent is missing
 - Fixed `wwctl upgrade nodes` to properly handle kernel argument lists. #1938
-- Improved netplan support. #1873
+- Fixed a panic during `wwctl overlay edit` due to missing `reexec.Init()`. #1879
 
 ## v4.6.2, 2025-07-09
 

--- a/cmd/wwctl/main.go
+++ b/cmd/wwctl/main.go
@@ -4,10 +4,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/containers/storage/pkg/reexec"
 	"github.com/warewulf/warewulf/internal/app/wwctl"
 )
 
 func main() {
+	if reexec.Init() {
+		return
+	}
+
 	root := wwctl.GetRootCommand()
 
 	err := root.Execute()

--- a/internal/pkg/image/imprt.go
+++ b/internal/pkg/image/imprt.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage/drivers/copy"
-	"github.com/containers/storage/pkg/reexec"
 	"github.com/pkg/errors"
 
 	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
@@ -67,9 +66,6 @@ func ImportDirectory(uri string, name string) error {
 
 	if !util.IsFile(path.Join(uri, "/bin/sh")) {
 		return errors.New("Source directory has no /bin/sh: " + uri)
-	}
-	if reexec.Init() {
-		return errors.New("couldn't init reexec")
 	}
 	err = copy.DirCopy(uri, fullPath, copy.Content, true)
 	if err != nil {


### PR DESCRIPTION
## Description of the Pull Request (PR):

The containers/storage library uses a "reexec" pattern where it spawns subprocesses of itself to perform certain operations (like unpacking archives in chroot environments). When it does this, it expects the main() function to have called reexec.Init() to register handlers for these subprocess operations.

This was previously done targeting image imports. This fix moves the init to the beginning of wwctl to cover all possible cases within the command.

## This fixes or addresses the following GitHub issues:

- Fixes: #1879

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
