### PR TITLE
Add IPMI speed tag to 50-ipmi template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Renamed debian.interfaces overlay to ifupdown
 - Change the DHCP server package used on openeuler 24.03 to dnsmasq
+- Added configurable Serial over LAN speed via IPMI `bit-rate` tag in `50-ipmi` template
 
 ### Fixed
 

--- a/overlays/wwinit/internal/nodes.conf
+++ b/overlays/wwinit/internal/nodes.conf
@@ -11,3 +11,5 @@ nodes:
       netmask: 255.255.255.0
       gateway: 192.168.4.1
       write: true
+      tags:
+        bit-rate: "115.2"

--- a/overlays/wwinit/internal/wwinit_test.go
+++ b/overlays/wwinit/internal/wwinit_test.go
@@ -17,6 +17,7 @@ func Test_wwinitOverlay(t *testing.T) {
 	env.ImportFile("etc/warewulf/nodes.conf", "nodes.conf")
 	env.ImportFile("var/lib/warewulf/overlays/wwinit/rootfs/etc/warewulf/warewulf.conf.ww", "../rootfs/etc/warewulf/warewulf.conf.ww")
 	env.ImportFile("var/lib/warewulf/overlays/wwinit/rootfs/warewulf/config.ww", "../rootfs/warewulf/config.ww")
+	env.ImportFile("var/lib/warewulf/overlays/wwinit/rootfs/warewulf/init.d/50-ipmi.ww", "../rootfs/warewulf/init.d/50-ipmi.ww")
 
 	tests := []struct {
 		name string
@@ -32,6 +33,11 @@ func Test_wwinitOverlay(t *testing.T) {
 			name: "wwinit:config.ww",
 			args: []string{"--render", "node1", "wwinit", "warewulf/config.ww"},
 			log:  wwinit_config,
+		},
+		{
+			name: "wwinit:50-ipmi.ww",
+			args: []string{"--render", "node1", "wwinit", "warewulf/init.d/50-ipmi.ww"},
+			log:  wwinit_50_ipmi,
 		},
 	}
 
@@ -94,4 +100,119 @@ WWIPMI_GATEWAY="192.168.4.1"
 WWIPMI_USER="user"
 WWIPMI_PASSWORD="password"
 WWIPMI_WRITE="true"
+`
+
+const wwinit_50_ipmi string = `backupFile: true
+writeFile: true
+Filename: warewulf/init.d/50-ipmi
+#!/bin/sh
+
+. /warewulf/config
+
+export PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+echo "Warewulf prescript: IPMI"
+echo
+
+if [ "$WWIPMI_WRITE" != "true" ]; then
+    echo "IPMI write not configured: skipping"
+    exit
+fi
+
+echo "Loading IPMI kernel modules..."
+modprobe ipmi_si ipmi_ssif ipmi_devintf ipmi_msghandler || (
+    echo "Unable to load IPMI kernel modules: skipping IPMI configuration"
+    exit
+)
+
+if [ ! -e /dev/ipmi0 ]; then
+    echo "/dev/ipmi0 does not exist; creating..."
+    sleep 1
+    ipmi_dev=$(grep ipmidev /proc/devices | awk '{ print $1 }')
+    mknod -m 0666 /dev/ipmi0 c "$ipmi_dev" 0
+fi
+
+command -v ipmitool >/dev/null 2>&1 || (
+    echo "ipmitool is not available: skipping IPMI configuration"
+    exit
+)
+
+lan_info="$(ipmitool lan print 1)"
+
+if [ -n "$WWIPMI_VLAN" ]; then
+    prev_vlan=$(echo "$lan_info" | grep "^802.1q VLAN ID *:" | awk -F': ' '{print $2 }')
+    if [ "$prev_vlan" == "$WWIPMI_VLAN" ] || [ "$prev_vlan" = "Disabled" -a "$WWIPMI_VLAN" = off ]; then
+        echo "IPMI VLAN: $WWIPMI_VLAN"
+    else
+        echo "IPMI VLAN: $prev_vlan -> $WWIPMI_VLAN"
+        ipmitool lan set 1 vlan id "$WWIPMI_VLAN"
+    fi
+fi
+
+if [ -n "$WWIPMI_IPADDR" ]; then
+    prev_ip=$(echo "$lan_info" | grep "^IP Address *:" | awk -F': ' '{ print $2 }')
+    if [ "$prev_ip" != "$WWIPMI_IPADDR" ]; then
+        echo "IPMI IP address: $prev_ip -> $WWIPMI_IPADDR"
+        ipmitool lan set 1 ipsrc static
+        ipmitool lan set 1 ipaddr "$WWIPMI_IPADDR"
+        ipmitool lan set 1 access on
+    else
+        echo "IPMI IP address: $WWIPMI_IPADDR"
+    fi
+fi
+
+if [ -n "$WWIPMI_NETMASK" ]; then
+    prev_netmask=$(echo "$lan_info" | grep "^Subnet Mask *:" | awk -F': ' '{ print $2 }')
+    if [ "$prev_netmask" != "$WWIPMI_NETMASK" ]; then
+        echo "IPMI netmask: $prev_netmask -> $WWIPMI_NETMASK"
+        ipmitool lan set 1 netmask $WWIPMI_NETMASK
+    else
+        echo "IPMI netmask: $WWIPMI_NETMASK"
+    fi
+fi
+
+if [ -n "$WWIPMI_GATEWAY" ]; then
+    prev_gateway=$(echo "$lan_info" | grep "^Default Gateway IP *:" | awk -F': ' '{ print $2 }')
+    if [ "$prev_gateway" != "$WWIPMI_GATEWAY" ]; then
+        echo "IPMI gateway: $prev_gateway -> $WWIPMI_GATEWAY"
+        ipmitool lan set 1 defgw ipaddr "$WWIPMI_GATEWAY"
+    else
+        echo "IPMI gateway: $WWIPMI_GATEWAY"
+    fi
+fi
+
+if [ -n "$WWIPMI_USER" ]; then
+    prev_user=$(ipmitool -c user list 1 | awk -F, '{ if ($1 == 2) { print $2; exit } }')
+    if [ "$prev_user" != "$WWIPMI_USER" ]; then
+        ipmitool user set name 2 "$WWIPMI_USER"
+        ipmitool user priv 2 4 1
+        ipmitool user enable 2
+        echo "IPMI username: $prev_user -> $WWIPMI_USER"
+    else
+        echo "IPMI username: $WWIPMI_USER"
+    fi
+fi
+
+if [ -n "$WWIPMI_PASSWORD" ]; then
+    ipmitool user test 2 20 "$WWIPMI_PASSWORD" >/dev/null || ipmitool user test 2 16 "$WWIPMI_PASSWORD" >/dev/null
+    if [ $? -ne 0 ]; then
+        ipmitool user set password 2 "$WWIPMI_PASSWORD"
+        ipmitool user priv 2 4 1
+        ipmitool user enable 2
+        echo "IPMI password: [updated]"
+    else
+        echo "IPMI password: [unchanged]"
+    fi
+fi
+
+echo "Configuring Serial over LAN..."
+ipmitool channel setaccess 1 2 link=on ipmi=on callin=on privilege=4
+ipmitool sol set force-encryption true 1
+ipmitool sol set force-authentication true 1
+ipmitool sol set privilege-level admin 1
+ipmitool sol payload enable 1 2
+ipmitool sol set enabled true 1 1
+speed=115.2
+ipmitool sol set non-volatile-bit-rate $speed 1
+ipmitool sol set volatile-bit-rate $speed 1
 `

--- a/overlays/wwinit/rootfs/warewulf/init.d/50-ipmi.ww
+++ b/overlays/wwinit/rootfs/warewulf/init.d/50-ipmi.ww
@@ -105,6 +105,6 @@ ipmitool sol set force-authentication true 1
 ipmitool sol set privilege-level admin 1
 ipmitool sol payload enable 1 2
 ipmitool sol set enabled true 1 1
-speed=38.4  # 19.2 38.4 115.2
+speed={{ default "38.4" (index .Ipmi.Tags "bit-rate") }}
 ipmitool sol set non-volatile-bit-rate $speed 1
 ipmitool sol set volatile-bit-rate $speed 1

--- a/userdocs/nodes/ipmi.rst
+++ b/userdocs/nodes/ipmi.rst
@@ -35,6 +35,14 @@ Additionally, a ``vlan`` ipmi tag can be used to set the IPMI VLAN ID.
    wwctl profile set default \
      --ipmitagadd vlan=42
 
+A ``bit-rate`` ipmi tag can be used to set the Serial over LAN bit rate (defaults to 38.4).
+Typical options are 19.2, 38.4, and 115.2.
+
+.. code-block::
+
+   wwctl profile set default \
+     --ipmitagadd bit-rate=115.2
+
 ``wwctl node list`` has a specific overview for IPMI settings.
 
 .. code-block:: console


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds support for a new speed IPMI tag that allows configuration of the Serial over LAN (SOL) bit rate for IPMI-enabled nodes. Some organizations have different requirements, sometimes on a per node basis, for setting the SOL speed. This does rename `50-ipmi` to `50-ipmi.ww`. 

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
