### PR TITLE
Fix a find/replace typo from #1999

### DIFF
--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -14,7 +14,7 @@
 %define _build_id_links none
 %endif
 
-%define _overlaydir %{_overlaydir}
+%define _overlaydir %{_datadir}/warewulf/overlays
 %global __brp_mangle_shebangs_exclude_from ^%{_overlaydir}/.*$
 
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

In #1999 I defined `_overlaydir` as `%{_datadir}/warewulf/overlays`, then did a find/replace, which also replaced the right-side of my define. This PR fixes that mistake.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
