### PR TITLE
Add support for node-specific local users and groups in syncuser overlay

### DIFF
--- a/.github/workflows/userdocs.yml
+++ b/.github/workflows/userdocs.yml
@@ -25,12 +25,13 @@ jobs:
         with:
           submodules: recursive
       - uses: actions/setup-python@v5
+        with:
+          cache: pip
 
       - name: prepare
         run: |
-          sudo apt update
-          sudo apt-get install -f -y texlive-latex-extra latexmk graphviz pandoc
-          pip install --user --upgrade --upgrade-strategy eager sphinx sphinx-rtd-theme restructuredtext_lint pygments sphinx_reredirects
+          sudo apt-get install -f -y graphviz pandoc
+          pip install --user sphinx sphinx-rtd-theme restructuredtext_lint pygments sphinx_reredirects
 
       - name: make generated docs
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Remove unused Netdev `Prefix` field. #2068
 - Remove unused `IPv6net` from host configuration. #2068
+- Renamed debian.interfaces overlay to ifupdown
+- Change the DHCP server package used on openeuler 24.03 to dnsmasq
+- Added configurable Serial over LAN speed via IPMI `bit-rate` tag in `50-ipmi` template
+- Manage SELinux context of TFTP directory. #1997
+- Dynamically write `$tftpdir/warewulf/grub.cfg` to the configured value from `warewulf.conf`
+- Absolute paths specified with `{{ file }}` in an overlay now write to that absolute path.
+- Use opencontainers/selinux to manage SELinux in wwclient.
+- `syncuser` overlay can now add local users and local groups to nodes by using resources.
 
 ### Fixed
 

--- a/overlays/syncuser/internal/nodes.conf
+++ b/overlays/syncuser/internal/nodes.conf
@@ -5,3 +5,38 @@ nodes:
     image name: rockylinux-9
     tags:
       PasswordlessRoot: true
+  node3:
+    image name: rockylinux-9
+    resources:
+      localusers:
+        - name: dbuser
+          uid: 1001
+          gid: 1002
+          gecos: "Database User"
+          home: /var/lib/db
+          shell: /bin/nologin
+        - name: appuser
+          uid: 1003
+          gid: 1004
+          gecos: "Application User"
+          home: /opt/app
+          shell: /bin/bash
+      localgroups:
+        - name: dbgroup
+          gid: 1002
+          members:
+            - dbuser
+            - appuser
+        - name: appgroup
+          gid: 1004
+          members:
+            - appuser
+  node4:
+    image name: rockylinux-9
+    resources:
+      localusers:
+        - name: svcuser
+          uid: 2001
+          gid: 2001
+          home: /
+          shell: /sbin/nologin

--- a/overlays/syncuser/internal/nodes.conf
+++ b/overlays/syncuser/internal/nodes.conf
@@ -1,3 +1,12 @@
+nodeprofiles:
+  svcprofile:
+    resources:
+      localusers:
+        - name: profileuser
+          uid: 3001
+          gid: 3001
+          home: /var/lib/profilesvc
+          shell: /sbin/nologin
 nodes:
   node1:
     image name: rockylinux-9
@@ -40,3 +49,16 @@ nodes:
           gid: 2001
           home: /
           shell: /sbin/nologin
+  node5:
+    image name: rockylinux-9
+    resources:
+      localusers:
+        - name: collideuser
+          uid: 1500
+          gid: 1000
+          home: /var/lib/collide
+          shell: /bin/bash
+  node6:
+    image name: rockylinux-9
+    profiles:
+      - svcprofile

--- a/overlays/syncuser/internal/syncuser_test.go
+++ b/overlays/syncuser/internal/syncuser_test.go
@@ -62,6 +62,50 @@ root:x:0:
 user:x:1000:
 `,
 		},
+		"syncuser:passwd.ww (with local users)": {
+			args: []string{"--render", "node3", "syncuser", "etc/passwd.ww"},
+			log: `backupFile: true
+writeFile: true
+Filename: etc/passwd
+root:x:0:0:root:/root:/bin/bash
+user:x:1000:1000:user:/home/user:/bin/bash
+dbuser:x:1001:1002:Database User:/var/lib/db:/bin/nologin
+appuser:x:1003:1004:Application User:/opt/app:/bin/bash
+`,
+		},
+		"syncuser:group.ww (with local groups)": {
+			args: []string{"--render", "node3", "syncuser", "etc/group.ww"},
+			log: `backupFile: true
+writeFile: true
+Filename: etc/group
+root:x:0:
+user:x:1000:
+dbuser:x:1002:
+appuser:x:1004:
+dbgroup:x:1002:dbuser,appuser
+appgroup:x:1004:appuser
+`,
+		},
+		"syncuser:passwd.ww (local user without gecos)": {
+			args: []string{"--render", "node4", "syncuser", "etc/passwd.ww"},
+			log: `backupFile: true
+writeFile: true
+Filename: etc/passwd
+root:x:0:0:root:/root:/bin/bash
+user:x:1000:1000:user:/home/user:/bin/bash
+svcuser:x:2001:2001::/:/sbin/nologin
+`,
+		},
+		"syncuser:group.ww (local user primary group)": {
+			args: []string{"--render", "node4", "syncuser", "etc/group.ww"},
+			log: `backupFile: true
+writeFile: true
+Filename: etc/group
+root:x:0:
+user:x:1000:
+svcuser:x:2001:
+`,
+		},
 	}
 
 	for name, tt := range tests {

--- a/overlays/syncuser/internal/syncuser_test.go
+++ b/overlays/syncuser/internal/syncuser_test.go
@@ -106,6 +106,36 @@ user:x:1000:
 svcuser:x:2001:
 `,
 		},
+		"syncuser:group.ww (local user gid collides with image group gid)": {
+			args: []string{"--render", "node5", "syncuser", "etc/group.ww"},
+			log: `backupFile: true
+writeFile: true
+Filename: etc/group
+root:x:0:
+user:x:1000:
+collideuser:x:1000:
+`,
+		},
+		"syncuser:passwd.ww (local users from profile)": {
+			args: []string{"--render", "node6", "syncuser", "etc/passwd.ww"},
+			log: `backupFile: true
+writeFile: true
+Filename: etc/passwd
+root:x:0:0:root:/root:/bin/bash
+user:x:1000:1000:user:/home/user:/bin/bash
+profileuser:x:3001:3001::/var/lib/profilesvc:/sbin/nologin
+`,
+		},
+		"syncuser:group.ww (local users from profile)": {
+			args: []string{"--render", "node6", "syncuser", "etc/group.ww"},
+			log: `backupFile: true
+writeFile: true
+Filename: etc/group
+root:x:0:
+user:x:1000:
+profileuser:x:3001:
+`,
+		},
 	}
 
 	for name, tt := range tests {

--- a/overlays/syncuser/rootfs/etc/group.ww
+++ b/overlays/syncuser/rootfs/etc/group.ww
@@ -1,6 +1,23 @@
-{{
-    printf "%s\n%s"
-        (IncludeFrom $.ImageName "/etc/group" | trim)
-        (Include (printf "%s/%s" .Paths.Sysconfdir "group") | trim)
-    | UniqueField ":" 0 | trim
-}}
+{{- $sources := list }}
+{{- $sources = append $sources (IncludeFrom $.ImageName "/etc/group" | trim) }}
+{{- $sources = append $sources (Include (printf "%s/%s" .Paths.Sysconfdir "group") | trim) }}
+
+{{- if .Resources.localusers }}
+{{- range .Resources.localusers }}
+  {{- if .gid }}
+    {{- $sources = append $sources (printf "%s:x:%d:" .name .gid) }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- if .Resources.localgroups }}
+{{- range .Resources.localgroups }}
+  {{- $memberStr := "" }}
+  {{- if .members }}
+    {{- $memberStr = join "," .members }}
+  {{- end }}
+  {{- $sources = append $sources (printf "%s:x:%d:%s" .name .gid $memberStr) }}
+{{- end }}
+{{- end }}
+
+{{- join "\n" $sources | UniqueField ":" 0 | trim }}

--- a/overlays/syncuser/rootfs/etc/group.ww
+++ b/overlays/syncuser/rootfs/etc/group.ww
@@ -4,7 +4,7 @@
 
 {{- if .Resources.localusers }}
 {{- range .Resources.localusers }}
-  {{- if .gid }}
+  {{- if hasKey . "gid" }}
     {{- $sources = append $sources (printf "%s:x:%d:" .name .gid) }}
   {{- end }}
 {{- end }}

--- a/overlays/syncuser/rootfs/etc/passwd.ww
+++ b/overlays/syncuser/rootfs/etc/passwd.ww
@@ -1,7 +1,13 @@
-{{- $sources := list }}
-{{- if and .Tags.PasswordlessRoot (eq (lower .Tags.PasswordlessRoot) "true") }}
-{{- $sources = append $sources "root::0:0:root:/root:/bin/bash" }}
-{{- end }}
-{{- $sources = append $sources (IncludeFrom $.ImageName "/etc/passwd" | trim) }}
-{{- $sources = append $sources (Include (printf "%s/%s" .Paths.Sysconfdir "passwd") | trim) }}
+{{- $sources := list }}  
+{{- if and .Tags.PasswordlessRoot (eq (lower .Tags.PasswordlessRoot) "true") }}  
+{{- $sources = append $sources "root::0:0:root:/root:/bin/bash" }}  
+{{- end }}  
+{{- $sources = append $sources (IncludeFrom $.ImageName "/etc/passwd" | trim) }}  
+{{- $sources = append $sources (Include (printf "%s/%s" .Paths.Sysconfdir "passwd") | trim) }}  
+{{- if .Resources.localusers }}  
+{{- range .Resources.localusers }}  
+{{- $gecos := .gecos | default "" }}  
+{{- $sources = append $sources (printf "%s:x:%d:%d:%s:%s:%s" .name .uid .gid $gecos .home .shell) }}  
+{{- end }}  
+{{- end }}  
 {{- join "\n" $sources | UniqueField ":" 0 | trim }}

--- a/overlays/syncuser/rootfs/etc/passwd.ww
+++ b/overlays/syncuser/rootfs/etc/passwd.ww
@@ -1,13 +1,13 @@
-{{- $sources := list }}  
-{{- if and .Tags.PasswordlessRoot (eq (lower .Tags.PasswordlessRoot) "true") }}  
-{{- $sources = append $sources "root::0:0:root:/root:/bin/bash" }}  
-{{- end }}  
-{{- $sources = append $sources (IncludeFrom $.ImageName "/etc/passwd" | trim) }}  
-{{- $sources = append $sources (Include (printf "%s/%s" .Paths.Sysconfdir "passwd") | trim) }}  
-{{- if .Resources.localusers }}  
-{{- range .Resources.localusers }}  
-{{- $gecos := .gecos | default "" }}  
-{{- $sources = append $sources (printf "%s:x:%d:%d:%s:%s:%s" .name .uid .gid $gecos .home .shell) }}  
-{{- end }}  
-{{- end }}  
+{{- $sources := list }}
+{{- if and .Tags.PasswordlessRoot (eq (lower .Tags.PasswordlessRoot) "true") }}
+{{- $sources = append $sources "root::0:0:root:/root:/bin/bash" }}
+{{- end }}
+{{- $sources = append $sources (IncludeFrom $.ImageName "/etc/passwd" | trim) }}
+{{- $sources = append $sources (Include (printf "%s/%s" .Paths.Sysconfdir "passwd") | trim) }}
+{{- if .Resources.localusers }}
+{{- range .Resources.localusers }}
+{{- $gecos := .gecos | default "" }}
+{{- $sources = append $sources (printf "%s:x:%d:%d:%s:%s:%s" .name .uid .gid $gecos .home .shell) }}
+{{- end }}
+{{- end }}
 {{- join "\n" $sources | UniqueField ":" 0 | trim }}

--- a/userdocs/images/syncuser.rst
+++ b/userdocs/images/syncuser.rst
@@ -57,3 +57,44 @@ For the overlay to work correctly, the image should also have been prepared with
 the syncuser command (see above) so that UID/GID values are consistent.
 
 See :ref:`Syncuser` in the overlays documentation for more detail.
+
+Node-specific local users and groups
+-------------------------------------
+
+Warewulf supports defining **node-specific local users and groups** through
+the :ref:`resources <nodes-resources>` section of node definitions. These user and
+group entries are merged into the syncuser overlay and included in ``/etc/passwd`` and
+``/etc/group`` on the target nodes at provisioning time.
+
+This is useful for applications that require a node-local account (e.g.,
+database, application, or storage service users) without having to maintain
+centralized identity management.
+
+.. note::
+
+   Users created through this method do not have passwords set. They are intended for service accounts and non-interactive use.
+
+Example:
+
+.. code-block:: yaml
+
+   nodes:
+     n1:
+       resources:
+         localgroups:
+           - gid: 1002
+             members:
+               - dbuser
+               - dbuserbackup
+             name: dbgroup
+         localusers:
+           - gid: 1001
+             home: /
+             name: dbuser
+             shell: /bin/nologin
+             uid: 1001
+           - gid: 1005
+             home: /
+             name: dbuserbackup
+             shell: /bin/nologin
+             uid: 1005

--- a/userdocs/nodes/nodes.rst
+++ b/userdocs/nodes/nodes.rst
@@ -210,6 +210,8 @@ node directly, to network interfaces, and even to IPMI interfaces.
    wwctl node set n1 --tagadd="localtime=UTC"
    wwctl node set n1 --nettagadd="DNS1=1.1.1.1"
 
+.. _nodes-resources:
+
 Resources
 =========
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR adds support for defining **node-specific local users and groups** through the `resources` section of node configurations. These local accounts are automatically merged into the `syncuser` overlay and included in `/etc/passwd` and `/etc/group` on target nodes.

### Key Features:
- **Local Users**: Define user accounts with uid, gid, description, home directory, and shell per node
- **Local Groups**: Define groups with gid and member lists per node  
- **Automatic Integration**: Users and groups are automatically added via the syncuser overlay templates
- **No Passwords**: Local users are created without passwords, intended for service accounts and non-interactive use

### Use Cases:
This is useful for applications that require node-local accounts (e.g., database users, application service accounts, or storage service users) without needing centralized identity management like LDAP.

### Changes:
- Updated `syncuser` overlay templates (`passwd.ww` and `group.ww`) to support `Resources.localusers` and `Resources.localgroups`
- Added comprehensive test coverage for local user/group functionality
- Updated documentation in `userdocs/images/syncuser.rst` with examples and usage notes
- Fixed template to properly handle optional `gecos` field

### Example Configuration:

```yaml
nodes:
  n1:
    resources:
      localusers:
        - name: dbuser
          uid: 1001
          gid: 1002
          gecos: "Database User"
          home: /var/lib/db
          shell: /bin/nologin
      localgroups:
        - name: dbgroup
          gid: 1002
          members:
            - dbuser
```            

## This fixes or addresses the following GitHub issues:

- Fixes #

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
