### PR TITLE
Fixed handling of comma-separated mount options in fstab and ignition overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed a bug when cloning an overlay to site when parent is missing
 - Fixed `wwctl upgrade nodes` to properly handle kernel argument lists. #1938
 - Fixed a panic during `wwctl overlay edit` due to missing `reexec.Init()`. #1879
+- Fixed handling of comma-separated mount options in `fstab` and `ignition` overlays. #1950
 
 ## v4.6.2, 2025-07-09
 

--- a/overlays/fstab/internal/fstab_test.go
+++ b/overlays/fstab/internal/fstab_test.go
@@ -61,7 +61,8 @@ sysfs /sys sysfs defaults 0 0
 proc /proc proc defaults 0 0
 # mounts for local file systems created with ignition in nodes.conf
 # all with noauto as mounts happens with systemd units
-/dev/disk/by-partlabel/scratch /scratch btrfs noauto,defaults 0 0
+/dev/disk/by-partlabel/scratch /scratch btrfs noauto,nondefault 0 0
+/dev/disk/by-partlabel/scratch2 /scratch2 btrfs noauto,defaults 0 0
 /dev/disk/by-partlabel/swap swap swap noauto,defaults 0 0
 warewulf:/home /home nfs defaults 0 0
 `

--- a/overlays/fstab/internal/nodes.conf
+++ b/overlays/fstab/internal/nodes.conf
@@ -18,6 +18,11 @@ nodes:
         format: btrfs
         path: /scratch
         wipe_filesystem: true
+        mount_options: "nondefault"
+      /dev/disk/by-partlabel/scratch2:
+        format: btrfs
+        path: /scratch2
+        wipe_filesystem: true
       /dev/disk/by-partlabel/swap:
         format: swap
         path: swap

--- a/overlays/fstab/rootfs/etc/fstab.ww
+++ b/overlays/fstab/rootfs/etc/fstab.ww
@@ -9,7 +9,7 @@ proc /proc proc defaults 0 0
 # all with noauto as mounts happens with systemd units
 {{- range $fsdevice,$fs := .FileSystems }}
 {{ $fsdevice }} {{ $fs.Path }} {{ $fs.Format }}
-{{- if $fs.MountOptions }} noauto{{range $index,$opt := $fs.MountOptions }},{{ $opt }}{{ end }} 0 0
+{{- if $fs.MountOptions }} noauto,{{ $fs.MountOptions }} 0 0
 {{- else }} noauto,defaults 0 0
 {{- end }}{{ end }}{{ end }}
 {{- with $fstab := index .Resources "fstab" }}

--- a/overlays/ignition/internal/ignition_test.go
+++ b/overlays/ignition/internal/ignition_test.go
@@ -111,6 +111,7 @@ nodes:
         format: btrfs
         path: /scratch
         wipe_filesystem: true
+        mount_options: "nondefault"
       /dev/disk/by-partlabel/swap:
         format: swap
         path: swap`,
@@ -129,6 +130,7 @@ After=ignition-ww4-disks.service
 Where=/scratch
 What=/dev/disk/by-partlabel/scratch
 Type=btrfs
+Options=nondefault
 [Install]
 RequiredBy=local-fs.target
 backupFile: true

--- a/overlays/ignition/rootfs/etc/systemd/system/ww4-mounts.ww
+++ b/overlays/ignition/rootfs/etc/systemd/system/ww4-mounts.ww
@@ -27,7 +27,7 @@ Where={{ $fs.Path }}
 What={{ $fsdevice }}
 Type={{ $fs.Format }}
 {{- if $fs.MountOptions }}
-Options={{ $fs.MountOptions | join "." }}
+Options={{ $fs.MountOptions }}
 {{- end }}
 [Install]
 RequiredBy=local-fs.target


### PR DESCRIPTION
## Description of the Pull Request (PR):

Update fstab and ignition overlays to properly handle overlays specified in a scalar, comma-separated string, when expected.

## This fixes or addresses the following GitHub issues:

- Fixed: #1950


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
