### PR TITLE
Fix ImageDelete API not returning error when checking if image is used by nodes/profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix "address already in use" in `wwclient` when `secure: true`. #2009
 - Use device names in netplan bonds. #2013
+- Fix ImageDelete API not returning error when checking if image is used by nodes/profiles
 
 ### Dependencies
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR fix discarded error within `ImageDelete`. The logic was splitted in 4 consecutive loops:
1. Image name validation
2. Check if the deleted images are not used by nodes
3. Check if the deleted images are not used by profiles
4. Delete images

## This fixes or addresses the following GitHub issues:

- Fixes #1705 


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
