### PR TITLE
Update golang BuildRequires in warewulf.spec.in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed a bug in `wwclient` which prevented proper cleanup of ephemeral files.
 - Fixed `wwclient --debug` to properly enable debug logging.
+- Updated golang BuildRequires in RPM specfile. #1990
 
 ## v4.6.3, 2025-08-01
 

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -35,7 +35,7 @@ Conflicts: warewulf-ipmi
 %if 0%{?suse_version} || 0%{?sle_version}
 BuildRequires: distribution-release
 BuildRequires: systemd-rpm-macros
-BuildRequires: go >= 1.16
+BuildRequires: go >= 1.22
 BuildRequires: firewall-macros
 BuildRequires: firewalld
 BuildRequires: tftp
@@ -48,7 +48,7 @@ Requires: ipxe-bootimgs
 # Assume Red Hat/Fedora build
 BuildRequires: system-release
 BuildRequires: systemd
-BuildRequires: golang >= 1.16
+BuildRequires: golang >= 1.22
 BuildRequires: firewalld-filesystem
 %if ! (0%{?rhel} >= 10)
 Requires: tftp-server
@@ -266,6 +266,9 @@ about Warewulf in an sos report.
 
 
 %changelog
+* Thu Sep 4 2025 Jonathon Anderson <janderson@ciq.com>
+- Update golang BuildRequires to 1.22
+
 * Tue Apr 1 2025 Jonathon Anderson <janderson@ciq.com>
 - Remove gRPC API
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Update the rpm specfile BuildRequires to match go.mod for the required Go version.


## This fixes or addresses the following GitHub issues:

- Fixes: #1990


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
