### PR TITLE
Remove libgpgme-devel from Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/tumbleweed:latest as builder
+FROM opensuse/tumbleweed:latest AS builder
 
 RUN zypper  -n install --no-recommends git go1.22 unzip &&\
   zypper -n install -t pattern devel_basis


### PR DESCRIPTION
## Description of the Pull Request (PR):

The package `libgpgme-devel` is no longer available in opensuse/tumbleweed:latest. Warewulf also builds without it -> remove it from the list of installed packages.

Also capitalize "as" to make silence the warning about it.

## This fixes or addresses the following GitHub issues:

- Fixes #2052 


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
