### PR TITLE
New architecture-specific wwclient overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## v4.6.5, unreleased
 
+### Added
+
+- `wwclient.aarch64` overlay always provides an aarch64 wwclient executable.
+- `wwclient.x86_64` overlay always provides an x86_64 wwclient executable.
+
 ### Changed
 
 - Renamed debian.interfaces overlay to ifupdown

--- a/overlays/debian.interfaces
+++ b/overlays/debian.interfaces
@@ -1,1 +1,0 @@
-ifupdown

--- a/userdocs/images/images.rst
+++ b/userdocs/images/images.rst
@@ -443,19 +443,11 @@ Then, ``wwctl image exec`` will work regardless of the architecture of the
 image. For more information about QEMU, see their `GitHub
 <https://github.com/multiarch/qemu-user-static>`_
 
-To use wwclient on a booted image using a different architecture, wwclient must
-be compiled for the specific architecture. This requires GOLang build tools 1.21
-or newer. Below is an example for building wwclient for arm64:
+.. note::
 
-.. code-block:: console
-
-   # git clone https://github.com/warewulf/warewulf
-   # cd warewulf
-   # GOARCH=arm64 PREFIX=/ make wwclient
-   # mkdir -p /var/lib/warewulf/overlays/wwclient_arm64/rootfs/warewulf
-   # cp wwclient /var/lib/warewulf/overlays/wwclient_arm64/rootfs/warewulf
-
-Then, apply the new "wwclient_arm64" system overlay to your arm64 node/profile
+   When provisioning cluster nodes with a different architecture than the
+   Warewulf server, also use the matching architecture-specific :ref:`wwclient`
+   overlay: e.g., wwclient.x86_64 or wwclient.aarch64.
 
 Read-only images
 ================

--- a/userdocs/overlays/overlays.rst
+++ b/userdocs/overlays/overlays.rst
@@ -202,6 +202,8 @@ provisioning actions:
 - **/warewulf/init.d/:** executed in the final root file system but before
   calling ``init``.
 
+.. _wwclient:
+
 wwclient
 --------
 
@@ -209,9 +211,14 @@ All configured overlays are provisioned initially along with the node image
 itself; but **wwclient** periodically fetches and applies the runtime overlay to
 allow configuration of some settings without a reboot.
 
-wwclient will contat the ``ipaddr`` value from ``warewulf.conf`` by default.
-This can be overridden by specifying a ``WW_IPADDR`` environment variable, which
-can be set via an overlay in ``/etc/default/wwclient``.
+wwclient contacts the ``ipaddr`` value from ``warewulf.conf`` by default. This
+can be overridden by specifying a ``WW_IPADDR`` environment variable, which can
+be set via an overlay in ``/etc/default/wwclient``.
+
+The default wwclient overlay contains a ``wwclient`` executable compiled for the
+same architecture as the Warewulf server. Architecture-specific wwclient.aarch64
+and wwclient.x86_64 overlays are available as well. This supports using wwclient
+on cluster nodes with a different architecture than the Warewulf server.
 
 Network interfaces
 ------------------

--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -210,6 +210,8 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %{_overlaydir}/udev.netname/rootfs/*
 %{_overlaydir}/wicked/rootfs/*
 %{_overlaydir}/wwclient/rootfs/*
+%{_overlaydir}/wwclient.x86_64/rootfs/*
+%{_overlaydir}/wwclient.aarch64/rootfs/*
 %{_overlaydir}/wwinit/rootfs/*
 %{_overlaydir}/localtime/rootfs/*
 %{_overlaydir}/sfdisk/rootfs/*


### PR DESCRIPTION
## Description of the Pull Request (PR):

- `wwclient.aarch64` overlay always provides an aarch64 wwclient executable.
- `wwclient.x86_64` overlay always provides an x86_64 wwclient executable.

The `wwclient` overlay remains, and contains a build that matches the Warewulf server, which is the current behavior.

I also stripped out debug symbols from the wwclient binary to reduce its size.

```
# wwctl overlay show wwclient.aarch64 /warewulf/wwclient | file -
/dev/stdin: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, BuildID[sha1]=f2cc610495ba6e1bc49928d2ef696eb34e5d6b62, stripped

# wwctl overlay show wwclient.x86_64 /warewulf/wwclient | file -
/dev/stdin: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, BuildID[sha1]=46c91db670bf86416458b9bd8fc58feeaeb2bbad, stripped

# wwctl overlay show wwclient /warewulf/wwclient | file -
/dev/stdin: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, BuildID[sha1]=f2cc610495ba6e1bc49928d2ef696eb34e5d6b62, stripped

# arch 
aarch64
```

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
