### PR TITLE
Add default for systemd name for warewulf in warewulf.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Build support for EL10, EL10 depends on `dnsmasq` and no longer `dhcpd-server` (EOL). #1974
 - `make rpm` added for local development rpm builds. #1974
 - `wwclient --once` prompts wwclient to run once. #1226
+- Added default for warewulf 'systemd name' #1993
 
 ### Changed
 

--- a/etc/warewulf.conf
+++ b/etc/warewulf.conf
@@ -5,6 +5,7 @@ warewulf:
   update interval: 60
   autobuild overlays: true
   host overlay: true
+  systemd name: warewulfd
 dhcp:
   enabled: true
   range start: 10.0.1.1


### PR DESCRIPTION
## Description of the Pull Request (PR):

Adds 'warewulfd' to 'systemd name' key in 'warewulf' in warewulf.conf

Without this set warewulfd is not restarted with `wwctl configure --all`

This is the warning produced without the key.
```
WARN   : Not (re)starting Warewulf server: no systemd name configured
```

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
