### PR TITLE
Fix sfdisk overlay for fresh disks by forcing GPT label

### DIFF
--- a/overlays/sfdisk/internal/sfdisk_test.go
+++ b/overlays/sfdisk/internal/sfdisk_test.go
@@ -181,7 +181,7 @@ if ! command -v sfdisk >/dev/null ; then
     info "warewulf: sfdisk not found, skipping partitioning"
 else :
     info "warewulf: sfdisk: partitioning /dev/sda"
-    sfdisk --wipe "auto" "/dev/sda" < "${PREFIX}/warewulf/sfdisk/device-0" || die "warewulf: sfdisk: failed to partition /dev/sda"
+    sfdisk --label gpt --wipe "auto" "/dev/sda" < "${PREFIX}/warewulf/sfdisk/device-0" || die "warewulf: sfdisk: failed to partition /dev/sda"
 
     if command -v blockdev >/dev/null ; then
         info "warewulf: blockdev: re-reading partition table"
@@ -238,14 +238,14 @@ if ! command -v sfdisk >/dev/null ; then
     info "warewulf: sfdisk not found, skipping partitioning"
 else :
     info "warewulf: sfdisk: partitioning /dev/sda"
-    sfdisk --wipe "auto" "/dev/sda" < "${PREFIX}/warewulf/sfdisk/device-0" || die "warewulf: sfdisk: failed to partition /dev/sda"
+    sfdisk --label gpt --wipe "auto" "/dev/sda" < "${PREFIX}/warewulf/sfdisk/device-0" || die "warewulf: sfdisk: failed to partition /dev/sda"
 
     if command -v blockdev >/dev/null ; then
         info "warewulf: blockdev: re-reading partition table"
         blockdev --rereadpt /dev/sda
     fi
     info "warewulf: sfdisk: partitioning /dev/sdb"
-    sfdisk --wipe "always" "/dev/sdb" < "${PREFIX}/warewulf/sfdisk/device-1" || die "warewulf: sfdisk: failed to partition /dev/sdb"
+    sfdisk --label gpt --wipe "always" "/dev/sdb" < "${PREFIX}/warewulf/sfdisk/device-1" || die "warewulf: sfdisk: failed to partition /dev/sdb"
 
     if command -v blockdev >/dev/null ; then
         info "warewulf: blockdev: re-reading partition table"

--- a/overlays/sfdisk/rootfs/warewulf/wwinit.d/10-sfdisk.sh.ww
+++ b/overlays/sfdisk/rootfs/warewulf/wwinit.d/10-sfdisk.sh.ww
@@ -33,7 +33,7 @@ else :
 {{- range $i, $device := $disks }}
 {{- 	if $device.device }}
     info "warewulf: sfdisk: partitioning {{ $device.device }}"
-    sfdisk --wipe "{{ default "auto" $device.wipe }}" "{{ $device.device }}" < "${PREFIX}/warewulf/sfdisk/device-{{ $i }}" || die "warewulf: sfdisk: failed to partition {{ $device.device }}"
+    sfdisk --label gpt --wipe "{{ default "auto" $device.wipe }}" "{{ $device.device }}" < "${PREFIX}/warewulf/sfdisk/device-{{ $i }}" || die "warewulf: sfdisk: failed to partition {{ $device.device }}"
 
     if command -v blockdev >/dev/null ; then
         info "warewulf: blockdev: re-reading partition table"


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR fixes an issue with the sfdisk overlay where fresh disks without a partition table fail to boot due to missing `PARTLABEL`.  
The current overlay defaults to MSR/MBR when no label exists, which is incompatible with Warewulf’s requirement for GPT to provide `PARTLABEL`.  
The change adds `--label gpt` to the sfdisk command in `10-sfdisk.sh.ww`, ensuring that disks are always initialized with GPT, regardless of their previous state (raw, GPT, or MBR).  

The corresponding test `sfdisk_test.go` has been updated to reflect this change in expected behavior.


## This fixes or addresses the following GitHub issues:

- Fixes #2025


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
