### PR TITLE
Add OpenEuler support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Renamed debian.interfaces overlay to ifupdown
+- Change the DHCP server package used on openeuler 24.03 to dnsmasq
 
 ## v4.6.4, 2025-09-05
 

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -65,7 +65,7 @@ Requires: ipxe-bootimgs-aarch64
 %endif
 %endif
 
-%if 0%{?rhel} >= 10
+%if 0%{?rhel} >= 10 || 0%{?openEuler}
 Requires: dnsmasq
 %else
 %if 0%{?rhel} >= 8 || 0%{?suse_version} || 0%{?fedora}
@@ -125,7 +125,7 @@ export NO_BRP_STALE_LINK_ERROR=yes
 make install \
     DESTDIR=%{buildroot}
 
-%if 0%{?rhel} >= 10
+%if 0%{?rhel} >= 10 || 0%{?openEuler}
 sed -i '
   s/systemd name: dhcpd/systemd name: dnsmasq/
   s/systemd name: tftp/systemd name: dnsmasq/


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add's support for openEuler, which will use dnsmasq, from OpenHPC4.x.  Pulled from https://github.com/openhpc/ohpc/pull/2239

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
