### PR TITLE
Setup tftpboot directory for dnsmasq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## v4.6.5, unreleased
 
+### Added
+
+- Configure `/var/lib/warewulf/tftpboot` for use by dnsmasq in EL10 and OpenEuler packages. #1997
+
 ### Changed
 
 - Renamed debian.interfaces overlay to ifupdown

--- a/etc/warewulf.conf-el10
+++ b/etc/warewulf.conf-el10
@@ -1,0 +1,39 @@
+ipaddr: 10.0.0.1
+netmask: 255.255.252.0
+warewulf:
+  secure: false
+  update interval: 60
+  autobuild overlays: true
+  host overlay: true
+  systemd name: warewulfd
+dhcp:
+  enabled: true
+  range start: 10.0.1.1
+  range end: 10.0.1.255
+  systemd name: dnsmasq
+  template: default
+tftp:
+  enabled: true
+  systemd name: dnsmasq
+  ipxe:
+    00:09: ipxe-snponly-x86_64.efi
+    00:00: undionly.kpxe
+    00:0B: arm64-efi/snponly.efi
+    00:07: ipxe-snponly-x86_64.efi
+nfs:
+  enabled: true
+  export paths:
+  - path: /home
+    export options: rw,sync
+  - path: /opt
+    export options: ro,sync,no_root_squash
+  systemd name: nfs-server
+image mounts:
+  - source: /etc/resolv.conf
+    dest: /etc/resolv.conf
+    readonly: true
+ssh:
+  key types:
+    - ed25519
+    - ecdsa
+    - rsa

--- a/etc/warewulf.conf-suse
+++ b/etc/warewulf.conf-suse
@@ -1,0 +1,40 @@
+ipaddr: 10.0.0.1
+netmask: 255.255.252.0
+warewulf:
+  secure: false
+  update interval: 60
+  autobuild overlays: true
+  host overlay: true
+  systemd name: warewulfd
+dhcp:
+  enabled: true
+  range start: 10.0.1.1
+  range end: 10.0.1.255
+  systemd name: dhcpd
+  template: default
+tftp:
+  enabled: true
+  systemd name: tftp
+  ipxe:
+    00:00: undionly.kpxe
+    00:07: ipxe-x86_64.efi
+    00:09: ipxe-x86_64.efi
+    00:0B: snp-arm64.efi
+nfs:
+  enabled: true
+  export paths:
+  - path: /home
+    export options: rw,sync
+  - path: /opt
+    export options: ro,sync,no_root_squash
+  systemd name: nfs-server
+image mounts:
+  - source: /etc/resolv.conf
+    dest: /etc/resolv.conf
+    readonly: true
+ssh:
+  key types:
+    - ed25519
+    - ecdsa
+    - rsa
+    - dsa

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -1,11 +1,29 @@
 %global debug_package %{nil}
 
-%if 0%{?suse_version}
-%global tftpdir /srv/tftpboot
+# feature macros
+%if 0%{?rhel} >= 10 || 0%{?openEuler}
+%global use_dnsmasq 1
+%global use_warewulf_tftpdir 1
 %else
-# Assume Fedora-based OS if not SUSE-based
+%global use_dnsmasq 0
+%global use_warewulf_tftpdir 0
+%endif
+
+%if 0%{?suse_version} || 0%{?sle_version}
+%global is_suse 1
+%else
+%global is_suse 0
+%endif
+
+# Set tftpdir based on distribution
+%if 0%{?is_suse}
+%global tftpdir /srv/tftpboot
+%elif 0%{?use_warewulf_tftpdir}
+%global tftpdir /var/lib/warewulf/tftpboot
+%else
 %global tftpdir /var/lib/tftpboot
 %endif
+
 %global srvdir %{_sharedstatedir}
 
 %global wwgroup warewulf
@@ -35,14 +53,13 @@ Conflicts: warewulf-vnfs
 Conflicts: warewulf-provision
 Conflicts: warewulf-ipmi
 
-%if 0%{?suse_version} || 0%{?sle_version}
+%if 0%{?is_suse}
 BuildRequires: distribution-release
 BuildRequires: systemd-rpm-macros
 BuildRequires: go >= 1.22
 BuildRequires: firewall-macros
 BuildRequires: firewalld
 BuildRequires: tftp
-BuildRequires: yq
 Requires: tftp
 Requires: nfs-kernel-server
 Requires: firewalld
@@ -53,7 +70,7 @@ BuildRequires: system-release
 BuildRequires: systemd
 BuildRequires: golang >= 1.22
 BuildRequires: firewalld-filesystem
-%if ! (0%{?rhel} >= 10)
+%if ! 0%{?use_dnsmasq}
 Requires: tftp-server
 %endif
 Requires: nfs-utils
@@ -65,15 +82,13 @@ Requires: ipxe-bootimgs-aarch64
 %endif
 %endif
 
-%if 0%{?rhel} >= 10 || 0%{?openEuler}
+%if 0%{?use_dnsmasq}
 Requires: dnsmasq
-%else
-%if 0%{?rhel} >= 8 || 0%{?suse_version} || 0%{?fedora}
+%elif 0%{?rhel} >= 8 || 0%{?is_suse} || 0%{?fedora}
 Requires: dhcp-server
 %else
 # rhel < 8 and others
 Requires: dhcp
-%endif
 %endif
 
 BuildRequires: git
@@ -126,21 +141,13 @@ make install \
     DESTDIR=%{buildroot}
 
 %if 0%{?rhel} >= 10 || 0%{?openEuler}
-sed -i '
-  s/systemd name: dhcpd/systemd name: dnsmasq/
-  s/systemd name: tftp/systemd name: dnsmasq/
-  /- dsa/d' \
-  -i %{buildroot}%{_sysconfdir}/warewulf/warewulf.conf
+cp -f etc/warewulf.conf-el10 %{buildroot}%{_sysconfdir}/warewulf/warewulf.conf
+mkdir -p %{buildroot}%{_sharedstatedir}/warewulf/tftpboot
+%elif 0%{?is_suse}
+cp -f etc/warewulf.conf-suse %{buildroot}%{_sysconfdir}/warewulf/warewulf.conf
 %endif
 
-%if 0%{?suse_version} || 0%{?sle_version}
-yq e '
-  .tftp.ipxe."00:00" = "undionly.kpxe" |
-  .tftp.ipxe."00:07" = "ipxe-x86_64.efi" |
-  .tftp.ipxe."00:09" = "ipxe-x86_64.efi" |
-  .tftp.ipxe."00:0B" = "snp-arm64.efi" ' \
-  -i %{buildroot}%{_sysconfdir}/warewulf/warewulf.conf
-%else
+%if ! 0%{?is_suse}
 make install-sos \
     DESTDIR=%{buildroot}
 %endif
@@ -164,6 +171,21 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %firewalld_reload
 
 
+%if 0%{?use_warewulf_tftpdir}
+%triggerin -- selinux-policy-targeted
+semanage fcontext -a -t public_content_t "%{_sharedstatedir}/warewulf/tftpboot(/.*)?" 2>/dev/null || :
+restorecon -R -v %{_sharedstatedir}/warewulf/tftpboot 2>/dev/null || :
+
+%triggerun -- selinux-policy-targeted
+semanage fcontext -d -t public_content_t "%{_sharedstatedir}/warewulf/tftpboot(/.*)?" 2>/dev/null || :
+
+%triggerpostun -- selinux-policy-targeted
+if [ -d %{_sharedstatedir}/warewulf/tftpboot ]; then
+    restorecon -R -v %{_sharedstatedir}/warewulf/tftpboot 2>/dev/null || :
+fi
+%endif
+
+
 %files
 %defattr(-, root, root)
 
@@ -180,6 +202,9 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %dir %{_sharedstatedir}/warewulf
 %dir %{_sharedstatedir}/warewulf/chroots
 %dir %{_sharedstatedir}/warewulf/overlays
+%if 0%{?use_warewulf_tftpdir}
+%dir %attr(0755, root, root) %{_sharedstatedir}/warewulf/tftpboot
+%endif
 
 %dir %{_datadir}/warewulf
 %{_datadir}/warewulf/bmc
@@ -229,8 +254,7 @@ Summary: dracut module for loading a Warewulf image
 BuildArch: noarch
 
 Requires: dracut
-%if 0%{?suse_version}
-%else
+%if ! 0%{?is_suse}
 Requires: dracut-network
 %endif
 Requires: curl
@@ -249,8 +273,7 @@ initramfs that can fetch and boot a Warewulf node image from a Warewulf server.
 %{_prefix}/lib/dracut/modules.d/90wwinit
 
 
-%if 0%{?suse_version} || 0%{?sle_version}
-%else
+%if ! 0%{?is_suse}
 %package sos
 Summary: sos plugin for Warewulf
 BuildArch: noarch
@@ -270,6 +293,10 @@ about Warewulf in an sos report.
 
 
 %changelog
+* Tue Oct 28 2025 Jonathon Anderson <janderson@ciq.com>
+- Create /var/lib/warewulf/tftpboot for dnsmasq environments
+- Use static variants for warewulf.conf-suse and warewulf.conf-el10
+
 * Thu Sep 4 2025 Jonathon Anderson <janderson@ciq.com>
 - Update golang BuildRequires to 1.22
 - Exclude overlay files from brp-mangle-shebangs


### PR DESCRIPTION
## Description of the Pull Request (PR):

Setup /var/lib/warewulf/tftpboot for use by dnsmasq, inclusing selinux.

Also refactors warewulf.spec.in for clarity.

- Alternative to: #2044


## This fixes or addresses the following GitHub issues:

- Fixes #1997


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
