### PR TITLE
Add systemd.networkd overlay to RPM

### DIFF
--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -207,6 +207,7 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %{_overlaydir}/ssh.host_keys/rootfs/*
 %{_overlaydir}/syncuser/rootfs/*
 %{_overlaydir}/systemd.netname/rootfs/*
+%{_overlaydir}/systemd.networkd/rootfs/*
 %{_overlaydir}/udev.netname/rootfs/*
 %{_overlaydir}/wicked/rootfs/*
 %{_overlaydir}/wwclient/rootfs/*


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix to build rpm for IPv6 patch.  Add systemd-networkd overlay to rpm.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
