### PR TITLE
Fix a race condition in wwctl overlay edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed `wwctl upgrade nodes` to properly handle kernel argument lists. #1938
 - Fixed a panic during `wwctl overlay edit` due to missing `reexec.Init()`. #1879
 - Fixed handling of comma-separated mount options in `fstab` and `ignition` overlays. #1950
+- Fixed a race condition in `wwctl overlay edit`. #1947
 
 ## v4.6.2, 2025-07-09
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Switches to using sha256 rather than mtime to detect changes to an overlay file.


## This fixes or addresses the following GitHub issues:

- Fixes: #1947


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
