### PR TITLE
Exclude overlays from brp-mangle-shebangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `wwclient` skips files that do not appear to have been modified. #1984
 - `wwctl overlay edit` again writes temporary files to the default location.
   (After #1886 better resolves the underlying issue from #1473.) #1946
+- Prevent brp-mangle-shebangs from changing files in overlays.
 
 ### Fixed
 

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -14,6 +14,8 @@
 %define _build_id_links none
 %endif
 
+%global __brp_mangle_shebangs_exclude_from ^/usr/share/warewulf/overlays/.*$
+
 
 Name: warewulf
 Summary: A provisioning system for large clusters of bare metal and/or virtual systems
@@ -268,6 +270,7 @@ about Warewulf in an sos report.
 %changelog
 * Thu Sep 4 2025 Jonathon Anderson <janderson@ciq.com>
 - Update golang BuildRequires to 1.22
+- Exclude overlay files from brp-mangle-shebangs
 
 * Tue Apr 1 2025 Jonathon Anderson <janderson@ciq.com>
 - Remove gRPC API

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -14,7 +14,8 @@
 %define _build_id_links none
 %endif
 
-%global __brp_mangle_shebangs_exclude_from ^/usr/share/warewulf/overlays/.*$
+%define _overlaydir %{_overlaydir}
+%global __brp_mangle_shebangs_exclude_from ^%{_overlaydir}/.*$
 
 
 Name: warewulf
@@ -182,35 +183,35 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 
 %dir %{_datadir}/warewulf
 %{_datadir}/warewulf/bmc
-%dir %{_datadir}/warewulf/overlays
-%dir %{_datadir}/warewulf/overlays/*
-%dir %{_datadir}/warewulf/overlays/*/rootfs
-%{_datadir}/warewulf/overlays/NetworkManager/rootfs/*
-%{_datadir}/warewulf/overlays/debian.interfaces/rootfs/*
-%{_datadir}/warewulf/overlays/debug/rootfs/*
-%{_datadir}/warewulf/overlays/fstab/rootfs/*
-%{_datadir}/warewulf/overlays/host/rootfs/*
-%{_datadir}/warewulf/overlays/hostname/rootfs/*
-%{_datadir}/warewulf/overlays/hosts/rootfs/*
-%{_datadir}/warewulf/overlays/ifcfg/rootfs/*
-%{_datadir}/warewulf/overlays/ignition/rootfs/*
-%{_datadir}/warewulf/overlays/issue/rootfs/*
-%{_datadir}/warewulf/overlays/netplan/rootfs/*
-%{_datadir}/warewulf/overlays/resolv/rootfs/*
-%attr(700, -, -) %{_datadir}/warewulf/overlays/ssh.authorized_keys/rootfs/*
-%{_datadir}/warewulf/overlays/ssh.host_keys/rootfs/*
-%{_datadir}/warewulf/overlays/syncuser/rootfs/*
-%{_datadir}/warewulf/overlays/systemd.netname/rootfs/*
-%{_datadir}/warewulf/overlays/udev.netname/rootfs/*
-%{_datadir}/warewulf/overlays/wicked/rootfs/*
-%{_datadir}/warewulf/overlays/wwclient/rootfs/*
-%{_datadir}/warewulf/overlays/wwinit/rootfs/*
-%{_datadir}/warewulf/overlays/localtime/rootfs/*
-%{_datadir}/warewulf/overlays/sfdisk/rootfs/*
-%{_datadir}/warewulf/overlays/mkfs/rootfs/*
-%{_datadir}/warewulf/overlays/mkswap/rootfs/*
-%{_datadir}/warewulf/overlays/systemd.mount/rootfs/*
-%{_datadir}/warewulf/overlays/systemd.swap/rootfs/*
+%dir %{_overlaydir}
+%dir %{_overlaydir}/*
+%dir %{_overlaydir}/*/rootfs
+%{_overlaydir}/NetworkManager/rootfs/*
+%{_overlaydir}/debian.interfaces/rootfs/*
+%{_overlaydir}/debug/rootfs/*
+%{_overlaydir}/fstab/rootfs/*
+%{_overlaydir}/host/rootfs/*
+%{_overlaydir}/hostname/rootfs/*
+%{_overlaydir}/hosts/rootfs/*
+%{_overlaydir}/ifcfg/rootfs/*
+%{_overlaydir}/ignition/rootfs/*
+%{_overlaydir}/issue/rootfs/*
+%{_overlaydir}/netplan/rootfs/*
+%{_overlaydir}/resolv/rootfs/*
+%attr(700, -, -) %{_overlaydir}/ssh.authorized_keys/rootfs/*
+%{_overlaydir}/ssh.host_keys/rootfs/*
+%{_overlaydir}/syncuser/rootfs/*
+%{_overlaydir}/systemd.netname/rootfs/*
+%{_overlaydir}/udev.netname/rootfs/*
+%{_overlaydir}/wicked/rootfs/*
+%{_overlaydir}/wwclient/rootfs/*
+%{_overlaydir}/wwinit/rootfs/*
+%{_overlaydir}/localtime/rootfs/*
+%{_overlaydir}/sfdisk/rootfs/*
+%{_overlaydir}/mkfs/rootfs/*
+%{_overlaydir}/mkswap/rootfs/*
+%{_overlaydir}/systemd.mount/rootfs/*
+%{_overlaydir}/systemd.swap/rootfs/*
 
 %{_bindir}/wwctl
 %{_prefix}/lib/firewalld/services/warewulf.xml


### PR DESCRIPTION
## Description of the Pull Request (PR):

brp-mangle-shebangs has been changing shebang lines in overlays, including changing `/bin/sh` to `/usr/bin/sh`. This is probably not the right thing for overlays, at least, since we don't actually know that the system being booted has moved things to `/usr/`.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
