### PR TITLE
Add the v4.6.4 release notes to the userdocs index

### DIFF
--- a/userdocs/index.rst
+++ b/userdocs/index.rst
@@ -93,3 +93,4 @@ Welcome to the Warewulf User Guide!
    v4.6.1 <release/v4.6.1>
    v4.6.2 <release/v4.6.2>
    v4.6.3 <release/v4.6.3>
+   v4.6.4 <release/v4.6.4>


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add the v4.6.4 release notes ot the userdocs index.

The release notes are there; they just aren't listed in the table of contents.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
