### PR TITLE
Skip wwinit module if not root=wwinit*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix "address already in use" in `wwclient` when `secure: true`. #2009
 - Use device names in netplan bonds. #2013
 - Fix ImageDelete API not returning error when checking if image is used by nodes/profiles
+- Fix warewulf-dracut to not run the wwinit module if root is not set to `root=wwclient*`
 
 ### Dependencies
 

--- a/dracut/modules.d/90wwinit/load-wwinit.sh
+++ b/dracut/modules.d/90wwinit/load-wwinit.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+[ -z "${wwinit_root_device}" ] && return 0
+
 get_stage() {
     stage="${1}"
     info "warewulf: loading stage: ${stage}"


### PR DESCRIPTION
## Description of the Pull Request (PR):

If warewulf-dracut is installed on a non-node and the module is enabled, the wwinit module will try to run even if root cmdline is not set to root=wwinit* (for example root=/dev/sda).  This PR skips the module if `$wwinit_root_device` is not set, which is set by `parse-wwinit.sh`

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
