### PR TITLE
Add support for EL10

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Warewulf Development",
-  "image": "registry.docker.com/library/rockylinux:9",
+  "image": "registry.docker.com/rockylinux/rockylinux:10",
   "remoteUser": "vscode",
   "onCreateCommand": "sudo dnf install -y dnf-utils && sudo dnf config-manager --set-enabled crb && sudo dnf install -y unzip cpio gpgme-devel python3-sphinx python3-sphinx_rtd_theme",
   "features": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       has-recent-commits: ${{ steps.commits.outputs.has-recent-commits }}
       commits: ${{ steps.commits.outputs.commits }}
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - name: Checkout Code
@@ -43,6 +44,13 @@ jobs:
         run: |
           make warewulf.spec dist
 
+      - name: Get build version
+        id: version
+        run: |
+          VERSION=$(make version)
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Version: ${VERSION}"
+
       - name: Upload spec
         uses: actions/upload-artifact@v4
         with:
@@ -65,18 +73,20 @@ jobs:
     name: Build RPMs
     runs-on: ${{ matrix.runs-on }}
     container:
-      image: rockylinux/rockylinux:9
+      image: rockylinux/rockylinux:10
       options: --privileged
     strategy:
       fail-fast: false
       matrix:
         arch: [x86_64, aarch64]
-        dist: [el9, el8, suse.lp155]
+        dist: [el10, el9, el8, suse.lp155]
         include:
           - dist: el8
             target: rocky+epel-8
           - dist: el9
             target: rocky+epel-9
+          - dist: el10
+            target: rocky+epel-10
           - dist: suse.lp155
             target: opensuse-leap-15.5
           - arch: x86_64
@@ -110,7 +120,7 @@ jobs:
             root="${eol_root}"
           fi
           mock --root="${root}" --rebuild --spec=warewulf.spec --sources=. \
-          && mock --root="${root}" --chroot -- bash -c "make -C /builddir/build/BUILD/warewulf-*/ test"
+          && mock --root="${root}" --chroot -- bash -c "make -C /builddir/build/BUILD/warewulf-${{ needs.dist.outputs.version }} test"
 
       - name: Upload RPMs
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+- Build support for EL10, EL10 depends on `dnsmasq` and no longer `dhcpd-server` (EOL). #1974
+- `make rpm` added for local development rpm builds. #1974
+
+### Changed
+- `make dist` now uses `mktemp` instead of `.dist`. #1974
+- Fixed dnsmasq template file to use basename for ipxe files. #1974
+- For EL10 default to dnsmasq for dhcpd and tftp. #1974
+
 ## v4.6.3, 2025-08-01
 
 ### Added

--- a/overlays/host/internal/host_test.go
+++ b/overlays/host/internal/host_test.go
@@ -260,7 +260,7 @@ dhcp-option-force=tag:efi-http,60,HTTPClient
 # for http boot always use shim/grub
 dhcp-boot=tag:efi-http,"http://192.168.0.1:9873/efiboot/shim.efi"
 dhcp-boot=tag:x86PC,"/warewulf/ipxe-snponly-x86_64.efi"
-dhcp-boot=tag:aarch64,"/warewulf/arm64-efi/snponly.efi"
+dhcp-boot=tag:aarch64,"/warewulf/snponly.efi"
 # iPXE binary will get the following configuration file
 dhcp-boot=tag:iPXE,"http://192.168.0.1:9873/ipxe/${mac:hexhyp}?assetkey=${asset}&uuid=${uuid}"
 dhcp-no-override

--- a/overlays/host/rootfs/etc/dnsmasq.d/ww4-hosts.conf.ww
+++ b/overlays/host/rootfs/etc/dnsmasq.d/ww4-hosts.conf.ww
@@ -19,7 +19,7 @@ dhcp-boot=tag:x86PC,"warewulf/shim.efi"
 dhcp-boot=tag:x86PC,"/warewulf/{{ index $.Tftp.IpxeBinaries "00:07" }}"
 {{- end }}
 {{- with (index $.Tftp.IpxeBinaries "00:0B" ) }}
-dhcp-boot=tag:aarch64,"/warewulf/{{ index $.Tftp.IpxeBinaries "00:0B" }}"
+dhcp-boot=tag:aarch64,"/warewulf/{{ index $.Tftp.IpxeBinaries "00:0B" | basename }}"
 {{- end }}
 {{- end }}
 # iPXE binary will get the following configuration file

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -50,7 +50,9 @@ BuildRequires: system-release
 BuildRequires: systemd
 BuildRequires: golang >= 1.16
 BuildRequires: firewalld-filesystem
+%if ! (0%{?rhel} >= 10)
 Requires: tftp-server
+%endif
 Requires: nfs-utils
 %if 0%{?rhel} < 8
 Requires: ipxe-bootimgs
@@ -60,11 +62,15 @@ Requires: ipxe-bootimgs-aarch64
 %endif
 %endif
 
+%if 0%{?rhel} >= 10
+Requires: dnsmasq
+%else
 %if 0%{?rhel} >= 8 || 0%{?suse_version} || 0%{?fedora}
 Requires: dhcp-server
 %else
-# rhel < 8
+# rhel < 8 and others
 Requires: dhcp
+%endif
 %endif
 
 BuildRequires: git
@@ -115,6 +121,14 @@ export OFFLINE_BUILD=1
 export NO_BRP_STALE_LINK_ERROR=yes
 make install \
     DESTDIR=%{buildroot}
+
+%if 0%{?rhel} >= 10
+sed -i '
+  s/systemd name: dhcpd/systemd name: dnsmasq/
+  s/systemd name: tftp/systemd name: dnsmasq/
+  /- dsa/d' \
+  -i %{buildroot}%{_sysconfdir}/warewulf/warewulf.conf
+%endif
 
 %if 0%{?suse_version} || 0%{?sle_version}
 yq e '


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add support for EL10
 * Update `.spec` to depend on `dnsmasq` and not `dhcpd-server` for EL10
 * Add make rpm and version targets to the makefile
 * Use `tmpfile` for `make dist` to support building in a devcontainer with colima on a mac.
 * Update CI/CD to get the version via `make version` to support multiple directories in the mock build process (glob returns multiple directories in the `make -C` in `release.yml`.
 * Update CI/CD to use Rocky 10 build container.
 * Update CI/CD to add EL10 target
 * Update CI/CD to use `make version` information for mock
 * Updated .devcontainer to Rocky 10

Only tested on a manual trigger.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
