### PR TITLE
Fix a syntax error in the RPM specfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed a panic during `wwctl overlay edit` due to missing `reexec.Init()`. #1879
 - Fixed handling of comma-separated mount options in `fstab` and `ignition` overlays. #1950
 - Fixed a race condition in `wwctl overlay edit`. #1947
+- Fixed a syntax error in the RPM specfile.
 
 ## v4.6.2, 2025-07-09
 

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -82,7 +82,7 @@ system for large clusters of bare metal and/or virtual systems.
 
 
 %prep
-%setup -q -n %{name}-%{version} -b0 %if %{?with_offline:-a2}
+%setup -q -n %{name}-%{version} -b0
 
 
 %build


### PR DESCRIPTION
## Description of the Pull Request (PR):

This error was apparently being ignored by rpmbuild; but it was called out by Copilot during a recent review.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
