### PR TITLE
Add xattr saving and restoration to images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - New `Gateway6` network device field. #2068
 - New `systemd-networkd` overlay. #2068
 
+### Added
+
+- xattr handling for overlays and images. #2043
+
 ### Changed
 
 - Renamed `debian.interfaces` overlay to `ifupdown`. #2011

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - New `Gateway6` network device field. #2068
 - New `systemd-networkd` overlay. #2068
 
+### Added
+
+- xattr handling for overlays and images. #2043
+
 ### Changed
 
 - Renamed `debian.interfaces` overlay to `ifupdown`. #2011

--- a/LICENSE_DEPENDENCIES.md
+++ b/LICENSE_DEPENDENCIES.md
@@ -395,6 +395,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/pkg/errors/blob/v0.9.1/LICENSE>
 
+## github.com/pkg/xattr
+
+**License:** BSD-2-Clause
+
+**License URL:** <https://github.com/pkg/xattr/blob/v0.4.12/LICENSE>
+
 ## github.com/russross/blackfriday/v2
 
 **License:** BSD-2-Clause

--- a/LICENSE_DEPENDENCIES.md
+++ b/LICENSE_DEPENDENCIES.md
@@ -347,6 +347,12 @@ The dependencies and their licenses are as follows:
 
 **License URL:** <https://github.com/pkg/errors/blob/v0.9.1/LICENSE>
 
+## github.com/pkg/xattr
+
+**License:** BSD-2-Clause
+
+**License URL:** <https://github.com/pkg/xattr/blob/v0.4.12/LICENSE>
+
 ## github.com/russross/blackfriday/v2
 
 **License:** BSD-2-Clause

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	google.golang.org/grpc v1.70.0
 	google.golang.org/protobuf v1.36.5
 	gopkg.in/yaml.v3 v3.0.1
+	github.com/pkg/xattr v0.4.12
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
+	github.com/pkg/xattr v0.4.12
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,8 @@ github.com/opencontainers/umoci v0.4.7/go.mod h1:lgJ4bnwJezsN1o/5d7t/xdRPvmf8TvB
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/xattr v0.4.12 h1:rRTkSyFNTRElv6pkA3zpjHpQ90p/OdHQC1GmGh1aTjM=
+github.com/pkg/xattr v0.4.12/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -500,6 +502,7 @@ golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/opencontainers/umoci v0.6.0/go.mod h1:2DS3cxVN9pRJGYaCK5mnmmwVKV5vd9r
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/xattr v0.4.12 h1:rRTkSyFNTRElv6pkA3zpjHpQ90p/OdHQC1GmGh1aTjM=
+github.com/pkg/xattr v0.4.12/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/proglottis/gpgme v0.1.4 h1:3nE7YNA70o2aLjcg63tXMOhPD7bplfE5CBdV+hLAm2M=
 github.com/proglottis/gpgme v0.1.4/go.mod h1:5LoXMgpE4bttgwwdv9bLs/vwqv3qV7F4glEEZ7mRKrM=

--- a/internal/app/wwclient/root.go
+++ b/internal/app/wwclient/root.go
@@ -27,6 +27,7 @@ import (
 	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/pidfile"
 	"github.com/warewulf/warewulf/internal/pkg/version"
+	"github.com/warewulf/warewulf/internal/pkg/util"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 	"github.com/warewulf/warewulf/internal/pkg/wwurl"
 )
@@ -374,6 +375,25 @@ func updateSystem(target string, ipaddr string, port int, wwid string, tag strin
 		wwlog.Error("failed running cpio: %s", err)
 		return nil
 	}
+	// apply saved xattrs
+	xattrsDir := filepath.Join(tempDir, "warewulf", "xattrs")
+	err = filepath.WalkDir(xattrsDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type().IsRegular() {
+			err = util.SetXattrsFromFile(tempDir, path)
+		}
+		if err != nil {
+			wwlog.Warn("failed to apply xattrs from file %s", path)
+		}
+		os.Remove(path)
+		return err
+	})
+	if err != nil {
+		wwlog.Warn("errors encountered while appying xattr files: %w", err)
+	}
+	wwlog.Debug("xattrs applied to overlay")
 
 	// Atomically move files from temp directory to current working directory
 	err = atomicApplyOverlay(tempDir, target)
@@ -577,6 +597,11 @@ func copyFile(src, dst string, srcInfo os.FileInfo) (err error) {
 	err = os.Chtimes(dst, time.Time{}, srcInfo.ModTime())
 	if err != nil {
 		wwlog.Warn("failed to update timestamps for file %s: %s", dst, err)
+	}
+	wwlog.Debug("Copying xattrs for file: %s", dst)
+	err = util.CopyXattrs(src, dst)
+	if err != nil {
+		wwlog.Warn("failed to copy xattrs for file %s: %s", dst, err)
 	}
 
 	return nil

--- a/internal/app/wwclient/root.go
+++ b/internal/app/wwclient/root.go
@@ -26,8 +26,8 @@ import (
 	"github.com/spf13/cobra"
 	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/pidfile"
-	"github.com/warewulf/warewulf/internal/pkg/version"
 	"github.com/warewulf/warewulf/internal/pkg/util"
+	"github.com/warewulf/warewulf/internal/pkg/version"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 	"github.com/warewulf/warewulf/internal/pkg/wwurl"
 )

--- a/internal/pkg/util/copyfile.go
+++ b/internal/pkg/util/copyfile.go
@@ -45,6 +45,11 @@ func CopyFile(src string, dst string) error {
 		wwlog.Debug("Ownership copy from %s to %s failed.\n %s", src, dst, err)
 		return err
 	}
+	err = CopyXattrs(src, dst)
+	if err != nil {
+		wwlog.Debug("Xattr copy from %s to %s failed. \n %s", src, dst, err)
+		return err
+	}
 	return nil
 }
 

--- a/internal/pkg/util/copyfile.go
+++ b/internal/pkg/util/copyfile.go
@@ -49,6 +49,11 @@ func CopyFile(src string, dst string) (err error) {
 		wwlog.Debug("Ownership copy from %s to %s failed.\n %s", src, dst, err)
 		return err
 	}
+	err = CopyXattrs(src, dst)
+	if err != nil {
+		wwlog.Debug("Xattr copy from %s to %s failed. \n %s", src, dst, err)
+		return err
+	}
 	return nil
 }
 

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -19,6 +19,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/pkg/xattr"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
@@ -543,6 +545,21 @@ func BuildFsImage(
 	}
 	wwlog.Debug("Created image directory for %s: %s", name, imagePath)
 
+	xattrsPath := filepath.Join(rootfsPath, "warewulf", "xattrs")
+	err = os.MkdirAll(xattrsPath, 0o700)
+	// should failure to capture xattrs be fatal?
+	if err != nil {
+		wwlog.Warn("Failed to create xattrs dir for %s: %s: %w", name, rootfsPath, err)
+	} else {
+		err = CreateXattrDump(rootfsPath, filepath.Join(xattrsPath, fmt.Sprintf("xattrs-%s", HashString(name))))
+		if err != nil {
+			wwlog.Warn("Failed to save xattrs for %s: %w", name, err)
+			os.Remove(xattrsPath)
+			// this will only succeed if /warewulf is empty
+			os.Remove(filepath.Join(rootfsPath, "warewulf"))
+		}
+	}
+
 	files, err := FindFilterFiles(
 		rootfsPath,
 		include,
@@ -647,4 +664,203 @@ func EqualYaml(a interface{}, b interface{}) (bool, error) {
 // BoolP returns the value of a bool pointer, or false if nil
 func BoolP(p *bool) bool {
 	return p != nil && *p
+}
+
+func HashString(s string) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(s))
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+// CreateXattrDump creates a xattr dump file for the path rootfsPath at filePath
+func CreateXattrDump(rootfsPath string, filePath string) error {
+
+	// we probably could capture everything, but we're likely on concerned with
+	// these xattr types
+	mask := "security\\.capability|system\\.posix_acl.*|security\\.selinux"
+	if strings.Contains(rootfsPath, "overlay") {
+		// in an overlay, only capture capability and acl xattrs
+		mask = "security\\.capability|system\\.posix_acl.*"
+	}
+
+	xattrs, err := SGetXattrsR(rootfsPath, mask)
+	if err != nil {
+		wwlog.Warn("Failed to get xattrs for %s: %w", rootfsPath, err)
+	}
+
+	err = WriteXattrFile(filePath, xattrs)
+
+	if err != nil {
+		os.Remove(filePath)
+		return fmt.Errorf("error archiving xattrs for %s: %w", rootfsPath, err)
+	}
+	wwlog.Debug("Xattr file created for %s at %s", rootfsPath, filePath)
+
+	return nil
+}
+
+// SGetXattrsR recursively retrieves the xattrs for files under rootPath in a
+// format compatible with the getfattr command
+func SGetXattrsR(rootPath string, mask string) ([]string, error) {
+	xattrMask, err := regexp.Compile(mask)
+	if err != nil {
+		return nil, err
+	}
+	wwlog.Debug("SGetXattrsR called with rootPath: %s and mask: %s", rootPath, mask)
+	var allXattrs []string
+
+	err = filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type() == fs.ModeSymlink {
+			// do not act on
+			return nil
+		}
+		xattrNames, err := xattr.List(path)
+		if err != nil {
+			return err
+		}
+
+		relativePath, err := filepath.Rel(rootPath, path)
+		if err != nil {
+			return err
+		}
+
+		var entry strings.Builder
+		entry.WriteString(fmt.Sprintf("# file: %s\n", relativePath))
+		xattrError := 0
+		for _, i := range xattrNames {
+			t, err := xattr.Get(path, i)
+			if err != nil {
+				wwlog.Debug("failed to get xattr for %s", path)
+				xattrError++
+				continue
+			}
+			if xattrMask.MatchString(i) {
+				entry.WriteString(fmt.Sprintf("%s=0x%s\n", i, hex.EncodeToString(t)))
+			}
+		}
+		//newline between files in xattr file
+		entry.WriteString("\n")
+		if strings.Count(entry.String(), "\n") < 3 {
+			// skip files without captured xattrs
+			return nil
+		}
+
+		allXattrs = append(allXattrs, entry.String())
+		if xattrError > 0 {
+			err = fmt.Errorf("encountered at least one error getting xattrs for %s", path)
+		}
+		return err
+	})
+
+	return allXattrs, err
+}
+
+// WriteXattrFile writes a file containing one or more file xattr entries in
+// the style of the output of the setfattr command. This output should be
+// compatible with the setfattr --restore command.
+func WriteXattrFile(path string, xattrs []string) error {
+	if len(xattrs) < 1 {
+		wwlog.Debug("WriteXattrFile declining to write empty xattrs file")
+		return fmt.Errorf("no xattrs to write")
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	for _, entry := range xattrs {
+		_, err := file.WriteString(entry)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+// SetXattrsFromFile ingests a file containing xattr entries in the style of
+// getfattr and restores them recursively to prefix in the style of
+// setfattr --restore
+func SetXattrsFromFile(prefix string, file string) error {
+	f, err := os.Open(file)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	var ourError error
+
+	fileLineRegex := regexp.MustCompile("^# file: (.+)$")
+	// must be a file with the xattrs hex encoded, must be 0x prefixed (as if it were output by getfattr)
+	xattrLineRegex := regexp.MustCompile(`^(.+\..+)=0[xX]([0-9a-fA-F]+)$`)
+
+	failedFiles := 0
+	scanner := bufio.NewScanner(f)
+	fileName := ""
+	for scanner.Scan() {
+		line := scanner.Text()
+		if matches := fileLineRegex.FindStringSubmatch(line); matches != nil {
+			// this is a new file line
+			fileName = filepath.Join(prefix, matches[1])
+			continue
+		} else if matches := xattrLineRegex.FindStringSubmatch(line); matches != nil {
+			// xattr line
+			xattrName := matches[1]
+			//WHAT DO YOU MEAN YOU CAN'T DECODE A 0X PREFIXED STRING?!
+			xattrValue, err := hex.DecodeString(matches[2])
+			if err != nil {
+				// this shouldn't happen
+				wwlog.Debug("failed to decode xattr value for %s for file %s", xattrName, fileName)
+				failedFiles++
+				continue
+			}
+			err = xattr.LSet(fileName, xattrName, xattrValue)
+			if err != nil {
+				wwlog.Debug("failed to set xattr %s for file %s", xattrName, fileName)
+				failedFiles++
+			}
+		} else {
+			// hopefully this is just an empty new line or something and we're about to get a new file
+			fileName = ""
+			continue
+		}
+	}
+	if failedFiles > 0 {
+		ourError = fmt.Errorf("failed to apply all xattrs")
+	}
+	return ourError
+}
+
+// CopyXattrs copies the xattrs from source to dest
+func CopyXattrs(source string, dest string) error {
+	//we explicitly cannot copy selinux attrs
+	filter := regexp.MustCompile(`security\.selinux`)
+	xattrNames, err := xattr.List(source)
+	if err != nil {
+		return err
+	}
+	var filteredNames []string
+	for _, v := range xattrNames {
+		if filter.MatchString(v) {
+			continue
+		}
+		filteredNames = append(filteredNames, v)
+	}
+	var xattrValues [][]byte
+	for _, v := range filteredNames {
+		xattrValue, err := xattr.Get(source, v)
+		if err != nil {
+			return err
+		}
+		xattrValues = append(xattrValues, xattrValue)
+	}
+	for i, v := range filteredNames {
+		err := xattr.Set(dest, v, xattrValues[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
 }

--- a/internal/pkg/util/util_test.go
+++ b/internal/pkg/util/util_test.go
@@ -1,12 +1,18 @@
 package util_test
 
 import (
+	"encoding/hex"
+	"os/exec"
+	"os/user"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/warewulf/warewulf/internal/pkg/testenv"
 	"github.com/warewulf/warewulf/internal/pkg/util"
+
+	"github.com/pkg/xattr"
 )
 
 func Test_FindFiles(t *testing.T) {
@@ -92,4 +98,89 @@ func Test_FindFilterFiles(t *testing.T) {
 			assert.Equal(t, tt.findFiles, files)
 		})
 	}
+}
+
+func Test_SGetXattrsR(t *testing.T) {
+	currentUser, err := user.Current()
+	if currentUser.Uid != "0" || err != nil {
+		t.Skip("Skipping test, security.capability xattr can only be set when running as root")
+	}
+	tests := map[string]struct {
+		fileXattrs map[string]string
+	}{
+		"no xattrs": {
+			fileXattrs: map[string]string{"test/test1": "", "test/test2": ""},
+		},
+		"xattrs": {
+			fileXattrs: map[string]string{"test/test1": "security.capability=0x0000000200200000000000000000000000000000", "test/test2": "system.posix_acl_access=0x0200000001000600ffffffff02000600e903000004000400ffffffff10000600ffffffff20000400ffffffff"},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			mask := "security\\.capability|system\\.posix_acl.*"
+			env := testenv.New(t)
+			defer env.RemoveAll()
+			env.MkdirAll("/test")
+			for file_, xattr_ := range tt.fileXattrs {
+				env.CreateFile(filepath.Join("/", file_))
+				if xattr_ == "" {
+					break
+				}
+				xattr_ := strings.SplitN(xattr_, "=", 2)
+				xattrName := xattr_[0]
+				xattrValue := xattr_[1]
+				xattrHex, _ := hex.DecodeString(xattrValue[2:])
+				err := xattr.LSet(env.GetPath("/"+file_), xattrName, xattrHex)
+				assert.NoError(t, err)
+			}
+			xattrs, err := util.SGetXattrsR(env.GetPath("/"), mask)
+			assert.NoError(t, err)
+			for file_, xattr_ := range tt.fileXattrs {
+				if xattr_ == "" {
+					assert.Nil(t, xattrs)
+				} else {
+					assert.Contains(t, xattrs, "# file: "+file_+"\n"+tt.fileXattrs[file_]+"\n\n")
+				}
+			}
+		})
+	}
+}
+func Test_CopyXattrs(t *testing.T) {
+	t.Run("copy xattrs", func(t *testing.T) {
+		currentUser, err := user.Current()
+		if currentUser.Uid != "0" || err != nil {
+			t.Skip("Skipping test, security.capability xattr can only be set when running as root")
+		}
+		xattrs := map[string][]byte{"security.capability": []byte{0x0, 0x0, 0x0, 0x2, 0x0, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, "system.posix_acl_access": []byte{0x2, 0x0, 0x0, 0x0, 0x1, 0x0, 0x6, 0x0, 0xff, 0xff, 0xff, 0xff, 0x2, 0x0, 0x6, 0x0, 0xe9, 0x3, 0x0, 0x0, 0x4, 0x0, 0x4, 0x0, 0xff, 0xff, 0xff, 0xff, 0x10, 0x0, 0x6, 0x0, 0xff, 0xff, 0xff, 0xff, 0x20, 0x0, 0x4, 0x0, 0xff, 0xff, 0xff, 0xff}}
+		files := []string{"test1", "test2"}
+		dirs := []string{"/src", "/dest"}
+		env := testenv.New(t)
+		defer env.RemoveAll()
+		env.MkdirAll("/src")
+		for _, file := range files {
+			env.CreateFile(filepath.Join("/src", file))
+		}
+		env.MkdirAll("/dest")
+		for xattrName, value := range xattrs {
+			err := xattr.LSet(env.GetPath(filepath.Join(dirs[0], files[0])), xattrName, value)
+			assert.NoError(t, err)
+		}
+		err = xattr.LSet(env.GetPath(filepath.Join(dirs[0], files[1])), "system.posix_acl_access", xattrs["system.posix_acl_access"])
+		assert.NoError(t, err)
+
+		err = exec.Command("cp", "-r", env.GetPath(dirs[0])+"/.", env.GetPath(dirs[1])).Run()
+		assert.NoError(t, err)
+		for _, file := range files {
+			err := util.CopyXattrs(env.GetPath(filepath.Join(dirs[0], file)), env.GetPath(filepath.Join(dirs[1], file)))
+			assert.NoError(t, err)
+		}
+		for xattrName, value := range xattrs {
+			r, err := xattr.LGet(env.GetPath(filepath.Join(dirs[1], files[0])), xattrName)
+			assert.NoError(t, err)
+			assert.Equal(t, value, r)
+		}
+		r, err := xattr.LGet(env.GetPath(filepath.Join(dirs[1], files[1])), "system.posix_acl_access")
+		assert.NoError(t, err)
+		assert.Equal(t, r, xattrs["system.posix_acl_access"])
+	})
 }

--- a/internal/pkg/warewulfd/api/image_test.go
+++ b/internal/pkg/warewulfd/api/image_test.go
@@ -68,7 +68,7 @@ var imageTests = []struct {
 		request: func(serverURL string) (*http.Request, error) {
 			return http.NewRequest(http.MethodPost, serverURL+"/api/images/test-image/build?force=true&default=true", nil)
 		},
-		response: `{"kernels":[], "size":512, "buildtime":"<<PRESENCE>>", "writable":true}`,
+		response: `{"kernels":[], "size":1536, "buildtime":"<<PRESENCE>>", "writable":true}`,
 		resultFiles: []string{
 			"/srv/warewulf/images/test-image.img",
 			"/srv/warewulf/images/test-image.img.gz",
@@ -83,7 +83,7 @@ var imageTests = []struct {
 		request: func(serverURL string) (*http.Request, error) {
 			return http.NewRequest(http.MethodPatch, serverURL+"/api/images/test-image?build=true", bytes.NewBuffer([]byte(`{"name": "new-image"}`)))
 		},
-		response:     `{"kernels":[], "size":512, "buildtime":"<<PRESENCE>>", "writable":true}`,
+		response:     `{"kernels":[], "size":2560, "buildtime":"<<PRESENCE>>", "writable":true}`,
 		authenticate: true,
 	},
 	{
@@ -94,7 +94,7 @@ var imageTests = []struct {
 		request: func(serverURL string) (*http.Request, error) {
 			return http.NewRequest(http.MethodDelete, serverURL+"/api/images/new-image", nil)
 		},
-		response: `{"kernels":[], "size":512, "buildtime":"<<PRESENCE>>", "writable":true}`,
+		response: `{"kernels":[], "size":2560, "buildtime":"<<PRESENCE>>", "writable":true}`,
 		resultAbsentFiles: []string{
 			"/var/lib/warewulf/chroots/new-image",
 			"/srv/warewulf/images/new-image.img",

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -54,7 +54,7 @@ else
     fi
 
     info "warewulf: copying image to /newroot..."
-    tar -cf - --exclude ./proc --exclude ./sys --exclude ./dev --exclude --exclude ./newroot . | tar -xf - -C /newroot
+    tar -cf - --exclude ./proc --exclude ./sys --exclude ./dev --exclude --exclude ./newroot --xattrs . | tar -xf --xattrs - -C /newroot
 
     mkdir /newroot/proc /newroot/dev /newroot/sys 2>/dev/null
 

--- a/overlays/wwinit/rootfs/init
+++ b/overlays/wwinit/rootfs/init
@@ -55,7 +55,7 @@ else
     mountpoint -q /newroot || die "warewulf: ERROR: failed to mount ${WWROOT} at /newroot"
 
     info "warewulf: copying image to /newroot..."
-    tar -cf - --exclude ./proc --exclude ./sys --exclude ./dev --exclude ./newroot . | tar -xf - -C /newroot
+    tar -cf - --exclude ./proc --exclude ./sys --exclude ./dev --exclude ./newroot --xattrs . | tar -xf --xattrs - -C /newroot
 
     mkdir /newroot/proc /newroot/dev /newroot/sys 2>/dev/null
 

--- a/overlays/wwinit/rootfs/warewulf/init.d/80-xattrs
+++ b/overlays/wwinit/rootfs/warewulf/init.d/80-xattrs
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+. /warewulf/config
+
+if test -d /warewulf/xattrs; then
+    for i in /warewulf/xattrs/*; do
+        echo "Restoring xattrs for $i."
+        if setfattr -h --restore="$i" 2> /dev/null; then
+            echo "Restoring xattrs failed."
+        fi
+        rm -f "$i"
+    done
+else
+    echo "No saved xattrs dir found."
+    exit
+fi


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds a way to preserve file xattrs (acls, file capabilities, selinux labels) of files in images and overlays. It does this by searching the root of the image/overlay at creation time and recording the xattrs of all files in an unique to each image/overlay file staged in /warewulf/xattrs of the image/overlay. A new init.d script will read these files and apply the xattrs in them and delete them.  When the runtime overlays are updated by wwclient it will restore any xattrs present in the /warewulf/xattrs directory.

Need to implement the getfattr during image creation and setfattr in runtime updates to native golang implementations.


WIP obviously

## This fixes or addresses the following GitHub issues:

- Fixes #730 (potentially)


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
