### PR TITLE
add wwctl node|profile unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Expand troubleshooting documentation for container runtimes
 - Ignore local coding agent files
 - Add dracut_static ipxe method
+- Added `wwctl <node|profile> unset` #1954
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Refactored `wwctl <node|profile> set` to use cobra `cmd.Flags().Changed()` to
   apply only explicitly-set fields.
-- `wwctl <node|profile> set --partdel` and `wwctl <node|profile> unset --part`
+- `wwctl <node|profile> set --partdel` and `wwctl <node|profile> unset --partname`
   now scope partition deletion to a specific disk when `--diskname` is provided;
   without `--diskname`, the partition is removed from all disks (previous behavior).
 - `wwctl <node|profile> set` now calls `Flatten()` after each modification,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Refactored `wwctl <node|profile> set` to use cobra `cmd.Flags().Changed()` to
   apply only explicitly-set fields.
+- `wwctl <node|profile> set --partdel` and `wwctl <node|profile> unset --part`
+  now scope partition deletion to a specific disk when `--diskname` is provided;
+  without `--diskname`, the partition is removed from all disks (previous behavior).
+- `wwctl <node|profile> set` now calls `Flatten()` after each modification,
+  removing empty pointer-to-struct stubs (e.g. `ipmi: {}`) from the configuration.
 - Deprecated `wwctl node set --force` (never had any effect; will be removed in
   a future release)
 - Runtime overlay download failure during dracut/wwinit boot is now non-fatal;

--- a/internal/app/wwctl/flags/flags.go
+++ b/internal/app/wwctl/flags/flags.go
@@ -1,8 +1,36 @@
 package flags
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/spf13/cobra"
 )
+
+// ValidateUnsetScope checks that sub-entity unset flags have the required
+// scoping flags. Disk field flags require --diskname; partition field flags
+// require both --diskname and --partname; filesystem field flags require --fsname.
+func ValidateUnsetScope(unsetFields map[string]*bool, diskName, partName, fsName string) error {
+	for flagName, boolPtr := range unsetFields {
+		if boolPtr == nil || !*boolPtr {
+			continue
+		}
+		if strings.HasPrefix(flagName, "part") {
+			if diskName == "" || partName == "" {
+				return fmt.Errorf("--diskname and --partname must be specified with --%s", flagName)
+			}
+		} else if strings.HasPrefix(flagName, "disk") {
+			if diskName == "" {
+				return fmt.Errorf("--diskname must be specified with --%s", flagName)
+			}
+		} else if strings.HasPrefix(flagName, "fs") {
+			if fsName == "" {
+				return fmt.Errorf("--fsname must be specified with --%s", flagName)
+			}
+		}
+	}
+	return nil
+}
 
 func AddContainer(cmd *cobra.Command, dest *string) {
 	cmd.Flags().StringVarP(dest, "container", "C", "", "Set image name (backwards-compatibility)")

--- a/internal/app/wwctl/flags/flags.go
+++ b/internal/app/wwctl/flags/flags.go
@@ -1,37 +1,8 @@
 package flags
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
-
-// ValidateUnsetScope checks that sub-entity unset flags have the required
-// scoping flags, using the scope map produced by node.CreateUnsetFlags.
-// Scope values: "disk" requires --diskname; "disk,part" requires both
-// --diskname and --partname; "fs" requires --fsname.
-func ValidateUnsetScope(unsetFields map[string]*bool, scopeMap map[string]string, diskName, partName, fsName string) error {
-	for flagName, boolPtr := range unsetFields {
-		if boolPtr == nil || !*boolPtr {
-			continue
-		}
-		switch scopeMap[flagName] {
-		case "disk,part":
-			if diskName == "" || partName == "" {
-				return fmt.Errorf("--diskname and --partname must be specified with --%s", flagName)
-			}
-		case "disk":
-			if diskName == "" {
-				return fmt.Errorf("--diskname must be specified with --%s", flagName)
-			}
-		case "fs":
-			if fsName == "" {
-				return fmt.Errorf("--fsname must be specified with --%s", flagName)
-			}
-		}
-	}
-	return nil
-}
 
 func AddContainer(cmd *cobra.Command, dest *string) {
 	cmd.Flags().StringVarP(dest, "container", "C", "", "Set image name (backwards-compatibility)")

--- a/internal/app/wwctl/flags/flags.go
+++ b/internal/app/wwctl/flags/flags.go
@@ -2,28 +2,29 @@ package flags
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 // ValidateUnsetScope checks that sub-entity unset flags have the required
-// scoping flags. Disk field flags require --diskname; partition field flags
-// require both --diskname and --partname; filesystem field flags require --fsname.
-func ValidateUnsetScope(unsetFields map[string]*bool, diskName, partName, fsName string) error {
+// scoping flags, using the scope map produced by node.CreateUnsetFlags.
+// Scope values: "disk" requires --diskname; "disk,part" requires both
+// --diskname and --partname; "fs" requires --fsname.
+func ValidateUnsetScope(unsetFields map[string]*bool, scopeMap map[string]string, diskName, partName, fsName string) error {
 	for flagName, boolPtr := range unsetFields {
 		if boolPtr == nil || !*boolPtr {
 			continue
 		}
-		if strings.HasPrefix(flagName, "part") {
+		switch scopeMap[flagName] {
+		case "disk,part":
 			if diskName == "" || partName == "" {
 				return fmt.Errorf("--diskname and --partname must be specified with --%s", flagName)
 			}
-		} else if strings.HasPrefix(flagName, "disk") {
+		case "disk":
 			if diskName == "" {
 				return fmt.Errorf("--diskname must be specified with --%s", flagName)
 			}
-		} else if strings.HasPrefix(flagName, "fs") {
+		case "fs":
 			if fsName == "" {
 				return fmt.Errorf("--fsname must be specified with --%s", flagName)
 			}

--- a/internal/app/wwctl/node/root.go
+++ b/internal/app/wwctl/node/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/warewulf/warewulf/internal/app/wwctl/node/sensors"
 	"github.com/warewulf/warewulf/internal/app/wwctl/node/set"
 	nodestatus "github.com/warewulf/warewulf/internal/app/wwctl/node/status"
+	"github.com/warewulf/warewulf/internal/app/wwctl/node/unset"
 )
 
 var (
@@ -31,6 +32,7 @@ func init() {
 	baseCmd.AddCommand(sensors.GetCommand())
 	baseCmd.AddCommand(list.GetCommand())
 	baseCmd.AddCommand(set.GetCommand())
+	baseCmd.AddCommand(unset.GetCommand())
 	baseCmd.AddCommand(add.GetCommand())
 	baseCmd.AddCommand(delete.GetCommand())
 	baseCmd.AddCommand(console.GetCommand())

--- a/internal/app/wwctl/node/set/main.go
+++ b/internal/app/wwctl/node/set/main.go
@@ -93,13 +93,16 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 					wwlog.Verbose("Node: %s, on disk %s, deleting partition: %s", nId, vars.nodeAdd.DiskName, vars.nodeDel.PartDel)
 					delete(disk.Partitions, vars.nodeDel.PartDel)
 				} else {
+					found := false
 					for diskname, disk := range nodePtr.Disks {
 						if _, ok := disk.Partitions[vars.nodeDel.PartDel]; ok {
 							wwlog.Verbose("Node: %s, on disk %s, deleting partition: %s", nId, diskname, vars.nodeDel.PartDel)
 							delete(disk.Partitions, vars.nodeDel.PartDel)
-						} else {
-							return fmt.Errorf("partition doesn't exist: %s", vars.nodeDel.PartDel)
+							found = true
 						}
+					}
+					if !found {
+						return fmt.Errorf("partition doesn't exist: %s", vars.nodeDel.PartDel)
 					}
 				}
 			}

--- a/internal/app/wwctl/node/set/main.go
+++ b/internal/app/wwctl/node/set/main.go
@@ -41,7 +41,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 			dsk := *vars.nodeConf.Disks["UNDEF"]
 			vars.nodeConf.Disks[vars.nodeAdd.DiskName] = &dsk
 		}
-		if (vars.nodeAdd.DiskName != "") != (vars.nodeAdd.PartName != "") {
+		if vars.nodeAdd.PartName != "" && vars.nodeAdd.DiskName == "" {
 			return fmt.Errorf("partition and disk must be specified")
 		}
 		delete(vars.nodeConf.Disks, "UNDEF")
@@ -82,12 +82,24 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 				delete(nodePtr.NetDevs, vars.nodeDel.NetDel)
 			}
 			if vars.nodeDel.PartDel != "" {
-				for diskname, disk := range nodePtr.Disks {
-					if _, ok := disk.Partitions[vars.nodeDel.PartDel]; ok {
-						wwlog.Verbose("Node: %s, on disk %s, deleting partition: %s", nId, diskname, vars.nodeDel.PartDel)
-						delete(disk.Partitions, vars.nodeDel.PartDel)
-					} else {
+				if vars.nodeAdd.DiskName != "" {
+					disk, ok := nodePtr.Disks[vars.nodeAdd.DiskName]
+					if !ok || disk == nil {
+						return fmt.Errorf("disk doesn't exist: %s", vars.nodeAdd.DiskName)
+					}
+					if _, ok := disk.Partitions[vars.nodeDel.PartDel]; !ok {
 						return fmt.Errorf("partition doesn't exist: %s", vars.nodeDel.PartDel)
+					}
+					wwlog.Verbose("Node: %s, on disk %s, deleting partition: %s", nId, vars.nodeAdd.DiskName, vars.nodeDel.PartDel)
+					delete(disk.Partitions, vars.nodeDel.PartDel)
+				} else {
+					for diskname, disk := range nodePtr.Disks {
+						if _, ok := disk.Partitions[vars.nodeDel.PartDel]; ok {
+							wwlog.Verbose("Node: %s, on disk %s, deleting partition: %s", nId, diskname, vars.nodeDel.PartDel)
+							delete(disk.Partitions, vars.nodeDel.PartDel)
+						} else {
+							return fmt.Errorf("partition doesn't exist: %s", vars.nodeDel.PartDel)
+						}
 					}
 				}
 			}
@@ -136,6 +148,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 					netDev.Tags[key] = val
 				}
 			}
+			nodePtr.Flatten()
 			count++
 		}
 

--- a/internal/app/wwctl/node/set/main_test.go
+++ b/internal/app/wwctl/node/set/main_test.go
@@ -459,6 +459,73 @@ nodes:
         format: btrfs
         path: /var`,
 		},
+		"single node delete partition scoped to diskname": {
+			args:    []string{"--partdel=var", "--diskname=/dev/vda", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    comment: testit
+nodes:
+  n01:
+    profiles:
+    - default
+    disks:
+      /dev/vda:
+        partitions:
+          var:
+            number: "1"
+      /dev/vdb:
+        partitions:
+          var:
+            number: "1"`,
+			outDB: `
+nodeprofiles:
+  default:
+    comment: testit
+nodes:
+  n01:
+    profiles:
+    - default
+    disks:
+      /dev/vda: {}
+      /dev/vdb:
+        partitions:
+          var:
+            number: "1"`,
+		},
+		"single node delete partition unscoped removes from all disks": {
+			args:    []string{"--partdel=var", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    comment: testit
+nodes:
+  n01:
+    profiles:
+    - default
+    disks:
+      /dev/vda:
+        partitions:
+          var:
+            number: "1"
+      /dev/vdb:
+        partitions:
+          var:
+            number: "1"`,
+			outDB: `
+nodeprofiles:
+  default:
+    comment: testit
+nodes:
+  n01:
+    profiles:
+    - default
+    disks:
+      /dev/vda: {}
+      /dev/vdb: {}`,
+		},
 		"single node delete existing disk": {
 			args:    []string{"--diskdel=/dev/vda", "n01"},
 			wantErr: false,

--- a/internal/app/wwctl/node/set/main_test.go
+++ b/internal/app/wwctl/node/set/main_test.go
@@ -526,6 +526,58 @@ nodes:
       /dev/vda: {}
       /dev/vdb: {}`,
 		},
+		"single node delete partition unscoped skips disks without it": {
+			args:    []string{"--partdel=var", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    comment: testit
+nodes:
+  n01:
+    profiles:
+    - default
+    disks:
+      /dev/vda:
+        partitions:
+          var:
+            number: "1"
+      /dev/vdb:
+        partitions:
+          boot:
+            number: "2"`,
+			outDB: `
+nodeprofiles:
+  default:
+    comment: testit
+nodes:
+  n01:
+    profiles:
+    - default
+    disks:
+      /dev/vda: {}
+      /dev/vdb:
+        partitions:
+          boot:
+            number: "2"`,
+		},
+		"single node delete partition unscoped errors when not found": {
+			args:    []string{"--partdel=nonexistent", "n01"},
+			wantErr: true,
+			inDB: `
+nodeprofiles:
+  default:
+    comment: testit
+nodes:
+  n01:
+    profiles:
+    - default
+    disks:
+      /dev/vda:
+        partitions:
+          var:
+            number: "1"`,
+		},
 		"single node delete existing disk": {
 			args:    []string{"--diskdel=/dev/vda", "n01"},
 			wantErr: false,

--- a/internal/app/wwctl/node/unset/main.go
+++ b/internal/app/wwctl/node/unset/main.go
@@ -115,15 +115,27 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
 			}
 			for _, name := range vars.partDel {
 				if vars.diskname != "" {
-					if disk, ok := nodePtr.Disks[vars.diskname]; ok && disk != nil {
-						delete(disk.Partitions, name)
+					disk, ok := nodePtr.Disks[vars.diskname]
+					if !ok || disk == nil {
+						return fmt.Errorf("disk doesn't exist: %s", vars.diskname)
 					}
+					if _, ok := disk.Partitions[name]; !ok {
+						return fmt.Errorf("partition doesn't exist: %s", name)
+					}
+					delete(disk.Partitions, name)
 				} else {
+					found := false
 					for _, disk := range nodePtr.Disks {
 						if disk == nil {
 							continue
 						}
-						delete(disk.Partitions, name)
+						if _, ok := disk.Partitions[name]; ok {
+							delete(disk.Partitions, name)
+							found = true
+						}
+					}
+					if !found {
+						return fmt.Errorf("partition doesn't exist: %s", name)
 					}
 				}
 			}

--- a/internal/app/wwctl/node/unset/main.go
+++ b/internal/app/wwctl/node/unset/main.go
@@ -37,7 +37,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
 		args = hostlist.Expand(args)
 
 		// Validate scoping: sub-entity fields require their parent scope flags
-		if err := wwctlflags.ValidateUnsetScope(vars.unsetFields, vars.diskname, vars.partname, vars.fsname); err != nil {
+		if err := wwctlflags.ValidateUnsetScope(vars.unsetFields, vars.unsetScopes, vars.diskname, vars.partname, vars.fsname); err != nil {
 			return err
 		}
 

--- a/internal/app/wwctl/node/unset/main.go
+++ b/internal/app/wwctl/node/unset/main.go
@@ -1,0 +1,169 @@
+package unset
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	wwctlflags "github.com/warewulf/warewulf/internal/app/wwctl/flags"
+	"github.com/warewulf/warewulf/internal/pkg/hostlist"
+	"github.com/warewulf/warewulf/internal/pkg/node"
+	"github.com/warewulf/warewulf/internal/pkg/util"
+	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
+	"github.com/warewulf/warewulf/internal/pkg/wwlog"
+)
+
+func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		// Check if any fields were specified
+		anyFieldSet := false
+		for _, boolPtr := range vars.unsetFields {
+			if *boolPtr {
+				anyFieldSet = true
+				break
+			}
+		}
+		anyFieldSet = anyFieldSet || len(vars.tags) > 0 || len(vars.ipmiTags) > 0 || len(vars.netTags) > 0 ||
+			len(vars.netDel) > 0 || len(vars.diskDel) > 0 || len(vars.partDel) > 0 || len(vars.fsDel) > 0
+		if !anyFieldSet {
+			return fmt.Errorf("no fields specified to unset")
+		}
+
+		nodeDB, err := node.New()
+		if err != nil {
+			return fmt.Errorf("failed to load node database: %w", err)
+		}
+
+		// Expand hostlist patterns
+		args = hostlist.Expand(args)
+
+		// Validate scoping: sub-entity fields require their parent scope flags
+		if err := wwctlflags.ValidateUnsetScope(vars.unsetFields, vars.diskname, vars.partname, vars.fsname); err != nil {
+			return err
+		}
+
+		// Confirmation prompt
+		if !vars.unsetYes {
+			count := 0
+			for _, nodeName := range args {
+				if _, ok := nodeDB.Nodes[nodeName]; ok {
+					count++
+				}
+			}
+			if count == 0 {
+				return fmt.Errorf("no valid nodes found")
+			}
+			yes := util.Confirm(fmt.Sprintf("Are you sure you want to modify %d node(s)", count))
+			if !yes {
+				return nil
+			}
+		}
+
+		// Modify nodes directly
+		modifiedCount := 0
+		for _, nodeName := range args {
+			nodePtr, ok := nodeDB.Nodes[nodeName]
+			if !ok {
+				wwlog.Warn("invalid node: %s", nodeName)
+				if !vars.unsetForce {
+					return fmt.Errorf("node not found: %s", nodeName)
+				}
+				continue
+			}
+
+			// Build scope node: zero-value with map entries for the keys to target
+			scopeNode := node.NewNode("")
+			scopeNode.NetDevs[vars.netname] = &node.NetDev{}
+			if vars.diskname != "" {
+				disk := &node.Disk{}
+				if vars.partname != "" {
+					disk.Partitions = map[string]*node.Partition{vars.partname: {}}
+				}
+				scopeNode.Disks = map[string]*node.Disk{vars.diskname: disk}
+			}
+			if vars.fsname != "" {
+				scopeNode.FileSystems = map[string]*node.FileSystem{vars.fsname: {}}
+			}
+			changed := func(lopt string) bool {
+				boolPtr, ok := vars.unsetFields[lopt]
+				return ok && boolPtr != nil && *boolPtr
+			}
+			nodePtr.UpdateFrom(&scopeNode, changed)
+
+			// Delete specified tags
+			for _, key := range vars.tags {
+				delete(nodePtr.Tags, key)
+			}
+			if nodePtr.Ipmi != nil {
+				for _, key := range vars.ipmiTags {
+					delete(nodePtr.Ipmi.Tags, key)
+				}
+			}
+			if len(vars.netTags) > 0 {
+				if netDev, ok := nodePtr.NetDevs[vars.netname]; ok && netDev != nil {
+					for _, key := range vars.netTags {
+						delete(netDev.Tags, key)
+					}
+				}
+			}
+
+			// Delete entire objects by name
+			for _, name := range vars.netDel {
+				delete(nodePtr.NetDevs, name)
+			}
+			for _, name := range vars.diskDel {
+				delete(nodePtr.Disks, name)
+			}
+			for _, name := range vars.partDel {
+				for _, disk := range nodePtr.Disks {
+					if disk == nil {
+						continue
+					}
+					delete(disk.Partitions, name)
+				}
+			}
+			for _, name := range vars.fsDel {
+				delete(nodePtr.FileSystems, name)
+			}
+
+			// Clean up empty structs
+			nodePtr.Flatten()
+
+			// Remove any empty map entries left after flattening
+			for netName, netDev := range nodePtr.NetDevs {
+				if node.ObjectIsEmpty(netDev) {
+					delete(nodePtr.NetDevs, netName)
+				}
+			}
+			for diskName, disk := range nodePtr.Disks {
+				if node.ObjectIsEmpty(disk) {
+					delete(nodePtr.Disks, diskName)
+				}
+			}
+			for fsName, fs := range nodePtr.FileSystems {
+				if node.ObjectIsEmpty(fs) {
+					delete(nodePtr.FileSystems, fsName)
+				}
+			}
+
+			modifiedCount++
+		}
+
+		if modifiedCount == 0 {
+			return fmt.Errorf("no nodes were modified")
+		}
+
+		// Save changes
+		if err := nodeDB.Persist(); err != nil {
+			return fmt.Errorf("failed to persist changes: %w", err)
+		}
+
+		// Reload daemon
+		if err := warewulfd.DaemonReload(); err != nil {
+			wwlog.Warn("failed to reload daemon: %v", err)
+			// Don't fail - changes were saved
+		}
+
+		wwlog.Info("Successfully unset fields on %d node(s)", modifiedCount)
+		return nil
+	}
+}

--- a/internal/app/wwctl/node/unset/main.go
+++ b/internal/app/wwctl/node/unset/main.go
@@ -114,11 +114,17 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
 				delete(nodePtr.Disks, name)
 			}
 			for _, name := range vars.partDel {
-				for _, disk := range nodePtr.Disks {
-					if disk == nil {
-						continue
+				if vars.diskname != "" {
+					if disk, ok := nodePtr.Disks[vars.diskname]; ok && disk != nil {
+						delete(disk.Partitions, name)
 					}
-					delete(disk.Partitions, name)
+				} else {
+					for _, disk := range nodePtr.Disks {
+						if disk == nil {
+							continue
+						}
+						delete(disk.Partitions, name)
+					}
 				}
 			}
 			for _, name := range vars.fsDel {

--- a/internal/app/wwctl/node/unset/main.go
+++ b/internal/app/wwctl/node/unset/main.go
@@ -15,6 +15,7 @@ import (
 func CobraRunE(vars *wwctlunset.Vars) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		// Check if any fields were specified
+		vars.NetnameChanged = cmd.Flags().Changed("netname")
 		anyFieldSet := false
 		for _, boolPtr := range vars.UnsetFields {
 			if *boolPtr {
@@ -23,7 +24,8 @@ func CobraRunE(vars *wwctlunset.Vars) func(cmd *cobra.Command, args []string) er
 			}
 		}
 		anyFieldSet = anyFieldSet || len(vars.Tags) > 0 || len(vars.IpmiTags) > 0 || len(vars.NetTags) > 0 ||
-			len(vars.NetDel) > 0 || len(vars.DiskDel) > 0 || len(vars.PartDel) > 0 || len(vars.FsDel) > 0
+			vars.NetnameChanged || cmd.Flags().Changed("diskname") ||
+			cmd.Flags().Changed("fsname") || cmd.Flags().Changed("partname")
 		if !anyFieldSet {
 			return fmt.Errorf("no fields specified to unset")
 		}
@@ -52,6 +54,7 @@ func CobraRunE(vars *wwctlunset.Vars) func(cmd *cobra.Command, args []string) er
 			if count == 0 {
 				return fmt.Errorf("no valid nodes found")
 			}
+			wwctlunset.WarnDeletions(vars)
 			yes := util.Confirm(fmt.Sprintf("Are you sure you want to modify %d node(s)", count))
 			if !yes {
 				return nil

--- a/internal/app/wwctl/node/unset/main.go
+++ b/internal/app/wwctl/node/unset/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	wwctlflags "github.com/warewulf/warewulf/internal/app/wwctl/flags"
+	wwctlunset "github.com/warewulf/warewulf/internal/app/wwctl/unset"
 	"github.com/warewulf/warewulf/internal/pkg/hostlist"
 	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/util"
@@ -12,18 +12,18 @@ import (
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
-func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
+func CobraRunE(vars *wwctlunset.Vars) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		// Check if any fields were specified
 		anyFieldSet := false
-		for _, boolPtr := range vars.unsetFields {
+		for _, boolPtr := range vars.UnsetFields {
 			if *boolPtr {
 				anyFieldSet = true
 				break
 			}
 		}
-		anyFieldSet = anyFieldSet || len(vars.tags) > 0 || len(vars.ipmiTags) > 0 || len(vars.netTags) > 0 ||
-			len(vars.netDel) > 0 || len(vars.diskDel) > 0 || len(vars.partDel) > 0 || len(vars.fsDel) > 0
+		anyFieldSet = anyFieldSet || len(vars.Tags) > 0 || len(vars.IpmiTags) > 0 || len(vars.NetTags) > 0 ||
+			len(vars.NetDel) > 0 || len(vars.DiskDel) > 0 || len(vars.PartDel) > 0 || len(vars.FsDel) > 0
 		if !anyFieldSet {
 			return fmt.Errorf("no fields specified to unset")
 		}
@@ -37,12 +37,12 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
 		args = hostlist.Expand(args)
 
 		// Validate scoping: sub-entity fields require their parent scope flags
-		if err := wwctlflags.ValidateUnsetScope(vars.unsetFields, vars.unsetScopes, vars.diskname, vars.partname, vars.fsname); err != nil {
+		if err := wwctlunset.ValidateScopeRequirements(vars); err != nil {
 			return err
 		}
 
 		// Confirmation prompt
-		if !vars.unsetYes {
+		if !vars.UnsetYes {
 			count := 0
 			for _, nodeName := range args {
 				if _, ok := nodeDB.Nodes[nodeName]; ok {
@@ -58,111 +58,20 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		// Modify nodes directly
 		modifiedCount := 0
 		for _, nodeName := range args {
 			nodePtr, ok := nodeDB.Nodes[nodeName]
 			if !ok {
 				wwlog.Warn("invalid node: %s", nodeName)
-				if !vars.unsetForce {
+				if !vars.UnsetForce {
 					return fmt.Errorf("node not found: %s", nodeName)
 				}
 				continue
 			}
 
-			// Build scope node: zero-value with map entries for the keys to target
-			scopeNode := node.NewNode("")
-			scopeNode.NetDevs[vars.netname] = &node.NetDev{}
-			if vars.diskname != "" {
-				disk := &node.Disk{}
-				if vars.partname != "" {
-					disk.Partitions = map[string]*node.Partition{vars.partname: {}}
-				}
-				scopeNode.Disks = map[string]*node.Disk{vars.diskname: disk}
+			if err := wwctlunset.UpdateEntity(nodePtr, vars); err != nil {
+				return err
 			}
-			if vars.fsname != "" {
-				scopeNode.FileSystems = map[string]*node.FileSystem{vars.fsname: {}}
-			}
-			changed := func(lopt string) bool {
-				boolPtr, ok := vars.unsetFields[lopt]
-				return ok && boolPtr != nil && *boolPtr
-			}
-			nodePtr.UpdateFrom(&scopeNode, changed)
-
-			// Delete specified tags
-			for _, key := range vars.tags {
-				delete(nodePtr.Tags, key)
-			}
-			if nodePtr.Ipmi != nil {
-				for _, key := range vars.ipmiTags {
-					delete(nodePtr.Ipmi.Tags, key)
-				}
-			}
-			if len(vars.netTags) > 0 {
-				if netDev, ok := nodePtr.NetDevs[vars.netname]; ok && netDev != nil {
-					for _, key := range vars.netTags {
-						delete(netDev.Tags, key)
-					}
-				}
-			}
-
-			// Delete entire objects by name
-			for _, name := range vars.netDel {
-				delete(nodePtr.NetDevs, name)
-			}
-			for _, name := range vars.diskDel {
-				delete(nodePtr.Disks, name)
-			}
-			for _, name := range vars.partDel {
-				if vars.diskname != "" {
-					disk, ok := nodePtr.Disks[vars.diskname]
-					if !ok || disk == nil {
-						return fmt.Errorf("disk doesn't exist: %s", vars.diskname)
-					}
-					if _, ok := disk.Partitions[name]; !ok {
-						return fmt.Errorf("partition doesn't exist: %s", name)
-					}
-					delete(disk.Partitions, name)
-				} else {
-					found := false
-					for _, disk := range nodePtr.Disks {
-						if disk == nil {
-							continue
-						}
-						if _, ok := disk.Partitions[name]; ok {
-							delete(disk.Partitions, name)
-							found = true
-						}
-					}
-					if !found {
-						return fmt.Errorf("partition doesn't exist: %s", name)
-					}
-				}
-			}
-			for _, name := range vars.fsDel {
-				delete(nodePtr.FileSystems, name)
-			}
-
-			// Clean up empty structs
-			nodePtr.Flatten()
-
-			// Remove any empty map entries left after flattening
-			for netName, netDev := range nodePtr.NetDevs {
-				if node.ObjectIsEmpty(netDev) {
-					delete(nodePtr.NetDevs, netName)
-				}
-			}
-			for diskName, disk := range nodePtr.Disks {
-				if node.ObjectIsEmpty(disk) {
-					delete(nodePtr.Disks, diskName)
-				}
-			}
-			for fsName, fs := range nodePtr.FileSystems {
-				if node.ObjectIsEmpty(fs) {
-					delete(nodePtr.FileSystems, fsName)
-				}
-			}
-
 			modifiedCount++
 		}
 
@@ -170,15 +79,12 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("no nodes were modified")
 		}
 
-		// Save changes
 		if err := nodeDB.Persist(); err != nil {
 			return fmt.Errorf("failed to persist changes: %w", err)
 		}
 
-		// Reload daemon
 		if err := warewulfd.DaemonReload(); err != nil {
 			wwlog.Warn("failed to reload daemon: %v", err)
-			// Don't fail - changes were saved
 		}
 
 		wwlog.Info("Successfully unset fields on %d node(s)", modifiedCount)

--- a/internal/app/wwctl/node/unset/main_test.go
+++ b/internal/app/wwctl/node/unset/main_test.go
@@ -190,6 +190,24 @@ nodes:
       default:
         ipaddr: 192.168.1.100`,
 		},
+		"unset net field targeting nonexistent network leaves db unchanged": {
+			args:    []string{"--ipaddr", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      eth0:
+        ipaddr: 10.0.0.100`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      eth0:
+        ipaddr: 10.0.0.100`,
+		},
 		"unset hwaddr": {
 			args:    []string{"--hwaddr", "n01"},
 			wantErr: false,
@@ -1166,9 +1184,86 @@ nodeprofiles: {}
 nodes:
   n01: {}`,
 		},
-		"unset part nonexistent is noop": {
-			args:    []string{"--part=nopart", "n01"},
+		"unset part unscoped skips disks that lack the partition": {
+			args:    []string{"--part=swap", "n01"},
 			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+      /dev/vdb:
+        partitions:
+          root:
+            number: "2"
+            size_mib: "51200"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vdb:
+        partitions:
+          root:
+            number: "2"
+            size_mib: "51200"`,
+		},
+		"error: unset part unscoped not found on any disk": {
+			args:    []string{"--part=nopart", "n01"},
+			wantErr: true,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"`,
+		},
+		"error: unset part scoped to nonexistent disk": {
+			args:    []string{"--part=swap", "--diskname=/dev/nonexistent", "n01"},
+			wantErr: true,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"`,
+		},
+		"error: unset part scoped partition not in disk": {
+			args:    []string{"--part=nopart", "--diskname=/dev/vda", "n01"},
+			wantErr: true,
 			inDB: `
 nodeprofiles: {}
 nodes:

--- a/internal/app/wwctl/node/unset/main_test.go
+++ b/internal/app/wwctl/node/unset/main_test.go
@@ -1,0 +1,1363 @@
+package unset
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/testenv"
+	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
+)
+
+func Test_Node_Unset(t *testing.T) {
+	tests := map[string]struct {
+		args    []string
+		wantErr bool
+		inDB    string
+		outDB   string
+	}{
+		// Basic field unsetting
+		"unset comment": {
+			args:    []string{"--comment", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    comment: test comment`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset cluster": {
+			args:    []string{"--cluster", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    cluster name: mycluster`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset image": {
+			args:    []string{"--image", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    image name: rockylinux-9`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+
+		// IP field unsetting - THE MAIN USE CASE!
+		"unset netmask (the problem this solves!)": {
+			args:    []string{"--netmask", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        netmask: 255.255.255.0`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset ipaddr": {
+			args:    []string{"--ipaddr", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset gateway": {
+			args:    []string{"--gateway", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        gateway: 192.168.1.1`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset ipaddr6": {
+			args:    []string{"--ipaddr6", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr6: 2001:db8::1`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset gateway6": {
+			args:    []string{"--gateway6", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        gateway6: 2001:db8::ffff`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+
+		// Multiple IP fields at once
+		"unset netmask and ipaddr together": {
+			args:    []string{"--netmask", "--ipaddr", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+        netmask: 255.255.255.0`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset all IPv4 network fields": {
+			args:    []string{"--ipaddr", "--netmask", "--gateway", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+        netmask: 255.255.255.0
+        gateway: 192.168.1.1`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+
+		// Network device specific unsetting
+		"unset ipaddr on specific network": {
+			args:    []string{"--netname", "eth0", "--ipaddr", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+      eth0:
+        ipaddr: 10.0.0.100`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100`,
+		},
+		"unset hwaddr": {
+			args:    []string{"--hwaddr", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        hwaddr: "aa:bb:cc:dd:ee:ff"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset netdev": {
+			args:    []string{"--netdev", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        device: eth0`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset mtu": {
+			args:    []string{"--mtu", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        mtu: "9000"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset type": {
+			args:    []string{"--type", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        type: ethernet`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+
+		// IPMI field unsetting
+		"unset ipmiaddr": {
+			args:    []string{"--ipmiaddr", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    ipmi:
+      ipaddr: 192.168.2.100`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset ipminetmask": {
+			args:    []string{"--ipminetmask", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    ipmi:
+      netmask: 255.255.255.0`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset ipmigateway": {
+			args:    []string{"--ipmigateway", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    ipmi:
+      gateway: 192.168.2.1`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset all IPMI IP fields": {
+			args:    []string{"--ipmiaddr", "--ipminetmask", "--ipmigateway", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    ipmi:
+      ipaddr: 192.168.2.100
+      netmask: 255.255.255.0
+      gateway: 192.168.2.1`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset ipmiuser": {
+			args:    []string{"--ipmiuser", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    ipmi:
+      username: admin`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset ipmipass": {
+			args:    []string{"--ipmipass", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    ipmi:
+      password: secret`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset ipmiport": {
+			args:    []string{"--ipmiport", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    ipmi:
+      port: "623"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset ipmiinterface": {
+			args:    []string{"--ipmiinterface", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    ipmi:
+      interface: lanplus`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+
+		// Kernel fields
+		"unset kernelversion": {
+			args:    []string{"--kernelversion", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    kernel:
+      version: 5.14.0`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset kernelargs": {
+			args:    []string{"--kernelargs", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    kernel:
+      args:
+      - quiet
+      - splash`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+
+		// Overlay fields
+		"unset runtime-overlays": {
+			args:    []string{"--runtime-overlays", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    runtime overlay:
+    - runtime1
+    - runtime2`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset system-overlays": {
+			args:    []string{"--system-overlays", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    system overlay:
+    - system1
+    - system2`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+
+		// Other fields
+		"unset init": {
+			args:    []string{"--init", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    init: /sbin/init`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset root": {
+			args:    []string{"--root", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    root: /dev/sda1`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset ipxe": {
+			args:    []string{"--ipxe", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    ipxe template: custom.ipxe`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset primarynet": {
+			args:    []string{"--primarynet", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    primary network: eth0`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset profile": {
+			args:    []string{"--profile", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    comment: default profile
+nodes:
+  n01:
+    profiles:
+    - default`,
+			outDB: `
+nodeprofiles:
+  default:
+    comment: default profile
+nodes:
+  n01: {}`,
+		},
+		"unset asset": {
+			args:    []string{"--asset", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    asset key: ASSET12345`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+
+		// Multiple fields from different categories
+		"unset comment, image, and ipaddr": {
+			args:    []string{"--comment", "--image", "--ipaddr", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    comment: test
+    image name: rocky-9
+    network devices:
+      default:
+        ipaddr: 192.168.1.100`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset mixed fields": {
+			args:    []string{"--comment", "--ipmiaddr", "--kernelversion", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    comment: test node
+    ipmi:
+      ipaddr: 10.0.0.100
+    kernel:
+      version: 5.14.0`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+
+		// Multiple nodes
+		"unset on multiple nodes": {
+			args:    []string{"--comment", "n0[1-2]"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    comment: node 1
+  n02:
+    comment: node 2`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}
+  n02: {}`,
+		},
+		"unset netmask on multiple nodes": {
+			args:    []string{"--netmask", "n0[1-3]"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        netmask: 255.255.255.0
+  n02:
+    network devices:
+      default:
+        netmask: 255.255.255.0
+  n03:
+    network devices:
+      default:
+        netmask: 255.255.255.0`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}
+  n02: {}
+  n03: {}`,
+		},
+
+		// Partial unsetting (other fields remain)
+		"unset comment but keep other fields": {
+			args:    []string{"--comment", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    comment: test comment
+    image name: rocky-9
+    cluster name: mycluster`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    image name: rocky-9
+    cluster name: mycluster`,
+		},
+		"unset netmask but keep ipaddr": {
+			args:    []string{"--netmask", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+        netmask: 255.255.255.0
+        gateway: 192.168.1.1`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+        gateway: 192.168.1.1`,
+		},
+		"unset ipaddr on one network, keep other network": {
+			args:    []string{"--netname", "eth0", "--ipaddr", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+      eth0:
+        ipaddr: 10.0.0.100
+      eth1:
+        ipaddr: 172.16.0.100`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+      eth1:
+        ipaddr: 172.16.0.100`,
+		},
+
+		// Unsetting already unset fields (should be no-op)
+		"unset already unset field": {
+			args:    []string{"--comment", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset non-existent field with other fields present": {
+			args:    []string{"--comment", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    image name: rocky-9`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    image name: rocky-9`,
+		},
+
+		// Error cases
+		"error: no fields specified": {
+			args:    []string{"n01"},
+			wantErr: true,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    comment: test`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    comment: test`,
+		},
+		"error: non-existent node": {
+			args:    []string{"--comment", "nonexistent"},
+			wantErr: true,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    comment: test`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    comment: test`,
+		},
+
+		// Profile inheritance tests
+		"unset field from node keeps profile value visible": {
+			args:    []string{"--comment", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    comment: profile comment
+nodes:
+  n01:
+    profiles:
+    - default
+    comment: node comment`,
+			outDB: `
+nodeprofiles:
+  default:
+    comment: profile comment
+nodes:
+  n01:
+    profiles:
+    - default`,
+		},
+
+		// Short flag variations
+		"unset with short flags": {
+			args:    []string{"-M", "-I", "-G", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+        netmask: 255.255.255.0
+        gateway: 192.168.1.1`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"unset profile with short flag": {
+			args:    []string{"-P", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default: {}
+nodes:
+  n01:
+    profiles:
+    - default`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes:
+  n01: {}`,
+		},
+
+		// Tag deletion tests
+		"delete node tag": {
+			args:    []string{"--tag=mytag", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    tags:
+      mytag: myvalue
+      keeptag: keepvalue`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    tags:
+      keeptag: keepvalue`,
+		},
+		"delete multiple node tags": {
+			args:    []string{"--tag=tag1,tag2", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    tags:
+      tag1: val1
+      tag2: val2
+      tag3: val3`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    tags:
+      tag3: val3`,
+		},
+		"delete all node tags leaves empty node": {
+			args:    []string{"--tag=only", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    tags:
+      only: value`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
+		"delete nonexistent tag is noop": {
+			args:    []string{"--tag=nonexistent", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    tags:
+      keep: value`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    tags:
+      keep: value`,
+		},
+		"delete tag from node with no tags": {
+			args:    []string{"--tag=anytag", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    comment: hello`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    comment: hello`,
+		},
+		"delete ipmi tag": {
+			args:    []string{"--ipmitag=bmctag", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    ipmi:
+      username: admin
+      tags:
+        bmctag: bmcvalue`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    ipmi:
+      username: admin`,
+		},
+		"delete ipmi tag when no ipmi section": {
+			args:    []string{"--ipmitag=anytag", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    comment: hello`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    comment: hello`,
+		},
+		"delete net tag on default network": {
+			args:    []string{"--nettag=dns1", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+        tags:
+          dns1: 8.8.8.8
+          dns2: 8.8.4.4`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+        tags:
+          dns2: 8.8.4.4`,
+		},
+		"delete net tag on specific network": {
+			args:    []string{"--netname", "eth1", "--nettag=mytag", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        tags:
+          mytag: defaultval
+      eth1:
+        ipaddr: 10.0.0.1
+        tags:
+          mytag: eth1val`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        tags:
+          mytag: defaultval
+      eth1:
+        ipaddr: 10.0.0.1`,
+		},
+		"delete net tag on nonexistent network is noop": {
+			args:    []string{"--netname", "nonet", "--nettag=anytag", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.1`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.1`,
+		},
+		"combine tag deletion with field unset": {
+			args:    []string{"--comment", "--tag=mytag", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    comment: hello
+    tags:
+      mytag: val
+      keep: val2`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    tags:
+      keep: val2`,
+		},
+
+		// Object deletion tests
+		"unset net removes entire netdev": {
+			args:    []string{"--net=eth0", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+      eth0:
+        ipaddr: 10.0.0.100`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100`,
+		},
+		"unset net removes only named netdev": {
+			args:    []string{"--net=eth0,eth1", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+      eth0:
+        ipaddr: 10.0.0.1
+      eth1:
+        ipaddr: 10.0.0.2`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100`,
+		},
+		"unset net nonexistent is noop": {
+			args:    []string{"--net=nonet", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100`,
+		},
+		"unset disk removes entire disk": {
+			args:    []string{"--disk=/dev/vda", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+      /dev/vdb:
+        partitions:
+          data:
+            number: "1"
+            size_mib: "102400"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vdb:
+        partitions:
+          data:
+            number: "1"
+            size_mib: "102400"`,
+		},
+		"unset disk nonexistent is noop": {
+			args:    []string{"--disk=/dev/vdz", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"`,
+		},
+		"unset part removes partition from disk": {
+			args:    []string{"--part=swap", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+          root:
+            number: "2"
+            size_mib: "51200"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          root:
+            number: "2"
+            size_mib: "51200"`,
+		},
+		"unset part nonexistent is noop": {
+			args:    []string{"--part=nopart", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"`,
+		},
+		"unset fs removes entire filesystem": {
+			args:    []string{"--fs=/dev/disk/by-partlabel/swap", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    filesystems:
+      /dev/disk/by-partlabel/swap:
+        format: swap
+      /dev/disk/by-partlabel/root:
+        format: ext4`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    filesystems:
+      /dev/disk/by-partlabel/root:
+        format: ext4`,
+		},
+		"unset fs nonexistent is noop": {
+			args:    []string{"--fs=/dev/nofs", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    filesystems:
+      /dev/disk/by-partlabel/root:
+        format: ext4`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    filesystems:
+      /dev/disk/by-partlabel/root:
+        format: ext4`,
+		},
+
+		// Scoped unset: disk/partition/filesystem
+		"scoped partnumber clears only targeted partition": {
+			args:    []string{"--partnumber", "--diskname=/dev/vda", "--partname=root", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          root:
+            number: "1"
+            size_mib: "1024"
+          swap:
+            number: "2"
+            size_mib: "512"
+      /dev/vdb:
+        partitions:
+          data:
+            number: "1"
+            size_mib: "2048"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          root:
+            size_mib: "1024"
+          swap:
+            number: "2"
+            size_mib: "512"
+      /dev/vdb:
+        partitions:
+          data:
+            number: "1"
+            size_mib: "2048"`,
+		},
+		"scoped diskwipe clears only targeted disk": {
+			args:    []string{"--diskwipe", "--diskname=/dev/vda", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        wipe_table: true
+        partitions:
+          root:
+            number: "1"
+      /dev/vdb:
+        wipe_table: true
+        partitions:
+          data:
+            number: "1"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          root:
+            number: "1"
+      /dev/vdb:
+        wipe_table: true
+        partitions:
+          data:
+            number: "1"`,
+		},
+		"scoped fsformat clears only targeted filesystem": {
+			args:    []string{"--fsformat", "--fsname=/dev/disk/by-partlabel/root", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    filesystems:
+      /dev/disk/by-partlabel/root:
+        format: ext4
+        path: /
+      /dev/disk/by-partlabel/var:
+        format: btrfs
+        path: /var`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    filesystems:
+      /dev/disk/by-partlabel/root:
+        path: /
+      /dev/disk/by-partlabel/var:
+        format: btrfs
+        path: /var`,
+		},
+		"error: partnumber without diskname/partname": {
+			args:    []string{"--partnumber", "n01"},
+			wantErr: true,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          root:
+            number: "1"
+            size_mib: "1024"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          root:
+            number: "1"
+            size_mib: "1024"`,
+		},
+		"error: diskwipe without diskname": {
+			args:    []string{"--diskwipe", "n01"},
+			wantErr: true,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        wipe_table: true`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        wipe_table: true`,
+		},
+		"error: fsformat without fsname": {
+			args:    []string{"--fsformat", "n01"},
+			wantErr: true,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    filesystems:
+      /dev/disk/by-partlabel/root:
+        format: ext4`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    filesystems:
+      /dev/disk/by-partlabel/root:
+        format: ext4`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			env := testenv.New(t)
+			defer env.RemoveAll()
+			env.WriteFile("etc/warewulf/nodes.conf", tt.inDB)
+			warewulfd.SetNoDaemon()
+
+			baseCmd := GetCommand()
+			args := append(tt.args, "--yes")
+			baseCmd.SetArgs(args)
+			buf := new(bytes.Buffer)
+			baseCmd.SetOut(buf)
+			baseCmd.SetErr(buf)
+			err := baseCmd.Execute()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			content := env.ReadFile("etc/warewulf/nodes.conf")
+			assert.YAMLEq(t, tt.outDB, content)
+		})
+	}
+}

--- a/internal/app/wwctl/node/unset/main_test.go
+++ b/internal/app/wwctl/node/unset/main_test.go
@@ -993,7 +993,7 @@ nodes:
 
 		// Object deletion tests
 		"unset net removes entire netdev": {
-			args:    []string{"--net=eth0", "n01"},
+			args:    []string{"--netname=eth0", "n01"},
 			wantErr: false,
 			inDB: `
 nodeprofiles: {}
@@ -1013,7 +1013,7 @@ nodes:
         ipaddr: 192.168.1.100`,
 		},
 		"unset net removes only named netdev": {
-			args:    []string{"--net=eth0,eth1", "n01"},
+			args:    []string{"--netname=eth0", "n01"},
 			wantErr: false,
 			inDB: `
 nodeprofiles: {}
@@ -1032,10 +1032,12 @@ nodes:
   n01:
     network devices:
       default:
-        ipaddr: 192.168.1.100`,
+        ipaddr: 192.168.1.100
+      eth1:
+        ipaddr: 10.0.0.2`,
 		},
 		"unset net nonexistent is noop": {
-			args:    []string{"--net=nonet", "n01"},
+			args:    []string{"--netname=nonet", "n01"},
 			wantErr: false,
 			inDB: `
 nodeprofiles: {}
@@ -1053,7 +1055,7 @@ nodes:
         ipaddr: 192.168.1.100`,
 		},
 		"unset disk removes entire disk": {
-			args:    []string{"--disk=/dev/vda", "n01"},
+			args:    []string{"--diskname=/dev/vda", "n01"},
 			wantErr: false,
 			inDB: `
 nodeprofiles: {}
@@ -1082,7 +1084,7 @@ nodes:
             size_mib: "102400"`,
 		},
 		"unset disk nonexistent is noop": {
-			args:    []string{"--disk=/dev/vdz", "n01"},
+			args:    []string{"--diskname=/dev/vdz", "n01"},
 			wantErr: false,
 			inDB: `
 nodeprofiles: {}
@@ -1106,7 +1108,7 @@ nodes:
             size_mib: "4096"`,
 		},
 		"unset part removes partition from disk": {
-			args:    []string{"--part=swap", "n01"},
+			args:    []string{"--partname=swap", "n01"},
 			wantErr: false,
 			inDB: `
 nodeprofiles: {}
@@ -1133,7 +1135,7 @@ nodes:
             size_mib: "51200"`,
 		},
 		"unset part scoped to diskname removes partition only from that disk": {
-			args:    []string{"--part=swap", "--diskname=/dev/vda", "n01"},
+			args:    []string{"--partname=swap", "--diskname=/dev/vda", "n01"},
 			wantErr: false,
 			inDB: `
 nodeprofiles: {}
@@ -1162,7 +1164,7 @@ nodes:
             size_mib: "4096"`,
 		},
 		"unset part unscoped removes partition from all disks": {
-			args:    []string{"--part=swap", "n01"},
+			args:    []string{"--partname=swap", "n01"},
 			wantErr: false,
 			inDB: `
 nodeprofiles: {}
@@ -1185,7 +1187,7 @@ nodes:
   n01: {}`,
 		},
 		"unset part unscoped skips disks that lack the partition": {
-			args:    []string{"--part=swap", "n01"},
+			args:    []string{"--partname=swap", "n01"},
 			wantErr: false,
 			inDB: `
 nodeprofiles: {}
@@ -1214,7 +1216,7 @@ nodes:
             size_mib: "51200"`,
 		},
 		"error: unset part unscoped not found on any disk": {
-			args:    []string{"--part=nopart", "n01"},
+			args:    []string{"--partname=nopart", "n01"},
 			wantErr: true,
 			inDB: `
 nodeprofiles: {}
@@ -1238,7 +1240,7 @@ nodes:
             size_mib: "4096"`,
 		},
 		"error: unset part scoped to nonexistent disk": {
-			args:    []string{"--part=swap", "--diskname=/dev/nonexistent", "n01"},
+			args:    []string{"--partname=swap", "--diskname=/dev/nonexistent", "n01"},
 			wantErr: true,
 			inDB: `
 nodeprofiles: {}
@@ -1262,7 +1264,7 @@ nodes:
             size_mib: "4096"`,
 		},
 		"error: unset part scoped partition not in disk": {
-			args:    []string{"--part=nopart", "--diskname=/dev/vda", "n01"},
+			args:    []string{"--partname=nopart", "--diskname=/dev/vda", "n01"},
 			wantErr: true,
 			inDB: `
 nodeprofiles: {}
@@ -1286,7 +1288,7 @@ nodes:
             size_mib: "4096"`,
 		},
 		"unset fs removes entire filesystem": {
-			args:    []string{"--fs=/dev/disk/by-partlabel/swap", "n01"},
+			args:    []string{"--fsname=/dev/disk/by-partlabel/swap", "n01"},
 			wantErr: false,
 			inDB: `
 nodeprofiles: {}
@@ -1306,7 +1308,7 @@ nodes:
         format: ext4`,
 		},
 		"unset fs nonexistent is noop": {
-			args:    []string{"--fs=/dev/nofs", "n01"},
+			args:    []string{"--fsname=/dev/nofs", "n01"},
 			wantErr: false,
 			inDB: `
 nodeprofiles: {}

--- a/internal/app/wwctl/node/unset/main_test.go
+++ b/internal/app/wwctl/node/unset/main_test.go
@@ -1114,6 +1114,58 @@ nodes:
             number: "2"
             size_mib: "51200"`,
 		},
+		"unset part scoped to diskname removes partition only from that disk": {
+			args:    []string{"--part=swap", "--diskname=/dev/vda", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+      /dev/vdb:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vdb:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"`,
+		},
+		"unset part unscoped removes partition from all disks": {
+			args:    []string{"--part=swap", "n01"},
+			wantErr: false,
+			inDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+      /dev/vdb:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01: {}`,
+		},
 		"unset part nonexistent is noop": {
 			args:    []string{"--part=nopart", "n01"},
 			wantErr: false,

--- a/internal/app/wwctl/node/unset/root.go
+++ b/internal/app/wwctl/node/unset/root.go
@@ -3,30 +3,13 @@ package unset
 import (
 	"github.com/spf13/cobra"
 	"github.com/warewulf/warewulf/internal/app/wwctl/completions"
+	wwctlunset "github.com/warewulf/warewulf/internal/app/wwctl/unset"
 	"github.com/warewulf/warewulf/internal/pkg/hostlist"
 	"github.com/warewulf/warewulf/internal/pkg/node"
 )
 
-type variables struct {
-	unsetYes    bool
-	unsetForce  bool
-	unsetFields map[string]*bool
-	unsetScopes map[string]string
-	netname     string
-	diskname    string
-	partname    string
-	fsname      string
-	tags        []string
-	ipmiTags    []string
-	netTags     []string
-	netDel      []string
-	diskDel     []string
-	partDel     []string
-	fsDel       []string
-}
-
 func GetCommand() *cobra.Command {
-	vars := variables{}
+	vars := wwctlunset.Vars{}
 	nodeConf := node.NewNode("")
 
 	baseCmd := &cobra.Command{
@@ -40,28 +23,28 @@ func GetCommand() *cobra.Command {
 	}
 
 	// Create unset flags and store maps
-	vars.unsetFields, vars.unsetScopes = nodeConf.CreateUnsetFlags(baseCmd)
+	vars.UnsetFields, vars.UnsetScopes = nodeConf.CreateUnsetFlags(baseCmd)
 
 	// Add scoping flags for specifying which sub-entity to modify
-	baseCmd.PersistentFlags().StringVar(&vars.netname, "netname", "default", "network which is modified")
-	baseCmd.PersistentFlags().StringVar(&vars.diskname, "diskname", "", "disk to modify")
-	baseCmd.PersistentFlags().StringVar(&vars.partname, "partname", "", "partition to modify (requires --diskname)")
-	baseCmd.PersistentFlags().StringVar(&vars.fsname, "fsname", "", "filesystem to modify")
+	baseCmd.PersistentFlags().StringVar(&vars.Netname, "netname", "default", "network which is modified")
+	baseCmd.PersistentFlags().StringVar(&vars.Diskname, "diskname", "", "disk to modify")
+	baseCmd.PersistentFlags().StringVar(&vars.Partname, "partname", "", "partition to modify (requires --diskname)")
+	baseCmd.PersistentFlags().StringVar(&vars.Fsname, "fsname", "", "filesystem to modify")
 
 	// Add tag deletion flags
-	baseCmd.PersistentFlags().StringSliceVar(&vars.tags, "tag", []string{}, "Unset tags")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.ipmiTags, "ipmitag", []string{}, "Unset IPMI tags")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.netTags, "nettag", []string{}, "Unset network tags")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.Tags, "tag", []string{}, "Unset tags")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.IpmiTags, "ipmitag", []string{}, "Unset IPMI tags")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.NetTags, "nettag", []string{}, "Unset network tags")
 
 	// Add object deletion flags
-	baseCmd.PersistentFlags().StringSliceVar(&vars.netDel, "net", []string{}, "Unset network device by name")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.diskDel, "disk", []string{}, "Unset disk by name")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.partDel, "part", []string{}, "Unset partition by name")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.fsDel, "fs", []string{}, "Unset filesystem by name")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.NetDel, "net", []string{}, "Unset network device by name")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.DiskDel, "disk", []string{}, "Unset disk by name")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.PartDel, "part", []string{}, "Unset partition by name")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.FsDel, "fs", []string{}, "Unset filesystem by name")
 
 	// Add control flags
-	baseCmd.PersistentFlags().BoolVarP(&vars.unsetYes, "yes", "y", false, "Set 'yes' to all questions asked")
-	baseCmd.PersistentFlags().BoolVarP(&vars.unsetForce, "force", "f", false, "Force configuration (even on error)")
+	baseCmd.PersistentFlags().BoolVarP(&vars.UnsetYes, "yes", "y", false, "Set 'yes' to all questions asked")
+	baseCmd.PersistentFlags().BoolVarP(&vars.UnsetForce, "force", "f", false, "Force configuration (even on error)")
 
 	return baseCmd
 }

--- a/internal/app/wwctl/node/unset/root.go
+++ b/internal/app/wwctl/node/unset/root.go
@@ -1,0 +1,67 @@
+package unset
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/warewulf/warewulf/internal/app/wwctl/completions"
+	"github.com/warewulf/warewulf/internal/pkg/hostlist"
+	"github.com/warewulf/warewulf/internal/pkg/node"
+)
+
+type variables struct {
+	unsetYes    bool
+	unsetForce  bool
+	unsetFields map[string]*bool
+	nodeConf    node.Node // For traversing struct
+	netname     string
+	diskname    string
+	partname    string
+	fsname      string
+	tags        []string
+	ipmiTags    []string
+	netTags     []string
+	netDel      []string
+	diskDel     []string
+	partDel     []string
+	fsDel       []string
+}
+
+func GetCommand() *cobra.Command {
+	vars := variables{}
+	vars.nodeConf = node.NewNode("")
+
+	baseCmd := &cobra.Command{
+		DisableFlagsInUseLine: true,
+		Use:                   "unset [OPTIONS] PATTERN",
+		Short:                 "Unset/clear node properties",
+		Long:                  "Unsets configuration properties for nodes matching PATTERN.\n\n" + hostlist.Docstring,
+		Args:                  cobra.MinimumNArgs(1),
+		RunE:                  CobraRunE(&vars),
+		ValidArgsFunction:     completions.Nodes,
+	}
+
+	// Create unset flags and store map
+	vars.unsetFields = vars.nodeConf.CreateUnsetFlags(baseCmd)
+
+	// Add scoping flags for specifying which sub-entity to modify
+	baseCmd.PersistentFlags().StringVar(&vars.netname, "netname", "default", "network which is modified")
+	baseCmd.PersistentFlags().StringVar(&vars.diskname, "diskname", "", "disk to modify")
+	baseCmd.PersistentFlags().StringVar(&vars.partname, "partname", "", "partition to modify (requires --diskname)")
+	baseCmd.PersistentFlags().StringVar(&vars.fsname, "fsname", "", "filesystem to modify")
+
+	// Add tag deletion flags
+	baseCmd.PersistentFlags().StringSliceVar(&vars.tags, "tag", []string{}, "Unset tags")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.ipmiTags, "ipmitag", []string{}, "Unset IPMI tags")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.netTags, "nettag", []string{}, "Unset network tags")
+
+	// Add object deletion flags
+	baseCmd.PersistentFlags().StringSliceVar(&vars.netDel, "net", []string{}, "Unset network device by name")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.diskDel, "disk", []string{}, "Unset disk by name")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.partDel, "part", []string{}, "Unset partition by name")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.fsDel, "fs", []string{}, "Unset filesystem by name")
+
+	// Add control flags
+	baseCmd.PersistentFlags().BoolVarP(&vars.unsetYes, "yes", "y", false, "Set 'yes' to all questions asked")
+	baseCmd.PersistentFlags().BoolVarP(&vars.unsetForce, "force", "f", false, "Force configuration (even on error)")
+
+	return baseCmd
+}

--- a/internal/app/wwctl/node/unset/root.go
+++ b/internal/app/wwctl/node/unset/root.go
@@ -11,7 +11,7 @@ type variables struct {
 	unsetYes    bool
 	unsetForce  bool
 	unsetFields map[string]*bool
-	nodeConf    node.Node // For traversing struct
+	unsetScopes map[string]string
 	netname     string
 	diskname    string
 	partname    string
@@ -27,7 +27,7 @@ type variables struct {
 
 func GetCommand() *cobra.Command {
 	vars := variables{}
-	vars.nodeConf = node.NewNode("")
+	nodeConf := node.NewNode("")
 
 	baseCmd := &cobra.Command{
 		DisableFlagsInUseLine: true,
@@ -39,8 +39,8 @@ func GetCommand() *cobra.Command {
 		ValidArgsFunction:     completions.Nodes,
 	}
 
-	// Create unset flags and store map
-	vars.unsetFields = vars.nodeConf.CreateUnsetFlags(baseCmd)
+	// Create unset flags and store maps
+	vars.unsetFields, vars.unsetScopes = nodeConf.CreateUnsetFlags(baseCmd)
 
 	// Add scoping flags for specifying which sub-entity to modify
 	baseCmd.PersistentFlags().StringVar(&vars.netname, "netname", "default", "network which is modified")

--- a/internal/app/wwctl/node/unset/root.go
+++ b/internal/app/wwctl/node/unset/root.go
@@ -36,12 +36,6 @@ func GetCommand() *cobra.Command {
 	baseCmd.PersistentFlags().StringSliceVar(&vars.IpmiTags, "ipmitag", []string{}, "Unset IPMI tags")
 	baseCmd.PersistentFlags().StringSliceVar(&vars.NetTags, "nettag", []string{}, "Unset network tags")
 
-	// Add object deletion flags
-	baseCmd.PersistentFlags().StringSliceVar(&vars.NetDel, "net", []string{}, "Unset network device by name")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.DiskDel, "disk", []string{}, "Unset disk by name")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.PartDel, "part", []string{}, "Unset partition by name")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.FsDel, "fs", []string{}, "Unset filesystem by name")
-
 	// Add control flags
 	baseCmd.PersistentFlags().BoolVarP(&vars.UnsetYes, "yes", "y", false, "Set 'yes' to all questions asked")
 	baseCmd.PersistentFlags().BoolVarP(&vars.UnsetForce, "force", "f", false, "Force configuration (even on error)")

--- a/internal/app/wwctl/overlay/info/main_test.go
+++ b/internal/app/wwctl/overlay/info/main_test.go
@@ -64,9 +64,9 @@ func Test_Overlay_Variables(t *testing.T) {
 			expectError: false,
 			expectedOutput: "VARIABLE        OPTION        TYPE      HELP\n" +
 				"--------        ------        ----      ----\n" +
-				".Ipmi.Ipaddr    --ipmiaddr    IP        Set the IPMI IP address\n" +
-				".Ipmi.UserName  --ipmiuser    string    Set the IPMI username\n" +
-				".Kernel.Args    --kernelargs  []string  Set kernel arguments\n" +
+				".Ipmi.Ipaddr    --ipmiaddr    IP        the IPMI IP address\n" +
+				".Ipmi.UserName  --ipmiuser    string    the IPMI username\n" +
+				".Kernel.Args    --kernelargs  []string  kernel arguments\n" +
 				".Warewulf.Port                int       \n",
 		},
 		{
@@ -153,7 +153,7 @@ Default: {{ .Hostname }}
 				"--------         ------           ----                     ----\n" +
 				".Hostname                         string                   \n" +
 				".Id                               string                   \n" +
-				".Kernel.Version  --kernelversion  string                   Set kernel version\n" +
+				".Kernel.Version  --kernelversion  string                   kernel version\n" +
 				".NetDevs                          map[string]*node.NetDev  \n",
 		},
 		{
@@ -172,7 +172,7 @@ Default: {{ .Hostname }}
 				"--------      ------        ----      ----\n" +
 				".Hostname                   string    \n" +
 				".Id                         string    \n" +
-				".Kernel.Args  --kernelargs  []string  Set kernel arguments\n" +
+				".Kernel.Args  --kernelargs  []string  kernel arguments\n" +
 				".Tags.foo                   string    \n",
 		},
 		{
@@ -187,7 +187,7 @@ Default: {{ .Hostname }}
 			expectError: false,
 			expectedOutput: "VARIABLE    OPTION   TYPE    HELP\n" +
 				"--------    ------   ----    ----\n" +
-				".ImageName  --image  string  Set image name\n",
+				".ImageName  --image  string  image name\n",
 		},
 		{
 			name: "mixed documentation types",
@@ -263,9 +263,9 @@ IP: {{ $netdev.Ipaddr }}
 				"\n" +
 				"VARIABLE        OPTION    TYPE                     HELP\n" +
 				"--------        ------    ----                     ----\n" +
-				"$netdev.Device  --netdev  string                   Set the device for given network\n" +
+				"$netdev.Device  --netdev  string                   the device for given network\n" +
 				"$netdev.Ipaddr  --ipaddr  IP                       IPv4 address in given network\n" +
-				"$netdev.Type    --type    string                   Set device type of given network\n" +
+				"$netdev.Type    --type    string                   device type of given network\n" +
 				".NetDevs                  map[string]*node.NetDev  \n",
 		},
 		{
@@ -283,8 +283,8 @@ IP: {{ $netdev.Ipaddr }}
 			expectError: false,
 			expectedOutput: "VARIABLE        OPTION    TYPE                     HELP\n" +
 				"--------        ------    ----                     ----\n" +
-				"$netdev.Device  --netdev  string                   Set the device for given network\n" +
-				"$netdev.Type    --type    string                   Set device type of given network\n" +
+				"$netdev.Device  --netdev  string                   the device for given network\n" +
+				"$netdev.Type    --type    string                   device type of given network\n" +
 				".NetDevs                  map[string]*node.NetDev  \n",
 		},
 		{

--- a/internal/app/wwctl/profile/root.go
+++ b/internal/app/wwctl/profile/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/warewulf/warewulf/internal/app/wwctl/profile/edit"
 	"github.com/warewulf/warewulf/internal/app/wwctl/profile/list"
 	"github.com/warewulf/warewulf/internal/app/wwctl/profile/set"
+	"github.com/warewulf/warewulf/internal/app/wwctl/profile/unset"
 )
 
 var (
@@ -25,6 +26,7 @@ func init() {
 	baseCmd.AddCommand(add.GetCommand())
 	baseCmd.AddCommand(delete.GetCommand())
 	baseCmd.AddCommand(edit.GetCommand())
+	baseCmd.AddCommand(unset.GetCommand())
 }
 
 // GetRootCommand returns the root cobra.Command for the application.

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -41,7 +41,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 			dsk := *vars.profileConf.Disks["UNDEF"]
 			vars.profileConf.Disks[vars.profileAdd.DiskName] = &dsk
 		}
-		if (vars.profileAdd.DiskName != "") != (vars.profileAdd.PartName != "") {
+		if vars.profileAdd.PartName != "" && vars.profileAdd.DiskName == "" {
 			return fmt.Errorf("partition and disk must be specified")
 		}
 		delete(vars.profileConf.Disks, "UNDEF")
@@ -77,12 +77,24 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 				delete(profilePtr.NetDevs, vars.profileDel.NetDel)
 			}
 			if vars.profileDel.PartDel != "" {
-				for diskname, disk := range profilePtr.Disks {
-					if _, ok := disk.Partitions[vars.profileDel.PartDel]; ok {
-						wwlog.Verbose("Profile: %s, on disk %s, deleting partition: %s", profileId, diskname, vars.profileDel.PartDel)
-						delete(disk.Partitions, vars.profileDel.PartDel)
-					} else {
+				if vars.profileAdd.DiskName != "" {
+					disk, ok := profilePtr.Disks[vars.profileAdd.DiskName]
+					if !ok || disk == nil {
+						return fmt.Errorf("disk doesn't exist: %s", vars.profileAdd.DiskName)
+					}
+					if _, ok := disk.Partitions[vars.profileDel.PartDel]; !ok {
 						return fmt.Errorf("partition doesn't exist: %s", vars.profileDel.PartDel)
+					}
+					wwlog.Verbose("Profile: %s, on disk %s, deleting partition: %s", profileId, vars.profileAdd.DiskName, vars.profileDel.PartDel)
+					delete(disk.Partitions, vars.profileDel.PartDel)
+				} else {
+					for diskname, disk := range profilePtr.Disks {
+						if _, ok := disk.Partitions[vars.profileDel.PartDel]; ok {
+							wwlog.Verbose("Profile: %s, on disk %s, deleting partition: %s", profileId, diskname, vars.profileDel.PartDel)
+							delete(disk.Partitions, vars.profileDel.PartDel)
+						} else {
+							return fmt.Errorf("partition doesn't exist: %s", vars.profileDel.PartDel)
+						}
 					}
 				}
 			}
@@ -133,6 +145,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 					netDev.Tags[key] = val
 				}
 			}
+			profilePtr.Flatten()
 			count++
 		}
 

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -88,13 +88,16 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 					wwlog.Verbose("Profile: %s, on disk %s, deleting partition: %s", profileId, vars.profileAdd.DiskName, vars.profileDel.PartDel)
 					delete(disk.Partitions, vars.profileDel.PartDel)
 				} else {
+					found := false
 					for diskname, disk := range profilePtr.Disks {
 						if _, ok := disk.Partitions[vars.profileDel.PartDel]; ok {
 							wwlog.Verbose("Profile: %s, on disk %s, deleting partition: %s", profileId, diskname, vars.profileDel.PartDel)
 							delete(disk.Partitions, vars.profileDel.PartDel)
-						} else {
-							return fmt.Errorf("partition doesn't exist: %s", vars.profileDel.PartDel)
+							found = true
 						}
+					}
+					if !found {
+						return fmt.Errorf("partition doesn't exist: %s", vars.profileDel.PartDel)
 					}
 				}
 			}

--- a/internal/app/wwctl/profile/set/main_test.go
+++ b/internal/app/wwctl/profile/set/main_test.go
@@ -214,6 +214,48 @@ nodeprofiles:
   default: {}
 nodes: {}`,
 		},
+		"single profile delete partition unscoped skips disks without it": {
+			args:    []string{"--partdel=var", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          var:
+            number: "1"
+      /dev/vdb:
+        partitions:
+          boot:
+            number: "2"
+nodes: {}
+`,
+			outDb: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda: {}
+      /dev/vdb:
+        partitions:
+          boot:
+            number: "2"
+nodes: {}`,
+		},
+		"single profile delete partition unscoped errors when not found": {
+			args:    []string{"--partdel=nonexistent", "default"},
+			wantErr: true,
+			inDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          var:
+            number: "1"
+nodes: {}
+`,
+		},
 		"single set wipetabe to true": {
 			args:    []string{"--diskwipe=true", "--partname=var", "--diskname=/dev/vda", "default"},
 			wantErr: false,

--- a/internal/app/wwctl/profile/set/main_test.go
+++ b/internal/app/wwctl/profile/set/main_test.go
@@ -164,6 +164,56 @@ nodeprofiles:
         path: /var
 nodes: {}`,
 		},
+		"single profile delete partition scoped to diskname": {
+			args:    []string{"--partdel=var", "--diskname=/dev/vda", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          var:
+            number: "1"
+      /dev/vdb:
+        partitions:
+          var:
+            number: "1"
+nodes: {}
+`,
+			outDb: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda: {}
+      /dev/vdb:
+        partitions:
+          var:
+            number: "1"
+nodes: {}`,
+		},
+		"single profile delete partition unscoped removes from all disks": {
+			args:    []string{"--partdel=var", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          var:
+            number: "1"
+      /dev/vdb:
+        partitions:
+          var:
+            number: "1"
+nodes: {}
+`,
+			outDb: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
 		"single set wipetabe to true": {
 			args:    []string{"--diskwipe=true", "--partname=var", "--diskname=/dev/vda", "default"},
 			wantErr: false,

--- a/internal/app/wwctl/profile/unset/main.go
+++ b/internal/app/wwctl/profile/unset/main.go
@@ -110,11 +110,17 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
 				delete(profilePtr.Disks, name)
 			}
 			for _, name := range vars.partDel {
-				for _, disk := range profilePtr.Disks {
-					if disk == nil {
-						continue
+				if vars.diskname != "" {
+					if disk, ok := profilePtr.Disks[vars.diskname]; ok && disk != nil {
+						delete(disk.Partitions, name)
 					}
-					delete(disk.Partitions, name)
+				} else {
+					for _, disk := range profilePtr.Disks {
+						if disk == nil {
+							continue
+						}
+						delete(disk.Partitions, name)
+					}
 				}
 			}
 			for _, name := range vars.fsDel {

--- a/internal/app/wwctl/profile/unset/main.go
+++ b/internal/app/wwctl/profile/unset/main.go
@@ -4,25 +4,25 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	wwctlflags "github.com/warewulf/warewulf/internal/app/wwctl/flags"
+	wwctlunset "github.com/warewulf/warewulf/internal/app/wwctl/unset"
 	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/util"
 	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
-func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
+func CobraRunE(vars *wwctlunset.Vars) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		// Check if any fields were specified
 		anyFieldSet := false
-		for _, boolPtr := range vars.unsetFields {
+		for _, boolPtr := range vars.UnsetFields {
 			if *boolPtr {
 				anyFieldSet = true
 				break
 			}
 		}
-		anyFieldSet = anyFieldSet || len(vars.tags) > 0 || len(vars.ipmiTags) > 0 || len(vars.netTags) > 0 ||
-			len(vars.netDel) > 0 || len(vars.diskDel) > 0 || len(vars.partDel) > 0 || len(vars.fsDel) > 0
+		anyFieldSet = anyFieldSet || len(vars.Tags) > 0 || len(vars.IpmiTags) > 0 || len(vars.NetTags) > 0 ||
+			len(vars.NetDel) > 0 || len(vars.DiskDel) > 0 || len(vars.PartDel) > 0 || len(vars.FsDel) > 0
 		if !anyFieldSet {
 			return fmt.Errorf("no fields specified to unset")
 		}
@@ -33,12 +33,12 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
 		}
 
 		// Validate scoping: sub-entity fields require their parent scope flags
-		if err := wwctlflags.ValidateUnsetScope(vars.unsetFields, vars.unsetScopes, vars.diskname, vars.partname, vars.fsname); err != nil {
+		if err := wwctlunset.ValidateScopeRequirements(vars); err != nil {
 			return err
 		}
 
 		// Confirmation prompt
-		if !vars.unsetYes {
+		if !vars.UnsetYes {
 			count := 0
 			for _, profileName := range args {
 				if _, ok := nodeDB.NodeProfiles[profileName]; ok {
@@ -54,111 +54,20 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		// Modify profiles directly
 		modifiedCount := 0
 		for _, profileName := range args {
 			profilePtr, ok := nodeDB.NodeProfiles[profileName]
 			if !ok {
 				wwlog.Warn("invalid profile: %s", profileName)
-				if !vars.unsetForce {
+				if !vars.UnsetForce {
 					return fmt.Errorf("profile not found: %s", profileName)
 				}
 				continue
 			}
 
-			// Build scope profile: zero-value with map entries for the keys to target
-			scopeProfile := node.NewProfile("")
-			scopeProfile.NetDevs[vars.netname] = &node.NetDev{}
-			if vars.diskname != "" {
-				disk := &node.Disk{}
-				if vars.partname != "" {
-					disk.Partitions = map[string]*node.Partition{vars.partname: {}}
-				}
-				scopeProfile.Disks = map[string]*node.Disk{vars.diskname: disk}
+			if err := wwctlunset.UpdateEntity(profilePtr, vars); err != nil {
+				return err
 			}
-			if vars.fsname != "" {
-				scopeProfile.FileSystems = map[string]*node.FileSystem{vars.fsname: {}}
-			}
-			changed := func(lopt string) bool {
-				boolPtr, ok := vars.unsetFields[lopt]
-				return ok && boolPtr != nil && *boolPtr
-			}
-			profilePtr.UpdateFrom(&scopeProfile, changed)
-
-			// Delete specified tags
-			for _, key := range vars.tags {
-				delete(profilePtr.Tags, key)
-			}
-			if profilePtr.Ipmi != nil {
-				for _, key := range vars.ipmiTags {
-					delete(profilePtr.Ipmi.Tags, key)
-				}
-			}
-			if len(vars.netTags) > 0 {
-				if netDev, ok := profilePtr.NetDevs[vars.netname]; ok && netDev != nil {
-					for _, key := range vars.netTags {
-						delete(netDev.Tags, key)
-					}
-				}
-			}
-
-			// Delete entire objects by name
-			for _, name := range vars.netDel {
-				delete(profilePtr.NetDevs, name)
-			}
-			for _, name := range vars.diskDel {
-				delete(profilePtr.Disks, name)
-			}
-			for _, name := range vars.partDel {
-				if vars.diskname != "" {
-					disk, ok := profilePtr.Disks[vars.diskname]
-					if !ok || disk == nil {
-						return fmt.Errorf("disk doesn't exist: %s", vars.diskname)
-					}
-					if _, ok := disk.Partitions[name]; !ok {
-						return fmt.Errorf("partition doesn't exist: %s", name)
-					}
-					delete(disk.Partitions, name)
-				} else {
-					found := false
-					for _, disk := range profilePtr.Disks {
-						if disk == nil {
-							continue
-						}
-						if _, ok := disk.Partitions[name]; ok {
-							delete(disk.Partitions, name)
-							found = true
-						}
-					}
-					if !found {
-						return fmt.Errorf("partition doesn't exist: %s", name)
-					}
-				}
-			}
-			for _, name := range vars.fsDel {
-				delete(profilePtr.FileSystems, name)
-			}
-
-			// Clean up empty structs
-			profilePtr.Flatten()
-
-			// Remove any empty map entries left after flattening
-			for netName, netDev := range profilePtr.NetDevs {
-				if node.ObjectIsEmpty(netDev) {
-					delete(profilePtr.NetDevs, netName)
-				}
-			}
-			for diskName, disk := range profilePtr.Disks {
-				if node.ObjectIsEmpty(disk) {
-					delete(profilePtr.Disks, diskName)
-				}
-			}
-			for fsName, fs := range profilePtr.FileSystems {
-				if node.ObjectIsEmpty(fs) {
-					delete(profilePtr.FileSystems, fsName)
-				}
-			}
-
 			modifiedCount++
 		}
 
@@ -166,15 +75,12 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("no profiles were modified")
 		}
 
-		// Save changes
 		if err := nodeDB.Persist(); err != nil {
 			return fmt.Errorf("failed to persist changes: %w", err)
 		}
 
-		// Reload daemon
 		if err := warewulfd.DaemonReload(); err != nil {
 			wwlog.Warn("failed to reload daemon: %v", err)
-			// Don't fail - changes were saved
 		}
 
 		wwlog.Info("Successfully unset fields on %d profile(s)", modifiedCount)

--- a/internal/app/wwctl/profile/unset/main.go
+++ b/internal/app/wwctl/profile/unset/main.go
@@ -14,6 +14,7 @@ import (
 func CobraRunE(vars *wwctlunset.Vars) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		// Check if any fields were specified
+		vars.NetnameChanged = cmd.Flags().Changed("netname")
 		anyFieldSet := false
 		for _, boolPtr := range vars.UnsetFields {
 			if *boolPtr {
@@ -22,7 +23,8 @@ func CobraRunE(vars *wwctlunset.Vars) func(cmd *cobra.Command, args []string) er
 			}
 		}
 		anyFieldSet = anyFieldSet || len(vars.Tags) > 0 || len(vars.IpmiTags) > 0 || len(vars.NetTags) > 0 ||
-			len(vars.NetDel) > 0 || len(vars.DiskDel) > 0 || len(vars.PartDel) > 0 || len(vars.FsDel) > 0
+			vars.NetnameChanged || cmd.Flags().Changed("diskname") ||
+			cmd.Flags().Changed("fsname") || cmd.Flags().Changed("partname")
 		if !anyFieldSet {
 			return fmt.Errorf("no fields specified to unset")
 		}
@@ -48,6 +50,7 @@ func CobraRunE(vars *wwctlunset.Vars) func(cmd *cobra.Command, args []string) er
 			if count == 0 {
 				return fmt.Errorf("no valid profiles found")
 			}
+			wwctlunset.WarnDeletions(vars)
 			yes := util.Confirm(fmt.Sprintf("Are you sure you want to modify %d profile(s)", count))
 			if !yes {
 				return nil

--- a/internal/app/wwctl/profile/unset/main.go
+++ b/internal/app/wwctl/profile/unset/main.go
@@ -111,15 +111,27 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
 			}
 			for _, name := range vars.partDel {
 				if vars.diskname != "" {
-					if disk, ok := profilePtr.Disks[vars.diskname]; ok && disk != nil {
-						delete(disk.Partitions, name)
+					disk, ok := profilePtr.Disks[vars.diskname]
+					if !ok || disk == nil {
+						return fmt.Errorf("disk doesn't exist: %s", vars.diskname)
 					}
+					if _, ok := disk.Partitions[name]; !ok {
+						return fmt.Errorf("partition doesn't exist: %s", name)
+					}
+					delete(disk.Partitions, name)
 				} else {
+					found := false
 					for _, disk := range profilePtr.Disks {
 						if disk == nil {
 							continue
 						}
-						delete(disk.Partitions, name)
+						if _, ok := disk.Partitions[name]; ok {
+							delete(disk.Partitions, name)
+							found = true
+						}
+					}
+					if !found {
+						return fmt.Errorf("partition doesn't exist: %s", name)
 					}
 				}
 			}

--- a/internal/app/wwctl/profile/unset/main.go
+++ b/internal/app/wwctl/profile/unset/main.go
@@ -33,7 +33,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
 		}
 
 		// Validate scoping: sub-entity fields require their parent scope flags
-		if err := wwctlflags.ValidateUnsetScope(vars.unsetFields, vars.diskname, vars.partname, vars.fsname); err != nil {
+		if err := wwctlflags.ValidateUnsetScope(vars.unsetFields, vars.unsetScopes, vars.diskname, vars.partname, vars.fsname); err != nil {
 			return err
 		}
 

--- a/internal/app/wwctl/profile/unset/main.go
+++ b/internal/app/wwctl/profile/unset/main.go
@@ -1,0 +1,165 @@
+package unset
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	wwctlflags "github.com/warewulf/warewulf/internal/app/wwctl/flags"
+	"github.com/warewulf/warewulf/internal/pkg/node"
+	"github.com/warewulf/warewulf/internal/pkg/util"
+	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
+	"github.com/warewulf/warewulf/internal/pkg/wwlog"
+)
+
+func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		// Check if any fields were specified
+		anyFieldSet := false
+		for _, boolPtr := range vars.unsetFields {
+			if *boolPtr {
+				anyFieldSet = true
+				break
+			}
+		}
+		anyFieldSet = anyFieldSet || len(vars.tags) > 0 || len(vars.ipmiTags) > 0 || len(vars.netTags) > 0 ||
+			len(vars.netDel) > 0 || len(vars.diskDel) > 0 || len(vars.partDel) > 0 || len(vars.fsDel) > 0
+		if !anyFieldSet {
+			return fmt.Errorf("no fields specified to unset")
+		}
+
+		nodeDB, err := node.New()
+		if err != nil {
+			return fmt.Errorf("failed to load node database: %w", err)
+		}
+
+		// Validate scoping: sub-entity fields require their parent scope flags
+		if err := wwctlflags.ValidateUnsetScope(vars.unsetFields, vars.diskname, vars.partname, vars.fsname); err != nil {
+			return err
+		}
+
+		// Confirmation prompt
+		if !vars.unsetYes {
+			count := 0
+			for _, profileName := range args {
+				if _, ok := nodeDB.NodeProfiles[profileName]; ok {
+					count++
+				}
+			}
+			if count == 0 {
+				return fmt.Errorf("no valid profiles found")
+			}
+			yes := util.Confirm(fmt.Sprintf("Are you sure you want to modify %d profile(s)", count))
+			if !yes {
+				return nil
+			}
+		}
+
+		// Modify profiles directly
+		modifiedCount := 0
+		for _, profileName := range args {
+			profilePtr, ok := nodeDB.NodeProfiles[profileName]
+			if !ok {
+				wwlog.Warn("invalid profile: %s", profileName)
+				if !vars.unsetForce {
+					return fmt.Errorf("profile not found: %s", profileName)
+				}
+				continue
+			}
+
+			// Build scope profile: zero-value with map entries for the keys to target
+			scopeProfile := node.NewProfile("")
+			scopeProfile.NetDevs[vars.netname] = &node.NetDev{}
+			if vars.diskname != "" {
+				disk := &node.Disk{}
+				if vars.partname != "" {
+					disk.Partitions = map[string]*node.Partition{vars.partname: {}}
+				}
+				scopeProfile.Disks = map[string]*node.Disk{vars.diskname: disk}
+			}
+			if vars.fsname != "" {
+				scopeProfile.FileSystems = map[string]*node.FileSystem{vars.fsname: {}}
+			}
+			changed := func(lopt string) bool {
+				boolPtr, ok := vars.unsetFields[lopt]
+				return ok && boolPtr != nil && *boolPtr
+			}
+			profilePtr.UpdateFrom(&scopeProfile, changed)
+
+			// Delete specified tags
+			for _, key := range vars.tags {
+				delete(profilePtr.Tags, key)
+			}
+			if profilePtr.Ipmi != nil {
+				for _, key := range vars.ipmiTags {
+					delete(profilePtr.Ipmi.Tags, key)
+				}
+			}
+			if len(vars.netTags) > 0 {
+				if netDev, ok := profilePtr.NetDevs[vars.netname]; ok && netDev != nil {
+					for _, key := range vars.netTags {
+						delete(netDev.Tags, key)
+					}
+				}
+			}
+
+			// Delete entire objects by name
+			for _, name := range vars.netDel {
+				delete(profilePtr.NetDevs, name)
+			}
+			for _, name := range vars.diskDel {
+				delete(profilePtr.Disks, name)
+			}
+			for _, name := range vars.partDel {
+				for _, disk := range profilePtr.Disks {
+					if disk == nil {
+						continue
+					}
+					delete(disk.Partitions, name)
+				}
+			}
+			for _, name := range vars.fsDel {
+				delete(profilePtr.FileSystems, name)
+			}
+
+			// Clean up empty structs
+			profilePtr.Flatten()
+
+			// Remove any empty map entries left after flattening
+			for netName, netDev := range profilePtr.NetDevs {
+				if node.ObjectIsEmpty(netDev) {
+					delete(profilePtr.NetDevs, netName)
+				}
+			}
+			for diskName, disk := range profilePtr.Disks {
+				if node.ObjectIsEmpty(disk) {
+					delete(profilePtr.Disks, diskName)
+				}
+			}
+			for fsName, fs := range profilePtr.FileSystems {
+				if node.ObjectIsEmpty(fs) {
+					delete(profilePtr.FileSystems, fsName)
+				}
+			}
+
+			modifiedCount++
+		}
+
+		if modifiedCount == 0 {
+			return fmt.Errorf("no profiles were modified")
+		}
+
+		// Save changes
+		if err := nodeDB.Persist(); err != nil {
+			return fmt.Errorf("failed to persist changes: %w", err)
+		}
+
+		// Reload daemon
+		if err := warewulfd.DaemonReload(); err != nil {
+			wwlog.Warn("failed to reload daemon: %v", err)
+			// Don't fail - changes were saved
+		}
+
+		wwlog.Info("Successfully unset fields on %d profile(s)", modifiedCount)
+		return nil
+	}
+}

--- a/internal/app/wwctl/profile/unset/main_test.go
+++ b/internal/app/wwctl/profile/unset/main_test.go
@@ -508,6 +508,24 @@ nodeprofiles:
         ipaddr: 192.168.1.100
 nodes: {}`,
 		},
+		"unset net field targeting nonexistent network leaves db unchanged": {
+			args:    []string{"--ipaddr", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      eth0:
+        ipaddr: 10.0.0.100
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    network devices:
+      eth0:
+        ipaddr: 10.0.0.100
+nodes: {}`,
+		},
 
 		// Already unset (idempotent)
 		"unset already-unset field": {
@@ -847,6 +865,107 @@ nodes: {}`,
 			outDB: `
 nodeprofiles:
   default: {}
+nodes: {}`,
+		},
+		"unset part unscoped skips disks that lack the partition": {
+			args:    []string{"--part=swap", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+      /dev/vdb:
+        partitions:
+          root:
+            number: "2"
+            size_mib: "51200"
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vdb:
+        partitions:
+          root:
+            number: "2"
+            size_mib: "51200"
+nodes: {}`,
+		},
+		"error: unset part unscoped not found on any disk": {
+			args:    []string{"--part=nopart", "--yes", "default"},
+			wantErr: true,
+			inDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+nodes: {}`,
+		},
+		"error: unset part scoped to nonexistent disk": {
+			args:    []string{"--part=swap", "--diskname=/dev/nonexistent", "--yes", "default"},
+			wantErr: true,
+			inDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+nodes: {}`,
+		},
+		"error: unset part scoped partition not in disk": {
+			args:    []string{"--part=nopart", "--diskname=/dev/vda", "--yes", "default"},
+			wantErr: true,
+			inDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
 nodes: {}`,
 		},
 		"unset fs removes filesystem from profile": {

--- a/internal/app/wwctl/profile/unset/main_test.go
+++ b/internal/app/wwctl/profile/unset/main_test.go
@@ -722,7 +722,7 @@ nodes: {}`,
 
 		// Object deletion tests
 		"unset net removes entire netdev from profile": {
-			args:    []string{"--net=eth0", "--yes", "default"},
+			args:    []string{"--netname=eth0", "--yes", "default"},
 			wantErr: false,
 			inDB: `
 nodeprofiles:
@@ -742,7 +742,7 @@ nodeprofiles:
 nodes: {}`,
 		},
 		"unset net nonexistent is noop on profile": {
-			args:    []string{"--net=nonet", "--yes", "default"},
+			args:    []string{"--netname=nonet", "--yes", "default"},
 			wantErr: false,
 			inDB: `
 nodeprofiles:
@@ -760,7 +760,7 @@ nodeprofiles:
 nodes: {}`,
 		},
 		"unset disk removes entire disk from profile": {
-			args:    []string{"--disk=/dev/vda", "--yes", "default"},
+			args:    []string{"--diskname=/dev/vda", "--yes", "default"},
 			wantErr: false,
 			inDB: `
 nodeprofiles:
@@ -789,7 +789,7 @@ nodeprofiles:
 nodes: {}`,
 		},
 		"unset part removes partition from profile disk": {
-			args:    []string{"--part=swap", "--yes", "default"},
+			args:    []string{"--partname=swap", "--yes", "default"},
 			wantErr: false,
 			inDB: `
 nodeprofiles:
@@ -816,7 +816,7 @@ nodeprofiles:
 nodes: {}`,
 		},
 		"unset part scoped to diskname removes partition only from that disk": {
-			args:    []string{"--part=swap", "--diskname=/dev/vda", "--yes", "default"},
+			args:    []string{"--partname=swap", "--diskname=/dev/vda", "--yes", "default"},
 			wantErr: false,
 			inDB: `
 nodeprofiles:
@@ -845,7 +845,7 @@ nodeprofiles:
 nodes: {}`,
 		},
 		"unset part unscoped removes partition from all disks": {
-			args:    []string{"--part=swap", "--yes", "default"},
+			args:    []string{"--partname=swap", "--yes", "default"},
 			wantErr: false,
 			inDB: `
 nodeprofiles:
@@ -868,7 +868,7 @@ nodeprofiles:
 nodes: {}`,
 		},
 		"unset part unscoped skips disks that lack the partition": {
-			args:    []string{"--part=swap", "--yes", "default"},
+			args:    []string{"--partname=swap", "--yes", "default"},
 			wantErr: false,
 			inDB: `
 nodeprofiles:
@@ -897,7 +897,7 @@ nodeprofiles:
 nodes: {}`,
 		},
 		"error: unset part unscoped not found on any disk": {
-			args:    []string{"--part=nopart", "--yes", "default"},
+			args:    []string{"--partname=nopart", "--yes", "default"},
 			wantErr: true,
 			inDB: `
 nodeprofiles:
@@ -921,7 +921,7 @@ nodeprofiles:
 nodes: {}`,
 		},
 		"error: unset part scoped to nonexistent disk": {
-			args:    []string{"--part=swap", "--diskname=/dev/nonexistent", "--yes", "default"},
+			args:    []string{"--partname=swap", "--diskname=/dev/nonexistent", "--yes", "default"},
 			wantErr: true,
 			inDB: `
 nodeprofiles:
@@ -945,7 +945,7 @@ nodeprofiles:
 nodes: {}`,
 		},
 		"error: unset part scoped partition not in disk": {
-			args:    []string{"--part=nopart", "--diskname=/dev/vda", "--yes", "default"},
+			args:    []string{"--partname=nopart", "--diskname=/dev/vda", "--yes", "default"},
 			wantErr: true,
 			inDB: `
 nodeprofiles:
@@ -969,7 +969,7 @@ nodeprofiles:
 nodes: {}`,
 		},
 		"unset fs removes filesystem from profile": {
-			args:    []string{"--fs=/dev/disk/by-partlabel/swap", "--yes", "default"},
+			args:    []string{"--fsname=/dev/disk/by-partlabel/swap", "--yes", "default"},
 			wantErr: false,
 			inDB: `
 nodeprofiles:

--- a/internal/app/wwctl/profile/unset/main_test.go
+++ b/internal/app/wwctl/profile/unset/main_test.go
@@ -797,6 +797,58 @@ nodeprofiles:
             size_mib: "51200"
 nodes: {}`,
 		},
+		"unset part scoped to diskname removes partition only from that disk": {
+			args:    []string{"--part=swap", "--diskname=/dev/vda", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+      /dev/vdb:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vdb:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+nodes: {}`,
+		},
+		"unset part unscoped removes partition from all disks": {
+			args:    []string{"--part=swap", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+      /dev/vdb:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
 		"unset fs removes filesystem from profile": {
 			args:    []string{"--fs=/dev/disk/by-partlabel/swap", "--yes", "default"},
 			wantErr: false,

--- a/internal/app/wwctl/profile/unset/main_test.go
+++ b/internal/app/wwctl/profile/unset/main_test.go
@@ -1,0 +1,960 @@
+package unset
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/warewulf/warewulf/internal/pkg/testenv"
+	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
+)
+
+func Test_Profile_Unset(t *testing.T) {
+	tests := map[string]struct {
+		args    []string
+		wantErr bool
+		inDB    string
+		outDB   string
+	}{
+		// Basic field unsetting
+		"unset comment": {
+			args:    []string{"--comment", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    comment: test comment
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset cluster": {
+			args:    []string{"--cluster", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    cluster name: mycluster
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset image": {
+			args:    []string{"--image", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    image name: rockylinux-9
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+
+		// Network field unsetting
+		"unset netmask": {
+			args:    []string{"--netmask", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        netmask: 255.255.255.0
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset ipaddr": {
+			args:    []string{"--ipaddr", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset gateway": {
+			args:    []string{"--gateway", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        gateway: 192.168.1.1
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset hwaddr": {
+			args:    []string{"--hwaddr", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        hwaddr: 00:11:22:33:44:55
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset netdev": {
+			args:    []string{"--netdev", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        device: eth0
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset mtu": {
+			args:    []string{"--mtu", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        mtu: 9000
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset type": {
+			args:    []string{"--type", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        type: ethernet
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+
+		// Multiple network fields at once
+		"unset multiple network fields": {
+			args:    []string{"--ipaddr", "--netmask", "--gateway", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+        netmask: 255.255.255.0
+        gateway: 192.168.1.1
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+
+		// IPv6 fields
+		"unset ipaddr6": {
+			args:    []string{"--ipaddr6", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        ipaddr6: fe80::1
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset gateway6": {
+			args:    []string{"--gateway6", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        gateway6: fe80::1
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+
+		// IPMI fields
+		"unset ipmiaddr": {
+			args:    []string{"--ipmiaddr", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    ipmi:
+      ipaddr: 192.168.1.10
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset ipminetmask": {
+			args:    []string{"--ipminetmask", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    ipmi:
+      netmask: 255.255.255.0
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset ipmigateway": {
+			args:    []string{"--ipmigateway", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    ipmi:
+      gateway: 192.168.1.1
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset ipmiuser": {
+			args:    []string{"--ipmiuser", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    ipmi:
+      username: admin
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset ipmipass": {
+			args:    []string{"--ipmipass", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    ipmi:
+      password: secret
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset ipmiport": {
+			args:    []string{"--ipmiport", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    ipmi:
+      port: 623
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+
+		// Kernel fields
+		"unset kernelversion": {
+			args:    []string{"--kernelversion", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    kernel:
+      version: 5.14.0
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset kernelargs": {
+			args:    []string{"--kernelargs", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    kernel:
+      args:
+      - quiet
+      - splash
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+
+		// Overlay fields
+		"unset runtime-overlays": {
+			args:    []string{"--runtime-overlays", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    runtime overlay:
+      - wwinit
+      - generic
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset system-overlays": {
+			args:    []string{"--system-overlays", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    system overlay:
+      - wwinit
+      - generic
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+
+		// Other fields
+		"unset init": {
+			args:    []string{"--init", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    init: /sbin/init
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset root": {
+			args:    []string{"--root", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    root: initramfs
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset ipxe": {
+			args:    []string{"--ipxe", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    ipxe template: default
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset primarynet": {
+			args:    []string{"--primarynet", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    primary network: eth0
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+		"unset profiles": {
+			args:    []string{"--profile", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    profiles:
+      - base
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+
+		// Multiple profiles
+		"unset on multiple profiles": {
+			args:    []string{"--comment", "--yes", "default", "compute"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    comment: default profile
+  compute:
+    comment: compute profile
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+  compute: {}
+nodes: {}`,
+		},
+
+		// Partial unsetting
+		"unset comment but keep image": {
+			args:    []string{"--comment", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    comment: test comment
+    image name: rockylinux-9
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    image name: rockylinux-9
+nodes: {}`,
+		},
+		"unset netmask but keep ipaddr": {
+			args:    []string{"--netmask", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+        netmask: 255.255.255.0
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+nodes: {}`,
+		},
+
+		// Network-specific with --netname
+		"unset ipaddr on specific network": {
+			args:    []string{"--ipaddr", "--netname", "eth1", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+      eth1:
+        ipaddr: 10.0.0.100
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+nodes: {}`,
+		},
+
+		// Already unset (idempotent)
+		"unset already-unset field": {
+			args:    []string{"--comment", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+
+		// Error cases
+		"error: no fields specified": {
+			args:    []string{"--yes", "default"},
+			wantErr: true,
+			inDB: `
+nodeprofiles:
+  default:
+    comment: test
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    comment: test
+nodes: {}`,
+		},
+		"error: non-existent profile": {
+			args:    []string{"--comment", "--yes", "nonexistent"},
+			wantErr: true,
+			inDB: `
+nodeprofiles:
+  default:
+    comment: test
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    comment: test
+nodes: {}`,
+		},
+		"force: continue on invalid profile": {
+			args:    []string{"--comment", "--yes", "--force", "nonexistent", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    comment: test
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+
+		// Multiple fields
+		"unset multiple fields": {
+			args:    []string{"--comment", "--cluster", "--image", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    comment: test comment
+    cluster name: mycluster
+    image name: rockylinux-9
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+		},
+
+		// Tag deletion tests
+		"delete profile tag": {
+			args:    []string{"--tag=mytag", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    tags:
+      mytag: myvalue
+      keeptag: keepvalue
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    tags:
+      keeptag: keepvalue
+nodes: {}`,
+		},
+		"delete multiple profile tags": {
+			args:    []string{"--tag=tag1,tag2", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    tags:
+      tag1: val1
+      tag2: val2
+      tag3: val3
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    tags:
+      tag3: val3
+nodes: {}`,
+		},
+		"delete ipmi tag from profile": {
+			args:    []string{"--ipmitag=bmctag", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    ipmi:
+      username: admin
+      tags:
+        bmctag: bmcvalue
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    ipmi:
+      username: admin
+nodes: {}`,
+		},
+		"delete net tag from profile": {
+			args:    []string{"--nettag=dns1", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+        tags:
+          dns1: 8.8.8.8
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+nodes: {}`,
+		},
+		"delete net tag on specific network from profile": {
+			args:    []string{"--netname", "eth1", "--nettag=mytag", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        tags:
+          mytag: defaultval
+      eth1:
+        ipaddr: 10.0.0.1
+        tags:
+          mytag: eth1val
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        tags:
+          mytag: defaultval
+      eth1:
+        ipaddr: 10.0.0.1
+nodes: {}`,
+		},
+		"combine tag deletion with field unset on profile": {
+			args:    []string{"--comment", "--tag=mytag", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    comment: hello
+    tags:
+      mytag: val
+      keep: val2
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    tags:
+      keep: val2
+nodes: {}`,
+		},
+
+		// Object deletion tests
+		"unset net removes entire netdev from profile": {
+			args:    []string{"--net=eth0", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+      eth0:
+        ipaddr: 10.0.0.100
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+nodes: {}`,
+		},
+		"unset net nonexistent is noop on profile": {
+			args:    []string{"--net=nonet", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        ipaddr: 192.168.1.100
+nodes: {}`,
+		},
+		"unset disk removes entire disk from profile": {
+			args:    []string{"--disk=/dev/vda", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+      /dev/vdb:
+        partitions:
+          data:
+            number: "1"
+            size_mib: "102400"
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vdb:
+        partitions:
+          data:
+            number: "1"
+            size_mib: "102400"
+nodes: {}`,
+		},
+		"unset part removes partition from profile disk": {
+			args:    []string{"--part=swap", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          swap:
+            number: "1"
+            size_mib: "4096"
+          root:
+            number: "2"
+            size_mib: "51200"
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          root:
+            number: "2"
+            size_mib: "51200"
+nodes: {}`,
+		},
+		"unset fs removes filesystem from profile": {
+			args:    []string{"--fs=/dev/disk/by-partlabel/swap", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    filesystems:
+      /dev/disk/by-partlabel/swap:
+        format: swap
+      /dev/disk/by-partlabel/root:
+        format: ext4
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    filesystems:
+      /dev/disk/by-partlabel/root:
+        format: ext4
+nodes: {}`,
+		},
+
+		// Scoped unset: disk/partition/filesystem
+		"scoped partnumber clears only targeted partition": {
+			args:    []string{"--partnumber", "--diskname=/dev/vda", "--partname=root", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          root:
+            number: "1"
+            size_mib: "1024"
+          swap:
+            number: "2"
+            size_mib: "512"
+      /dev/vdb:
+        partitions:
+          data:
+            number: "1"
+            size_mib: "2048"
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          root:
+            size_mib: "1024"
+          swap:
+            number: "2"
+            size_mib: "512"
+      /dev/vdb:
+        partitions:
+          data:
+            number: "1"
+            size_mib: "2048"
+nodes: {}`,
+		},
+		"scoped fsformat clears only targeted filesystem": {
+			args:    []string{"--fsformat", "--fsname=/dev/disk/by-partlabel/root", "--yes", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    filesystems:
+      /dev/disk/by-partlabel/root:
+        format: ext4
+        path: /
+      /dev/disk/by-partlabel/var:
+        format: btrfs
+        path: /var
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    filesystems:
+      /dev/disk/by-partlabel/root:
+        path: /
+      /dev/disk/by-partlabel/var:
+        format: btrfs
+        path: /var
+nodes: {}`,
+		},
+		"error: partnumber without diskname/partname": {
+			args:    []string{"--partnumber", "--yes", "default"},
+			wantErr: true,
+			inDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          root:
+            number: "1"
+            size_mib: "1024"
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          root:
+            number: "1"
+            size_mib: "1024"
+nodes: {}`,
+		},
+		"error: fsformat without fsname": {
+			args:    []string{"--fsformat", "--yes", "default"},
+			wantErr: true,
+			inDB: `
+nodeprofiles:
+  default:
+    filesystems:
+      /dev/disk/by-partlabel/root:
+        format: ext4
+nodes: {}`,
+			outDB: `
+nodeprofiles:
+  default:
+    filesystems:
+      /dev/disk/by-partlabel/root:
+        format: ext4
+nodes: {}`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			env := testenv.New(t)
+			defer env.RemoveAll()
+			env.WriteFile("etc/warewulf/nodes.conf", tt.inDB)
+			warewulfd.SetNoDaemon()
+
+			baseCmd := GetCommand()
+			baseCmd.SetArgs(tt.args)
+
+			// Capture output
+			buf := new(bytes.Buffer)
+			baseCmd.SetOut(buf)
+			baseCmd.SetErr(buf)
+
+			err := baseCmd.Execute()
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Read the output database
+			outDB := env.ReadFile("etc/warewulf/nodes.conf")
+
+			// Compare YAML
+			assert.YAMLEq(t, tt.outDB, outDB)
+		})
+	}
+}

--- a/internal/app/wwctl/profile/unset/root.go
+++ b/internal/app/wwctl/profile/unset/root.go
@@ -35,12 +35,6 @@ func GetCommand() *cobra.Command {
 	baseCmd.PersistentFlags().StringSliceVar(&vars.IpmiTags, "ipmitag", []string{}, "Unset IPMI tags")
 	baseCmd.PersistentFlags().StringSliceVar(&vars.NetTags, "nettag", []string{}, "Unset network tags")
 
-	// Add object deletion flags
-	baseCmd.PersistentFlags().StringSliceVar(&vars.NetDel, "net", []string{}, "Unset network device by name")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.DiskDel, "disk", []string{}, "Unset disk by name")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.PartDel, "part", []string{}, "Unset partition by name")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.FsDel, "fs", []string{}, "Unset filesystem by name")
-
 	// Add control flags
 	baseCmd.PersistentFlags().BoolVarP(&vars.UnsetYes, "yes", "y", false, "Set 'yes' to all questions asked")
 	baseCmd.PersistentFlags().BoolVarP(&vars.UnsetForce, "force", "f", false, "Force configuration (even on error)")

--- a/internal/app/wwctl/profile/unset/root.go
+++ b/internal/app/wwctl/profile/unset/root.go
@@ -10,7 +10,7 @@ type variables struct {
 	unsetYes    bool
 	unsetForce  bool
 	unsetFields map[string]*bool
-	profileConf node.Profile
+	unsetScopes map[string]string
 	netname     string
 	diskname    string
 	partname    string
@@ -26,7 +26,7 @@ type variables struct {
 
 func GetCommand() *cobra.Command {
 	vars := variables{}
-	vars.profileConf = node.NewProfile("")
+	profileConf := node.NewProfile("")
 
 	baseCmd := &cobra.Command{
 		DisableFlagsInUseLine: true,
@@ -38,8 +38,8 @@ func GetCommand() *cobra.Command {
 		ValidArgsFunction:     completions.Profiles,
 	}
 
-	// Create unset flags and store map
-	vars.unsetFields = vars.profileConf.CreateUnsetFlags(baseCmd)
+	// Create unset flags and store maps
+	vars.unsetFields, vars.unsetScopes = profileConf.CreateUnsetFlags(baseCmd)
 
 	// Add scoping flags for specifying which sub-entity to modify
 	baseCmd.PersistentFlags().StringVar(&vars.netname, "netname", "default", "network which is modified")

--- a/internal/app/wwctl/profile/unset/root.go
+++ b/internal/app/wwctl/profile/unset/root.go
@@ -3,29 +3,12 @@ package unset
 import (
 	"github.com/spf13/cobra"
 	"github.com/warewulf/warewulf/internal/app/wwctl/completions"
+	wwctlunset "github.com/warewulf/warewulf/internal/app/wwctl/unset"
 	"github.com/warewulf/warewulf/internal/pkg/node"
 )
 
-type variables struct {
-	unsetYes    bool
-	unsetForce  bool
-	unsetFields map[string]*bool
-	unsetScopes map[string]string
-	netname     string
-	diskname    string
-	partname    string
-	fsname      string
-	tags        []string
-	ipmiTags    []string
-	netTags     []string
-	netDel      []string
-	diskDel     []string
-	partDel     []string
-	fsDel       []string
-}
-
 func GetCommand() *cobra.Command {
-	vars := variables{}
+	vars := wwctlunset.Vars{}
 	profileConf := node.NewProfile("")
 
 	baseCmd := &cobra.Command{
@@ -39,28 +22,28 @@ func GetCommand() *cobra.Command {
 	}
 
 	// Create unset flags and store maps
-	vars.unsetFields, vars.unsetScopes = profileConf.CreateUnsetFlags(baseCmd)
+	vars.UnsetFields, vars.UnsetScopes = profileConf.CreateUnsetFlags(baseCmd)
 
 	// Add scoping flags for specifying which sub-entity to modify
-	baseCmd.PersistentFlags().StringVar(&vars.netname, "netname", "default", "network which is modified")
-	baseCmd.PersistentFlags().StringVar(&vars.diskname, "diskname", "", "disk to modify")
-	baseCmd.PersistentFlags().StringVar(&vars.partname, "partname", "", "partition to modify (requires --diskname)")
-	baseCmd.PersistentFlags().StringVar(&vars.fsname, "fsname", "", "filesystem to modify")
+	baseCmd.PersistentFlags().StringVar(&vars.Netname, "netname", "default", "network which is modified")
+	baseCmd.PersistentFlags().StringVar(&vars.Diskname, "diskname", "", "disk to modify")
+	baseCmd.PersistentFlags().StringVar(&vars.Partname, "partname", "", "partition to modify (requires --diskname)")
+	baseCmd.PersistentFlags().StringVar(&vars.Fsname, "fsname", "", "filesystem to modify")
 
 	// Add tag deletion flags
-	baseCmd.PersistentFlags().StringSliceVar(&vars.tags, "tag", []string{}, "Unset tags")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.ipmiTags, "ipmitag", []string{}, "Unset IPMI tags")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.netTags, "nettag", []string{}, "Unset network tags")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.Tags, "tag", []string{}, "Unset tags")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.IpmiTags, "ipmitag", []string{}, "Unset IPMI tags")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.NetTags, "nettag", []string{}, "Unset network tags")
 
 	// Add object deletion flags
-	baseCmd.PersistentFlags().StringSliceVar(&vars.netDel, "net", []string{}, "Unset network device by name")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.diskDel, "disk", []string{}, "Unset disk by name")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.partDel, "part", []string{}, "Unset partition by name")
-	baseCmd.PersistentFlags().StringSliceVar(&vars.fsDel, "fs", []string{}, "Unset filesystem by name")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.NetDel, "net", []string{}, "Unset network device by name")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.DiskDel, "disk", []string{}, "Unset disk by name")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.PartDel, "part", []string{}, "Unset partition by name")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.FsDel, "fs", []string{}, "Unset filesystem by name")
 
 	// Add control flags
-	baseCmd.PersistentFlags().BoolVarP(&vars.unsetYes, "yes", "y", false, "Set 'yes' to all questions asked")
-	baseCmd.PersistentFlags().BoolVarP(&vars.unsetForce, "force", "f", false, "Force configuration (even on error)")
+	baseCmd.PersistentFlags().BoolVarP(&vars.UnsetYes, "yes", "y", false, "Set 'yes' to all questions asked")
+	baseCmd.PersistentFlags().BoolVarP(&vars.UnsetForce, "force", "f", false, "Force configuration (even on error)")
 
 	return baseCmd
 }

--- a/internal/app/wwctl/profile/unset/root.go
+++ b/internal/app/wwctl/profile/unset/root.go
@@ -1,0 +1,66 @@
+package unset
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/warewulf/warewulf/internal/app/wwctl/completions"
+	"github.com/warewulf/warewulf/internal/pkg/node"
+)
+
+type variables struct {
+	unsetYes    bool
+	unsetForce  bool
+	unsetFields map[string]*bool
+	profileConf node.Profile
+	netname     string
+	diskname    string
+	partname    string
+	fsname      string
+	tags        []string
+	ipmiTags    []string
+	netTags     []string
+	netDel      []string
+	diskDel     []string
+	partDel     []string
+	fsDel       []string
+}
+
+func GetCommand() *cobra.Command {
+	vars := variables{}
+	vars.profileConf = node.NewProfile("")
+
+	baseCmd := &cobra.Command{
+		DisableFlagsInUseLine: true,
+		Use:                   "unset [OPTIONS] PROFILE...",
+		Short:                 "Unset/clear profile properties",
+		Long:                  "Unsets configuration properties for the specified PROFILE(s).",
+		Args:                  cobra.MinimumNArgs(1),
+		RunE:                  CobraRunE(&vars),
+		ValidArgsFunction:     completions.Profiles,
+	}
+
+	// Create unset flags and store map
+	vars.unsetFields = vars.profileConf.CreateUnsetFlags(baseCmd)
+
+	// Add scoping flags for specifying which sub-entity to modify
+	baseCmd.PersistentFlags().StringVar(&vars.netname, "netname", "default", "network which is modified")
+	baseCmd.PersistentFlags().StringVar(&vars.diskname, "diskname", "", "disk to modify")
+	baseCmd.PersistentFlags().StringVar(&vars.partname, "partname", "", "partition to modify (requires --diskname)")
+	baseCmd.PersistentFlags().StringVar(&vars.fsname, "fsname", "", "filesystem to modify")
+
+	// Add tag deletion flags
+	baseCmd.PersistentFlags().StringSliceVar(&vars.tags, "tag", []string{}, "Unset tags")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.ipmiTags, "ipmitag", []string{}, "Unset IPMI tags")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.netTags, "nettag", []string{}, "Unset network tags")
+
+	// Add object deletion flags
+	baseCmd.PersistentFlags().StringSliceVar(&vars.netDel, "net", []string{}, "Unset network device by name")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.diskDel, "disk", []string{}, "Unset disk by name")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.partDel, "part", []string{}, "Unset partition by name")
+	baseCmd.PersistentFlags().StringSliceVar(&vars.fsDel, "fs", []string{}, "Unset filesystem by name")
+
+	// Add control flags
+	baseCmd.PersistentFlags().BoolVarP(&vars.unsetYes, "yes", "y", false, "Set 'yes' to all questions asked")
+	baseCmd.PersistentFlags().BoolVarP(&vars.unsetForce, "force", "f", false, "Force configuration (even on error)")
+
+	return baseCmd
+}

--- a/internal/app/wwctl/unset/apply.go
+++ b/internal/app/wwctl/unset/apply.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/warewulf/warewulf/internal/pkg/node"
+	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
 // ValidateScopeRequirements checks that sub-entity unset flags have the
@@ -33,6 +34,39 @@ func ValidateScopeRequirements(vars *Vars) error {
 	return nil
 }
 
+// WarnDeletions prints a warning line for each sub-entity that will be deleted
+// entirely (scoping flag given with no corresponding sub-field flags). Call
+// before prompting for confirmation so the user knows what will be removed.
+func WarnDeletions(vars *Vars) {
+	if vars.NetnameChanged && !HasScopedFieldSet(vars, "net") && len(vars.NetTags) == 0 {
+		wwlog.Warn("network device %q will be removed entirely", vars.Netname)
+	}
+	if vars.Diskname != "" && vars.Partname == "" && !HasScopedFieldSet(vars, "disk") {
+		wwlog.Warn("disk %q will be removed entirely", vars.Diskname)
+	}
+	if vars.Fsname != "" && !HasScopedFieldSet(vars, "fs") {
+		wwlog.Warn("filesystem %q will be removed entirely", vars.Fsname)
+	}
+	if vars.Partname != "" && !HasScopedFieldSet(vars, "disk,part") {
+		if vars.Diskname != "" {
+			wwlog.Warn("partition %q on disk %q will be removed entirely", vars.Partname, vars.Diskname)
+		} else {
+			wwlog.Warn("partition %q will be removed from all disks", vars.Partname)
+		}
+	}
+}
+
+// HasScopedFieldSet returns true if any field in vars.UnsetFields is set and
+// has exactly the given scope value in vars.UnsetScopes.
+func HasScopedFieldSet(vars *Vars, scope string) bool {
+	for flagName, boolPtr := range vars.UnsetFields {
+		if boolPtr != nil && *boolPtr && vars.UnsetScopes[flagName] == scope {
+			return true
+		}
+	}
+	return false
+}
+
 // Entity is satisfied by *node.Node and *node.Profile.
 type Entity interface {
 	GetProfile() *node.Profile
@@ -46,16 +80,25 @@ func UpdateEntity(entity Entity, vars *Vars) error {
 	target := entity.GetProfile()
 	// Build scope: a zero-valued Profile with map entries for the targeted
 	// sub-entity keys so UpdateFrom knows which sub-entity to clear fields on.
+	// Only add sub-entities that actually have fields being unset — adding an
+	// entry unconditionally causes recursiveUpdateFrom to create stubs in the
+	// target, which defeats existence checks in the deletion logic below.
 	scope := node.NewProfile("")
-	scope.NetDevs[vars.Netname] = &node.NetDev{}
-	if vars.Diskname != "" {
-		disk := &node.Disk{}
-		if vars.Partname != "" {
-			disk.Partitions = map[string]*node.Partition{vars.Partname: {}}
-		}
-		scope.Disks = map[string]*node.Disk{vars.Diskname: disk}
+	if HasScopedFieldSet(vars, "net") {
+		scope.NetDevs[vars.Netname] = &node.NetDev{}
 	}
-	if vars.Fsname != "" {
+	if vars.Diskname != "" {
+		hasDiskFields := HasScopedFieldSet(vars, "disk")
+		hasPartFields := HasScopedFieldSet(vars, "disk,part")
+		if hasDiskFields || hasPartFields {
+			disk := &node.Disk{}
+			if vars.Partname != "" && hasPartFields {
+				disk.Partitions = map[string]*node.Partition{vars.Partname: {}}
+			}
+			scope.Disks = map[string]*node.Disk{vars.Diskname: disk}
+		}
+	}
+	if vars.Fsname != "" && HasScopedFieldSet(vars, "fs") {
 		scope.FileSystems = map[string]*node.FileSystem{vars.Fsname: {}}
 	}
 
@@ -82,41 +125,43 @@ func UpdateEntity(entity Entity, vars *Vars) error {
 		}
 	}
 
-	// Delete entire objects by name
-	for _, name := range vars.NetDel {
-		delete(target.NetDevs, name)
+	// Delete entire sub-entities when scoping flag given with no sub-fields.
+	// Net: also guard against --nettag (tag ops use --netname for scoping).
+	// Disk: also guard against --partname (that scopes a partition operation).
+	if vars.NetnameChanged && !HasScopedFieldSet(vars, "net") && len(vars.NetTags) == 0 {
+		delete(target.NetDevs, vars.Netname)
 	}
-	for _, name := range vars.DiskDel {
-		delete(target.Disks, name)
+	if vars.Diskname != "" && vars.Partname == "" && !HasScopedFieldSet(vars, "disk") {
+		delete(target.Disks, vars.Diskname)
 	}
-	for _, name := range vars.PartDel {
+	if vars.Fsname != "" && !HasScopedFieldSet(vars, "fs") {
+		delete(target.FileSystems, vars.Fsname)
+	}
+	if vars.Partname != "" && !HasScopedFieldSet(vars, "disk,part") {
 		if vars.Diskname != "" {
 			disk, ok := target.Disks[vars.Diskname]
 			if !ok || disk == nil {
 				return fmt.Errorf("disk doesn't exist: %s", vars.Diskname)
 			}
-			if _, ok := disk.Partitions[name]; !ok {
-				return fmt.Errorf("partition doesn't exist: %s", name)
+			if _, ok := disk.Partitions[vars.Partname]; !ok {
+				return fmt.Errorf("partition doesn't exist: %s", vars.Partname)
 			}
-			delete(disk.Partitions, name)
+			delete(disk.Partitions, vars.Partname)
 		} else {
 			found := false
 			for _, disk := range target.Disks {
 				if disk == nil {
 					continue
 				}
-				if _, ok := disk.Partitions[name]; ok {
-					delete(disk.Partitions, name)
+				if _, ok := disk.Partitions[vars.Partname]; ok {
+					delete(disk.Partitions, vars.Partname)
 					found = true
 				}
 			}
 			if !found {
-				return fmt.Errorf("partition doesn't exist: %s", name)
+				return fmt.Errorf("partition doesn't exist: %s", vars.Partname)
 			}
 		}
-	}
-	for _, name := range vars.FsDel {
-		delete(target.FileSystems, name)
 	}
 
 	entity.Flatten()

--- a/internal/app/wwctl/unset/apply.go
+++ b/internal/app/wwctl/unset/apply.go
@@ -1,0 +1,142 @@
+package unset
+
+import (
+	"fmt"
+
+	"github.com/warewulf/warewulf/internal/pkg/node"
+)
+
+// ValidateScopeRequirements checks that sub-entity unset flags have the
+// required scoping flags, using the scope map produced by CreateUnsetFlags.
+// Scope values: "disk" requires --diskname; "disk,part" requires both
+// --diskname and --partname; "fs" requires --fsname.
+func ValidateScopeRequirements(vars *Vars) error {
+	for flagName, boolPtr := range vars.UnsetFields {
+		if boolPtr == nil || !*boolPtr {
+			continue
+		}
+		switch vars.UnsetScopes[flagName] {
+		case "disk,part":
+			if vars.Diskname == "" || vars.Partname == "" {
+				return fmt.Errorf("--diskname and --partname must be specified with --%s", flagName)
+			}
+		case "disk":
+			if vars.Diskname == "" {
+				return fmt.Errorf("--diskname must be specified with --%s", flagName)
+			}
+		case "fs":
+			if vars.Fsname == "" {
+				return fmt.Errorf("--fsname must be specified with --%s", flagName)
+			}
+		}
+	}
+	return nil
+}
+
+// Entity is satisfied by *node.Node and *node.Profile.
+type Entity interface {
+	GetProfile() *node.Profile
+	UpdateFromProfile(src *node.Profile, changed func(string) bool)
+	Flatten()
+}
+
+// UpdateEntity applies all unset operations to entity, which must be a
+// *node.Node or *node.Profile.
+func UpdateEntity(entity Entity, vars *Vars) error {
+	target := entity.GetProfile()
+	// Build scope: a zero-valued Profile with map entries for the targeted
+	// sub-entity keys so UpdateFrom knows which sub-entity to clear fields on.
+	scope := node.NewProfile("")
+	scope.NetDevs[vars.Netname] = &node.NetDev{}
+	if vars.Diskname != "" {
+		disk := &node.Disk{}
+		if vars.Partname != "" {
+			disk.Partitions = map[string]*node.Partition{vars.Partname: {}}
+		}
+		scope.Disks = map[string]*node.Disk{vars.Diskname: disk}
+	}
+	if vars.Fsname != "" {
+		scope.FileSystems = map[string]*node.FileSystem{vars.Fsname: {}}
+	}
+
+	changed := func(lopt string) bool {
+		boolPtr, ok := vars.UnsetFields[lopt]
+		return ok && boolPtr != nil && *boolPtr
+	}
+	entity.UpdateFromProfile(&scope, changed)
+
+	// Delete specified tags
+	for _, key := range vars.Tags {
+		delete(target.Tags, key)
+	}
+	if target.Ipmi != nil {
+		for _, key := range vars.IpmiTags {
+			delete(target.Ipmi.Tags, key)
+		}
+	}
+	if len(vars.NetTags) > 0 {
+		if netDev, ok := target.NetDevs[vars.Netname]; ok && netDev != nil {
+			for _, key := range vars.NetTags {
+				delete(netDev.Tags, key)
+			}
+		}
+	}
+
+	// Delete entire objects by name
+	for _, name := range vars.NetDel {
+		delete(target.NetDevs, name)
+	}
+	for _, name := range vars.DiskDel {
+		delete(target.Disks, name)
+	}
+	for _, name := range vars.PartDel {
+		if vars.Diskname != "" {
+			disk, ok := target.Disks[vars.Diskname]
+			if !ok || disk == nil {
+				return fmt.Errorf("disk doesn't exist: %s", vars.Diskname)
+			}
+			if _, ok := disk.Partitions[name]; !ok {
+				return fmt.Errorf("partition doesn't exist: %s", name)
+			}
+			delete(disk.Partitions, name)
+		} else {
+			found := false
+			for _, disk := range target.Disks {
+				if disk == nil {
+					continue
+				}
+				if _, ok := disk.Partitions[name]; ok {
+					delete(disk.Partitions, name)
+					found = true
+				}
+			}
+			if !found {
+				return fmt.Errorf("partition doesn't exist: %s", name)
+			}
+		}
+	}
+	for _, name := range vars.FsDel {
+		delete(target.FileSystems, name)
+	}
+
+	entity.Flatten()
+
+	// Remove any empty map entries left after flattening
+	for netName, netDev := range target.NetDevs {
+		if node.ObjectIsEmpty(netDev) {
+			delete(target.NetDevs, netName)
+		}
+	}
+	for diskName, disk := range target.Disks {
+		if node.ObjectIsEmpty(disk) {
+			delete(target.Disks, diskName)
+		}
+	}
+	for fsName, fs := range target.FileSystems {
+		if node.ObjectIsEmpty(fs) {
+			delete(target.FileSystems, fsName)
+		}
+	}
+
+	return nil
+}

--- a/internal/app/wwctl/unset/vars.go
+++ b/internal/app/wwctl/unset/vars.go
@@ -3,19 +3,16 @@ package unset
 // Vars holds the parsed flags for an unset command. It is shared between
 // node unset and profile unset, which are structurally identical.
 type Vars struct {
-	UnsetYes    bool
-	UnsetForce  bool
-	UnsetFields map[string]*bool
-	UnsetScopes map[string]string
-	Netname     string
-	Diskname    string
-	Partname    string
-	Fsname      string
-	Tags        []string
-	IpmiTags    []string
-	NetTags     []string
-	NetDel      []string
-	DiskDel     []string
-	PartDel     []string
-	FsDel       []string
+	UnsetYes       bool
+	UnsetForce     bool
+	UnsetFields    map[string]*bool
+	UnsetScopes    map[string]string
+	Netname        string
+	Diskname       string
+	Partname       string
+	Fsname         string
+	NetnameChanged bool
+	Tags           []string
+	IpmiTags       []string
+	NetTags        []string
 }

--- a/internal/app/wwctl/unset/vars.go
+++ b/internal/app/wwctl/unset/vars.go
@@ -1,0 +1,21 @@
+package unset
+
+// Vars holds the parsed flags for an unset command. It is shared between
+// node unset and profile unset, which are structurally identical.
+type Vars struct {
+	UnsetYes    bool
+	UnsetForce  bool
+	UnsetFields map[string]*bool
+	UnsetScopes map[string]string
+	Netname     string
+	Diskname    string
+	Partname    string
+	Fsname      string
+	Tags        []string
+	IpmiTags    []string
+	NetTags     []string
+	NetDel      []string
+	DiskDel     []string
+	PartDel     []string
+	FsDel       []string
+}

--- a/internal/pkg/hostlist/hostlist.go
+++ b/internal/pkg/hostlist/hostlist.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-const Docstring = "Node patterns are a comma-separated list of individual pattern.\nEach pattern can either be a full node name or a node range like node[01-03,05]."
+const Docstring = "Node patterns are a comma-separated list of individual patterns.\nEach pattern can either be a full node name or a node range like node[01-03,05]."
 
 // Expand takes a slice of host strings, possibly containing comma-separated
 // values and bracketed ranges (e.g. "node[01-03]") and returns a fully expanded

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -102,7 +102,7 @@ Holds the disks of a node
 */
 type Disk struct {
 	id         string                `yaml:"-"                    json:"-"`
-	WipeTableP *bool                 `yaml:"wipe_table,omitempty" json:"wipe_table,omitempty" lopt:"diskwipe" comment:"whether or not the partition tables shall be wiped" name:"WipeTable"`
+	WipeTableP *bool                 `yaml:"wipe_table,omitempty" json:"wipe_table,omitempty" lopt:"diskwipe" comment:"whether or not the partition tables shall be wiped" name:"WipeTable" scope:"disk"`
 	Partitions map[string]*Partition `yaml:"partitions,omitempty" json:"partitions,omitempty"`
 }
 
@@ -112,13 +112,13 @@ Partitions map
 */
 type Partition struct {
 	id                  string `yaml:"-"                              json:"-"`
-	Number              string `yaml:"number,omitempty"               json:"number,omitempty"               lopt:"partnumber" comment:"the partition number (if not set, next free slot is used)" type:"uint"`
-	SizeMiB             string `yaml:"size_mib,omitempty"             json:"size_mib,omitempty"             lopt:"partsize"   comment:"the partition size (if not set, maximum possible size is used)" type:"uint"`
+	Number              string `yaml:"number,omitempty"               json:"number,omitempty"               lopt:"partnumber" comment:"the partition number (if not set, next free slot is used)" type:"uint"  scope:"disk,part"`
+	SizeMiB             string `yaml:"size_mib,omitempty"             json:"size_mib,omitempty"             lopt:"partsize"   comment:"the partition size (if not set, maximum possible size is used)" type:"uint" scope:"disk,part"`
 	StartMiB            string `yaml:"start_mib,omitempty"            json:"start_mib,omitempty"                              comment:"the start of the partition" type:"uint"`
-	TypeGuid            string `yaml:"type_guid,omitempty"            json:"type_guid,omitempty"            lopt:"parttype"   comment:"the partition type GUID"`
+	TypeGuid            string `yaml:"type_guid,omitempty"            json:"type_guid,omitempty"            lopt:"parttype"   comment:"the partition type GUID"                                                         scope:"disk,part"`
 	Guid                string `yaml:"guid,omitempty"                 json:"guid,omitempty"                                   comment:"the GPT unique partition GUID"`
-	WipePartitionEntryP *bool  `yaml:"wipe_partition_entry,omitempty" json:"wipe_partition_entry,omitempty" lopt:"partwipe"   comment:"if true, Ignition will clobber an existing partition if it does not match the config" name:"WipePartitionEntry"`
-	ShouldExistP        *bool  `yaml:"should_exist,omitempty"         json:"should_exist,omitempty"         lopt:"partcreate" comment:"create the partition if it does not exist" name:"ShouldExist"`
+	WipePartitionEntryP *bool  `yaml:"wipe_partition_entry,omitempty" json:"wipe_partition_entry,omitempty" lopt:"partwipe"   comment:"if true, Ignition will clobber an existing partition if it does not match the config" name:"WipePartitionEntry" scope:"disk,part"`
+	ShouldExistP        *bool  `yaml:"should_exist,omitempty"         json:"should_exist,omitempty"         lopt:"partcreate" comment:"create the partition if it does not exist" name:"ShouldExist"                        scope:"disk,part"`
 	ResizeP             *bool  `yaml:"resize,omitempty"               json:"resize,omitempty"                                 comment:"whether or not the existing partition should be resize" name:"Resize"`
 }
 
@@ -127,9 +127,9 @@ Definition of a filesystem. The device is uniq so its used as key
 */
 type FileSystem struct {
 	id              string   `yaml:"-"                         json:"-"`
-	Format          string   `yaml:"format,omitempty"          json:"format,omitempty"          lopt:"fsformat" comment:"format of the file system"`
-	Path            string   `yaml:"path,omitempty"            json:"path,omitempty"            lopt:"fspath"   comment:"the mount point of the file system"`
-	WipeFileSystemP *bool    `yaml:"wipe_filesystem,omitempty" json:"wipe_filesystem,omitempty" lopt:"fswipe"   comment:"wipe file system at boot" name:"WipeFileSystem"`
+	Format          string   `yaml:"format,omitempty"          json:"format,omitempty"          lopt:"fsformat" comment:"format of the file system"                                                   scope:"fs"`
+	Path            string   `yaml:"path,omitempty"            json:"path,omitempty"            lopt:"fspath"   comment:"the mount point of the file system"                                           scope:"fs"`
+	WipeFileSystemP *bool    `yaml:"wipe_filesystem,omitempty" json:"wipe_filesystem,omitempty" lopt:"fswipe"   comment:"wipe file system at boot" name:"WipeFileSystem"                               scope:"fs"`
 	Label           string   `yaml:"label,omitempty"           json:"label,omitempty"                           comment:"the label of the filesystem"`
 	Uuid            string   `yaml:"uuid,omitempty"            json:"uuid,omitempty"                            comment:"the uuid of the filesystem"`
 	Options         []string `yaml:"options,omitempty"         json:"options,omitempty"                         comment:"any additional options to be passed to the format-specific mkfs utility"`

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -82,17 +82,17 @@ type KernelConf struct {
 }
 
 type NetDev struct {
-	Type       string            `yaml:"type,omitempty"       json:"type,omitempty"       lopt:"type"       sopt:"T" comment:"device type of given network"`
-	OnBoot     wwtype.WWbool     `yaml:"onboot,omitempty"     json:"onbot,omitempty"      lopt:"onboot"              comment:"network device (true/false)"`
-	Device     string            `yaml:"device,omitempty"     json:"device,omitempty"     lopt:"netdev"     sopt:"N" comment:"the device for given network"`
-	Hwaddr     string            `yaml:"hwaddr,omitempty"     json:"hwaddr,omitempty"     lopt:"hwaddr"     sopt:"H" comment:"the device's HW address for given network" type:"MAC"`
-	Ipaddr     net.IP            `yaml:"ipaddr,omitempty"     json:"ipaddr,omitempty"     lopt:"ipaddr"     sopt:"I" comment:"IPv4 address in given network" type:"IP"`
-	Netmask    net.IP            `yaml:"netmask,omitempty"    json:"netmask,omitempty"    lopt:"netmask"    sopt:"M" comment:"the network's netmask" type:"IP"`
-	Gateway    net.IP            `yaml:"gateway,omitempty"    json:"gateway,omitempty"    lopt:"gateway"    sopt:"G" comment:"the node's IPv4 network device gateway" type:"IP"`
-	Ipaddr6    net.IP            `yaml:"ipaddr6,omitempty"    json:"ipaddr6,omitempty"    lopt:"ipaddr6"             comment:"IPv6 address in given network" type:"IP"`
-	PrefixLen6 string            `yaml:"prefixlen6,omitempty" json:"prefixlen6,omitempty" lopt:"prefixlen6"          comment:"the network's IPv6 prefix length" type:"uint"`
-	Gateway6   net.IP            `yaml:"gateway6,omitempty"   json:"gateway6,omitempty"   lopt:"gateway6"            comment:"the node's IPv6 network device gateway" type:"IP"`
-	MTU        string            `yaml:"mtu,omitempty"        json:"mtu,omitempty"        lopt:"mtu"                 comment:"the MTU" type:"uint"`
+	Type       string            `yaml:"type,omitempty"       json:"type,omitempty"       lopt:"type"       sopt:"T" comment:"device type of given network"                       scope:"net"`
+	OnBoot     wwtype.WWbool     `yaml:"onboot,omitempty"     json:"onbot,omitempty"      lopt:"onboot"              comment:"network device (true/false)"                          scope:"net"`
+	Device     string            `yaml:"device,omitempty"     json:"device,omitempty"     lopt:"netdev"     sopt:"N" comment:"the device for given network"                         scope:"net"`
+	Hwaddr     string            `yaml:"hwaddr,omitempty"     json:"hwaddr,omitempty"     lopt:"hwaddr"     sopt:"H" comment:"the device's HW address for given network" type:"MAC" scope:"net"`
+	Ipaddr     net.IP            `yaml:"ipaddr,omitempty"     json:"ipaddr,omitempty"     lopt:"ipaddr"     sopt:"I" comment:"IPv4 address in given network" type:"IP"              scope:"net"`
+	Netmask    net.IP            `yaml:"netmask,omitempty"    json:"netmask,omitempty"    lopt:"netmask"    sopt:"M" comment:"the network's netmask" type:"IP"                      scope:"net"`
+	Gateway    net.IP            `yaml:"gateway,omitempty"    json:"gateway,omitempty"    lopt:"gateway"    sopt:"G" comment:"the node's IPv4 network device gateway" type:"IP"     scope:"net"`
+	Ipaddr6    net.IP            `yaml:"ipaddr6,omitempty"    json:"ipaddr6,omitempty"    lopt:"ipaddr6"             comment:"IPv6 address in given network" type:"IP"              scope:"net"`
+	PrefixLen6 string            `yaml:"prefixlen6,omitempty" json:"prefixlen6,omitempty" lopt:"prefixlen6"          comment:"the network's IPv6 prefix length" type:"uint"          scope:"net"`
+	Gateway6   net.IP            `yaml:"gateway6,omitempty"   json:"gateway6,omitempty"   lopt:"gateway6"            comment:"the node's IPv6 network device gateway" type:"IP"     scope:"net"`
+	MTU        string            `yaml:"mtu,omitempty"        json:"mtu,omitempty"        lopt:"mtu"                 comment:"the MTU" type:"uint"                                  scope:"net"`
 	Tags       map[string]string `yaml:"tags,omitempty"       json:"tags,omitempty"`
 	primary    bool
 }

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -32,8 +32,8 @@ type Node struct {
 	id    string
 	valid bool // Is set true, if called by the constructor
 	// exported values
-	Discoverable wwtype.WWbool     `yaml:"discoverable,omitempty" json:"discoverable,omitempty" lopt:"discoverable" sopt:"e" comment:"Make discoverable in given network (true/false)"`
-	AssetKey     string            `yaml:"asset key,omitempty"    json:"asset key,omitempty"    lopt:"asset"                 comment:"Set the node's Asset tag (key)"`
+	Discoverable wwtype.WWbool     `yaml:"discoverable,omitempty" json:"discoverable,omitempty" lopt:"discoverable" sopt:"e" comment:"discoverable in given network (true/false)"`
+	AssetKey     string            `yaml:"asset key,omitempty"    json:"asset key,omitempty"    lopt:"asset"                 comment:"the node's Asset tag (key)"`
 	Profile      `yaml:"-,inline"` // include all values set in the profile, but inline them in yaml output if these are part of Node
 }
 
@@ -43,56 +43,56 @@ Holds the data which can be set for profiles and nodes.
 type Profile struct {
 	id string
 	// exported values
-	Profiles       []string               `yaml:"profiles,omitempty"         json:"profiles,omitempty"         lopt:"profile"             sopt:"P" comment:"Set the node's profile members (comma separated)"`
-	Comment        string                 `yaml:"comment,omitempty"          json:"comment,omitempty"          lopt:"comment"                      comment:"Set arbitrary string comment"`
-	ClusterName    string                 `yaml:"cluster name,omitempty"     json:"cluster name,omitempty"     lopt:"cluster"             sopt:"c" comment:"Set cluster group"`
-	ImageName      string                 `yaml:"image name,omitempty"       json:"image name,omitempty"       lopt:"image"                        comment:"Set image name"`
-	Ipxe           string                 `yaml:"ipxe template,omitempty"    json:"ipxe template,omitempty"    lopt:"ipxe"                         comment:"Set the iPXE template name"`
-	RuntimeOverlay []string               `yaml:"runtime overlay,omitempty"  json:"runtime overlay,omitempty"  lopt:"runtime-overlays"    sopt:"R" comment:"Set the runtime overlay"`
-	SystemOverlay  []string               `yaml:"system overlay,omitempty"   json:"system overlay,omitempty"   lopt:"system-overlays"     sopt:"O" comment:"Set the system overlay"`
+	Profiles       []string               `yaml:"profiles,omitempty"         json:"profiles,omitempty"         lopt:"profile"             sopt:"P" comment:"the node's profile members (comma separated)"`
+	Comment        string                 `yaml:"comment,omitempty"          json:"comment,omitempty"          lopt:"comment"                      comment:"arbitrary string comment"`
+	ClusterName    string                 `yaml:"cluster name,omitempty"     json:"cluster name,omitempty"     lopt:"cluster"             sopt:"c" comment:"cluster group"`
+	ImageName      string                 `yaml:"image name,omitempty"       json:"image name,omitempty"       lopt:"image"                        comment:"image name"`
+	Ipxe           string                 `yaml:"ipxe template,omitempty"    json:"ipxe template,omitempty"    lopt:"ipxe"                         comment:"the iPXE template name"`
+	RuntimeOverlay []string               `yaml:"runtime overlay,omitempty"  json:"runtime overlay,omitempty"  lopt:"runtime-overlays"    sopt:"R" comment:"the runtime overlay"`
+	SystemOverlay  []string               `yaml:"system overlay,omitempty"   json:"system overlay,omitempty"   lopt:"system-overlays"     sopt:"O" comment:"the system overlay"`
 	Kernel         *KernelConf            `yaml:"kernel,omitempty"           json:"kernel,omitempty"`
 	Ipmi           *IpmiConf              `yaml:"ipmi,omitempty"             json:"ipmi,omitempty"`
-	Init           string                 `yaml:"init,omitempty"             json:"init,omitempty"             lopt:"init"                sopt:"i" comment:"Define the init process to boot the image"`
-	Root           string                 `yaml:"root,omitempty"             json:"root,omitempty"             lopt:"root"                         comment:"Define the rootfs" `
+	Init           string                 `yaml:"init,omitempty"             json:"init,omitempty"             lopt:"init"                sopt:"i" comment:"the init process to boot the image"`
+	Root           string                 `yaml:"root,omitempty"             json:"root,omitempty"             lopt:"root"                         comment:"the rootfs" `
 	NetDevs        map[string]*NetDev     `yaml:"network devices,omitempty"  json:"network devices,omitempty"`
 	Tags           map[string]string      `yaml:"tags,omitempty"             json:"tags,omitempty"`
-	PrimaryNetDev  string                 `yaml:"primary network,omitempty"  json:"primary network,omitempty"  lopt:"primarynet"          sopt:"p" comment:"Set the primary network interface"`
+	PrimaryNetDev  string                 `yaml:"primary network,omitempty"  json:"primary network,omitempty"  lopt:"primarynet"          sopt:"p" comment:"the primary network interface"`
 	Disks          map[string]*Disk       `yaml:"disks,omitempty"            json:"disks,omitempty"`
 	FileSystems    map[string]*FileSystem `yaml:"filesystems,omitempty"      json:"filesystems,omitempty"`
 	Resources      map[string]Resource    `yaml:"resources,omitempty"        json:"resources,omitempty"`
 }
 
 type IpmiConf struct {
-	UserName   string            `yaml:"username,omitempty"   json:"username,omitempty"   lopt:"ipmiuser"       comment:"Set the IPMI username"`
-	Password   string            `yaml:"password,omitempty"   json:"password,omitempty"   lopt:"ipmipass"       comment:"Set the IPMI password"`
-	Ipaddr     net.IP            `yaml:"ipaddr,omitempty"     json:"ipaddr,omitempty"     lopt:"ipmiaddr"       comment:"Set the IPMI IP address" type:"IP"`
-	Gateway    net.IP            `yaml:"gateway,omitempty"    json:"gateway,omitempty"    lopt:"ipmigateway"    comment:"Set the IPMI gateway" type:"IP"`
-	Netmask    net.IP            `yaml:"netmask,omitempty"    json:"netmask,omitempty"    lopt:"ipminetmask"    comment:"Set the IPMI netmask" type:"IP"`
-	Port       string            `yaml:"port,omitempty"       json:"port,omitempty"       lopt:"ipmiport"       comment:"Set the IPMI port"`
-	Interface  string            `yaml:"interface,omitempty"  json:"interface,omitempty"  lopt:"ipmiinterface"  comment:"Set the node's IPMI interface (defaults: 'lan')"`
-	EscapeChar string            `yaml:"escapechar,omitempty" json:"escapechar,omitempty" lopt:"ipmiescapechar" comment:"Set the IPMI escape character (defaults: '~')"`
-	Write      wwtype.WWbool     `yaml:"write,omitempty"      json:"write,omitempty"      lopt:"ipmiwrite"      comment:"Enable the write of ipmi configuration (true/false)"`
+	UserName   string            `yaml:"username,omitempty"   json:"username,omitempty"   lopt:"ipmiuser"       comment:"the IPMI username"`
+	Password   string            `yaml:"password,omitempty"   json:"password,omitempty"   lopt:"ipmipass"       comment:"the IPMI password"`
+	Ipaddr     net.IP            `yaml:"ipaddr,omitempty"     json:"ipaddr,omitempty"     lopt:"ipmiaddr"       comment:"the IPMI IP address" type:"IP"`
+	Gateway    net.IP            `yaml:"gateway,omitempty"    json:"gateway,omitempty"    lopt:"ipmigateway"    comment:"the IPMI gateway" type:"IP"`
+	Netmask    net.IP            `yaml:"netmask,omitempty"    json:"netmask,omitempty"    lopt:"ipminetmask"    comment:"the IPMI netmask" type:"IP"`
+	Port       string            `yaml:"port,omitempty"       json:"port,omitempty"       lopt:"ipmiport"       comment:"the IPMI port"`
+	Interface  string            `yaml:"interface,omitempty"  json:"interface,omitempty"  lopt:"ipmiinterface"  comment:"the node's IPMI interface (defaults: 'lan')"`
+	EscapeChar string            `yaml:"escapechar,omitempty" json:"escapechar,omitempty" lopt:"ipmiescapechar" comment:"the IPMI escape character (defaults: '~')"`
+	Write      wwtype.WWbool     `yaml:"write,omitempty"      json:"write,omitempty"      lopt:"ipmiwrite"      comment:"writing of IPMI configuration (true/false)"`
 	Template   string            `yaml:"template,omitempty"   json:"template,omitempty"   lopt:"ipmitemplate"   comment:"template used for ipmi command"`
 	Tags       map[string]string `yaml:"tags,omitempty"       json:"tags,omitempty"`
 }
 
 type KernelConf struct {
-	Version string   `yaml:"version,omitempty" json:"version,omitempty" lopt:"kernelversion"          comment:"Set kernel version"`
-	Args    []string `yaml:"args,omitempty"    json:"args,omitempty"    lopt:"kernelargs"    sopt:"A" comment:"Set kernel arguments"`
+	Version string   `yaml:"version,omitempty" json:"version,omitempty" lopt:"kernelversion"          comment:"kernel version"`
+	Args    []string `yaml:"args,omitempty"    json:"args,omitempty"    lopt:"kernelargs"    sopt:"A" comment:"kernel arguments"`
 }
 
 type NetDev struct {
-	Type       string            `yaml:"type,omitempty"       json:"type,omitempty"       lopt:"type"       sopt:"T" comment:"Set device type of given network"`
-	OnBoot     wwtype.WWbool     `yaml:"onboot,omitempty"     json:"onbot,omitempty"      lopt:"onboot"              comment:"Enable/disable network device (true/false)"`
-	Device     string            `yaml:"device,omitempty"     json:"device,omitempty"     lopt:"netdev"     sopt:"N" comment:"Set the device for given network"`
-	Hwaddr     string            `yaml:"hwaddr,omitempty"     json:"hwaddr,omitempty"     lopt:"hwaddr"     sopt:"H" comment:"Set the device's HW address for given network" type:"MAC"`
+	Type       string            `yaml:"type,omitempty"       json:"type,omitempty"       lopt:"type"       sopt:"T" comment:"device type of given network"`
+	OnBoot     wwtype.WWbool     `yaml:"onboot,omitempty"     json:"onbot,omitempty"      lopt:"onboot"              comment:"network device (true/false)"`
+	Device     string            `yaml:"device,omitempty"     json:"device,omitempty"     lopt:"netdev"     sopt:"N" comment:"the device for given network"`
+	Hwaddr     string            `yaml:"hwaddr,omitempty"     json:"hwaddr,omitempty"     lopt:"hwaddr"     sopt:"H" comment:"the device's HW address for given network" type:"MAC"`
 	Ipaddr     net.IP            `yaml:"ipaddr,omitempty"     json:"ipaddr,omitempty"     lopt:"ipaddr"     sopt:"I" comment:"IPv4 address in given network" type:"IP"`
-	Netmask    net.IP            `yaml:"netmask,omitempty"    json:"netmask,omitempty"    lopt:"netmask"    sopt:"M" comment:"Set the networks netmask" type:"IP"`
-	Gateway    net.IP            `yaml:"gateway,omitempty"    json:"gateway,omitempty"    lopt:"gateway"    sopt:"G" comment:"Set the node's IPv4 network device gateway" type:"IP"`
+	Netmask    net.IP            `yaml:"netmask,omitempty"    json:"netmask,omitempty"    lopt:"netmask"    sopt:"M" comment:"the network's netmask" type:"IP"`
+	Gateway    net.IP            `yaml:"gateway,omitempty"    json:"gateway,omitempty"    lopt:"gateway"    sopt:"G" comment:"the node's IPv4 network device gateway" type:"IP"`
 	Ipaddr6    net.IP            `yaml:"ipaddr6,omitempty"    json:"ipaddr6,omitempty"    lopt:"ipaddr6"             comment:"IPv6 address in given network" type:"IP"`
-	PrefixLen6 string            `yaml:"prefixlen6,omitempty" json:"prefixlen6,omitempty" lopt:"prefixlen6"          comment:"Set the networks IPv6 prefix length" type:"uint"`
-	Gateway6   net.IP            `yaml:"gateway6,omitempty"   json:"gateway6,omitempty"   lopt:"gateway6"            comment:"Set the node's IPv6 network device gateway" type:"IP"`
-	MTU        string            `yaml:"mtu,omitempty"        json:"mtu,omitempty"        lopt:"mtu"                 comment:"Set the mtu" type:"uint"`
+	PrefixLen6 string            `yaml:"prefixlen6,omitempty" json:"prefixlen6,omitempty" lopt:"prefixlen6"          comment:"the network's IPv6 prefix length" type:"uint"`
+	Gateway6   net.IP            `yaml:"gateway6,omitempty"   json:"gateway6,omitempty"   lopt:"gateway6"            comment:"the node's IPv6 network device gateway" type:"IP"`
+	MTU        string            `yaml:"mtu,omitempty"        json:"mtu,omitempty"        lopt:"mtu"                 comment:"the MTU" type:"uint"`
 	Tags       map[string]string `yaml:"tags,omitempty"       json:"tags,omitempty"`
 	primary    bool
 }
@@ -112,13 +112,13 @@ Partitions map
 */
 type Partition struct {
 	id                  string `yaml:"-"                              json:"-"`
-	Number              string `yaml:"number,omitempty"               json:"number,omitempty"               lopt:"partnumber" comment:"Set the partition number, if not set next free slot is used" type:"uint"`
-	SizeMiB             string `yaml:"size_mib,omitempty"             json:"size_mib,omitempty"             lopt:"partsize"   comment:"Set the size of the partition, if not set maximal possible size is used" type:"uint"`
+	Number              string `yaml:"number,omitempty"               json:"number,omitempty"               lopt:"partnumber" comment:"the partition number (if not set, next free slot is used)" type:"uint"`
+	SizeMiB             string `yaml:"size_mib,omitempty"             json:"size_mib,omitempty"             lopt:"partsize"   comment:"the partition size (if not set, maximum possible size is used)" type:"uint"`
 	StartMiB            string `yaml:"start_mib,omitempty"            json:"start_mib,omitempty"                              comment:"the start of the partition" type:"uint"`
-	TypeGuid            string `yaml:"type_guid,omitempty"            json:"type_guid,omitempty"            lopt:"parttype"   comment:"Set the partition type GUID"`
+	TypeGuid            string `yaml:"type_guid,omitempty"            json:"type_guid,omitempty"            lopt:"parttype"   comment:"the partition type GUID"`
 	Guid                string `yaml:"guid,omitempty"                 json:"guid,omitempty"                                   comment:"the GPT unique partition GUID"`
 	WipePartitionEntryP *bool  `yaml:"wipe_partition_entry,omitempty" json:"wipe_partition_entry,omitempty" lopt:"partwipe"   comment:"if true, Ignition will clobber an existing partition if it does not match the config" name:"WipePartitionEntry"`
-	ShouldExistP        *bool  `yaml:"should_exist,omitempty"         json:"should_exist,omitempty"         lopt:"partcreate" comment:"Create partition if it does not exist" name:"ShouldExist"`
+	ShouldExistP        *bool  `yaml:"should_exist,omitempty"         json:"should_exist,omitempty"         lopt:"partcreate" comment:"create the partition if it does not exist" name:"ShouldExist"`
 	ResizeP             *bool  `yaml:"resize,omitempty"               json:"resize,omitempty"                                 comment:"whether or not the existing partition should be resize" name:"Resize"`
 }
 

--- a/internal/pkg/node/flags.go
+++ b/internal/pkg/node/flags.go
@@ -115,7 +115,7 @@ func recursiveCreateFlags(obj interface{}, baseCmd *cobra.Command) {
 		} else if field.Anonymous {
 			recursiveCreateFlags(fieldVal.Addr().Interface(), baseCmd)
 
-		} else if field.Type.Kind() == reflect.Ptr {
+		} else if field.Type.Kind() == reflect.Ptr && !fieldVal.IsNil() {
 			recursiveCreateFlags(fieldVal.Interface(), baseCmd)
 
 		} else if field.Type.Kind() == reflect.Struct {
@@ -126,7 +126,10 @@ func recursiveCreateFlags(obj interface{}, baseCmd *cobra.Command) {
 			case reflect.String, reflect.Interface:
 				continue
 			case reflect.Pointer, reflect.Slice, reflect.Map:
-				// add a map with key UNDEF so that it can hold values N.B. UNDEF can never be added through command line
+				// Map fields need a concrete entry to recurse into so sub-field flags can be
+				// registered. If the map is empty, create a synthetic "UNDEF" entry for this
+				// purpose. "UNDEF" is never a valid user-supplied key and is stripped out
+				// before any changes are persisted.
 				key := reflect.ValueOf("UNDEF")
 				if fieldVal.Len() == 0 {
 					if fieldVal.IsNil() {
@@ -254,3 +257,87 @@ func createFlags(baseCmd *cobra.Command,
 		}
 	}
 }
+
+/*
+CreateUnsetFlags creates boolean flags for unsetting fields.
+Returns a map from flag name to bool pointer.
+*/
+
+func (nodeConf *Node) CreateUnsetFlags(baseCmd *cobra.Command) map[string]*bool {
+	unsetMap := make(map[string]*bool)
+	recursiveCreateUnsetFlags(nodeConf, baseCmd, unsetMap)
+	return unsetMap
+}
+
+func (profileConf *Profile) CreateUnsetFlags(baseCmd *cobra.Command) map[string]*bool {
+	unsetMap := make(map[string]*bool)
+	recursiveCreateUnsetFlags(profileConf, baseCmd, unsetMap)
+	return unsetMap
+}
+
+func recursiveCreateUnsetFlags(obj interface{}, baseCmd *cobra.Command, unsetMap map[string]*bool) {
+	elemType := reflect.TypeOf(obj).Elem()
+	elemVal := reflect.ValueOf(obj).Elem()
+
+	for i := 0; i < elemVal.NumField(); i++ {
+		field := elemType.Field(i)
+		fieldVal := elemVal.Field(i)
+
+		if !field.IsExported() {
+			continue
+		}
+
+		if field.Tag.Get("comment") != "" {
+			// Create boolean flag for this field
+			createUnsetFlag(baseCmd, field, unsetMap)
+		} else if field.Anonymous {
+			recursiveCreateUnsetFlags(fieldVal.Addr().Interface(), baseCmd, unsetMap)
+		} else if field.Type.Kind() == reflect.Ptr && !fieldVal.IsNil() {
+			recursiveCreateUnsetFlags(fieldVal.Interface(), baseCmd, unsetMap)
+		} else if field.Type.Kind() == reflect.Struct {
+			recursiveCreateUnsetFlags(fieldVal.Addr().Interface(), baseCmd, unsetMap)
+		} else if field.Type.Kind() == reflect.Map {
+			switch field.Type.Elem().Kind() {
+			case reflect.String, reflect.Interface:
+				continue
+			case reflect.Pointer, reflect.Slice, reflect.Map:
+				// Map fields need a concrete entry to recurse into so sub-field flags can be
+				// registered. If the map is empty, create a synthetic "UNDEF" entry for this
+				// purpose. "UNDEF" is never a valid user-supplied key and is stripped out
+				// before any changes are persisted.
+				key := reflect.ValueOf("UNDEF")
+				if fieldVal.Len() == 0 {
+					if fieldVal.IsNil() {
+						fieldVal.Set(reflect.MakeMap(field.Type))
+					}
+					newPtr := reflect.New(field.Type.Elem().Elem())
+					fieldVal.SetMapIndex(key, newPtr)
+				} else {
+					key = fieldVal.MapKeys()[0]
+				}
+				recursiveCreateUnsetFlags(fieldVal.MapIndex(key).Interface(), baseCmd, unsetMap)
+			}
+		}
+	}
+}
+
+func createUnsetFlag(baseCmd *cobra.Command, myType reflect.StructField, unsetMap map[string]*bool) {
+	if myType.Tag.Get("lopt") != "" {
+		flagName := myType.Tag.Get("lopt")
+		shortOpt := myType.Tag.Get("sopt")
+
+		// Create a new bool variable for this flag
+		boolPtr := new(bool)
+		unsetMap[flagName] = boolPtr
+
+		comment := myType.Tag.Get("comment")
+
+		// Create boolean flag with short option if available
+		if shortOpt != "" {
+			baseCmd.PersistentFlags().BoolVarP(boolPtr, flagName, shortOpt, false, comment)
+		} else {
+			baseCmd.PersistentFlags().BoolVar(boolPtr, flagName, false, comment)
+		}
+	}
+}
+

--- a/internal/pkg/node/flags.go
+++ b/internal/pkg/node/flags.go
@@ -260,22 +260,26 @@ func createFlags(baseCmd *cobra.Command,
 
 /*
 CreateUnsetFlags creates boolean flags for unsetting fields.
-Returns a map from flag name to bool pointer.
+Returns a map from flag name to *bool (whether the flag was set by the user)
+and a map from flag name to required scope (values: "disk", "disk,part", "fs").
+Fields with no scope restriction have no entry in the scope map.
+The scope values are read directly from the "scope" struct tag on each field.
 */
-
-func (nodeConf *Node) CreateUnsetFlags(baseCmd *cobra.Command) map[string]*bool {
+func (nodeConf *Node) CreateUnsetFlags(baseCmd *cobra.Command) (map[string]*bool, map[string]string) {
 	unsetMap := make(map[string]*bool)
-	recursiveCreateUnsetFlags(nodeConf, baseCmd, unsetMap)
-	return unsetMap
+	scopeMap := make(map[string]string)
+	recursiveCreateUnsetFlags(nodeConf, baseCmd, unsetMap, scopeMap)
+	return unsetMap, scopeMap
 }
 
-func (profileConf *Profile) CreateUnsetFlags(baseCmd *cobra.Command) map[string]*bool {
+func (profileConf *Profile) CreateUnsetFlags(baseCmd *cobra.Command) (map[string]*bool, map[string]string) {
 	unsetMap := make(map[string]*bool)
-	recursiveCreateUnsetFlags(profileConf, baseCmd, unsetMap)
-	return unsetMap
+	scopeMap := make(map[string]string)
+	recursiveCreateUnsetFlags(profileConf, baseCmd, unsetMap, scopeMap)
+	return unsetMap, scopeMap
 }
 
-func recursiveCreateUnsetFlags(obj interface{}, baseCmd *cobra.Command, unsetMap map[string]*bool) {
+func recursiveCreateUnsetFlags(obj interface{}, baseCmd *cobra.Command, unsetMap map[string]*bool, scopeMap map[string]string) {
 	elemType := reflect.TypeOf(obj).Elem()
 	elemVal := reflect.ValueOf(obj).Elem()
 
@@ -288,14 +292,13 @@ func recursiveCreateUnsetFlags(obj interface{}, baseCmd *cobra.Command, unsetMap
 		}
 
 		if field.Tag.Get("comment") != "" {
-			// Create boolean flag for this field
-			createUnsetFlag(baseCmd, field, unsetMap)
+			createUnsetFlag(baseCmd, field, unsetMap, scopeMap)
 		} else if field.Anonymous {
-			recursiveCreateUnsetFlags(fieldVal.Addr().Interface(), baseCmd, unsetMap)
+			recursiveCreateUnsetFlags(fieldVal.Addr().Interface(), baseCmd, unsetMap, scopeMap)
 		} else if field.Type.Kind() == reflect.Ptr && !fieldVal.IsNil() {
-			recursiveCreateUnsetFlags(fieldVal.Interface(), baseCmd, unsetMap)
+			recursiveCreateUnsetFlags(fieldVal.Interface(), baseCmd, unsetMap, scopeMap)
 		} else if field.Type.Kind() == reflect.Struct {
-			recursiveCreateUnsetFlags(fieldVal.Addr().Interface(), baseCmd, unsetMap)
+			recursiveCreateUnsetFlags(fieldVal.Addr().Interface(), baseCmd, unsetMap, scopeMap)
 		} else if field.Type.Kind() == reflect.Map {
 			switch field.Type.Elem().Kind() {
 			case reflect.String, reflect.Interface:
@@ -315,24 +318,25 @@ func recursiveCreateUnsetFlags(obj interface{}, baseCmd *cobra.Command, unsetMap
 				} else {
 					key = fieldVal.MapKeys()[0]
 				}
-				recursiveCreateUnsetFlags(fieldVal.MapIndex(key).Interface(), baseCmd, unsetMap)
+				recursiveCreateUnsetFlags(fieldVal.MapIndex(key).Interface(), baseCmd, unsetMap, scopeMap)
 			}
 		}
 	}
 }
 
-func createUnsetFlag(baseCmd *cobra.Command, myType reflect.StructField, unsetMap map[string]*bool) {
+func createUnsetFlag(baseCmd *cobra.Command, myType reflect.StructField, unsetMap map[string]*bool, scopeMap map[string]string) {
 	if myType.Tag.Get("lopt") != "" {
 		flagName := myType.Tag.Get("lopt")
 		shortOpt := myType.Tag.Get("sopt")
 
-		// Create a new bool variable for this flag
 		boolPtr := new(bool)
 		unsetMap[flagName] = boolPtr
 
-		comment := myType.Tag.Get("comment")
+		if scope := myType.Tag.Get("scope"); scope != "" {
+			scopeMap[flagName] = scope
+		}
 
-		// Create boolean flag with short option if available
+		comment := myType.Tag.Get("comment")
 		if shortOpt != "" {
 			baseCmd.PersistentFlags().BoolVarP(boolPtr, flagName, shortOpt, false, comment)
 		} else {

--- a/internal/pkg/node/flags.go
+++ b/internal/pkg/node/flags.go
@@ -340,4 +340,3 @@ func createUnsetFlag(baseCmd *cobra.Command, myType reflect.StructField, unsetMa
 		}
 	}
 }
-

--- a/internal/pkg/node/update.go
+++ b/internal/pkg/node/update.go
@@ -19,6 +19,28 @@ func (dst *Profile) UpdateFrom(src *Profile, changed func(string) bool) {
 	recursiveUpdateFrom(reflect.ValueOf(dst).Elem(), reflect.ValueOf(src).Elem(), changed)
 }
 
+// UpdateFromProfile applies src as a profile-shaped source, copying fields
+// where changed returns true. Wraps UpdateFrom by embedding src in a Node.
+func (dst *Node) UpdateFromProfile(src *Profile, changed func(string) bool) {
+	dst.UpdateFrom(&Node{Profile: *src}, changed)
+}
+
+// UpdateFromProfile applies src as a profile-shaped source, copying fields
+// where changed returns true.
+func (dst *Profile) UpdateFromProfile(src *Profile, changed func(string) bool) {
+	dst.UpdateFrom(src, changed)
+}
+
+// GetProfile returns the Profile embedded in the Node.
+func (n *Node) GetProfile() *Profile {
+	return &n.Profile
+}
+
+// GetProfile returns the Profile itself.
+func (p *Profile) GetProfile() *Profile {
+	return p
+}
+
 func recursiveUpdateFrom(dst, src reflect.Value, changed func(string) bool) {
 	srcType := src.Type()
 

--- a/internal/pkg/node/util.go
+++ b/internal/pkg/node/util.go
@@ -59,7 +59,12 @@ func ObjectIsEmpty(obj interface{}) bool {
 	varType := reflect.TypeOf(obj)
 	varVal := reflect.ValueOf(obj)
 	if varType.Kind() == reflect.Ptr && !varVal.IsNil() {
-		return ObjectIsEmpty(varVal.Elem().Interface())
+		elem := varVal.Elem()
+		if elem.Kind() == reflect.Struct {
+			return ObjectIsEmpty(elem.Interface())
+		}
+		// Non-struct pointer (e.g. *bool): non-nil means it has an explicit value
+		return false
 	}
 	if varVal.IsZero() {
 		return true
@@ -70,7 +75,7 @@ func ObjectIsEmpty(obj interface{}) bool {
 			if val != "" {
 				return false
 			}
-		} else if varType.Field(i).Type == reflect.TypeOf(map[string]string{}) {
+		} else if varType.Field(i).Type.Kind() == reflect.Map {
 			if varVal.Field(i).Len() != 0 {
 				return false
 			}

--- a/userdocs/getting-started/quick-reference.rst
+++ b/userdocs/getting-started/quick-reference.rst
@@ -94,7 +94,7 @@ Adding a node
      --kernelargs="quiet crashkernel=no"
 
    # Un-set a field (revert to profile/default value)
-   wwctl node set n1 --image=UNDEF
+   wwctl node unset n1 --image
 
 Network interfaces
 ==================

--- a/userdocs/nodes/nodes.rst
+++ b/userdocs/nodes/nodes.rst
@@ -129,15 +129,15 @@ use the scoping flags ``--netname``, ``--diskname``, ``--partname``, and
 
    wwctl node unset n1 --netname=secondary --ipaddr
 
-Entire sub-objects can be removed by name using ``--net``, ``--disk``,
-``--part``, and ``--fs``. For ``--part``, an optional ``--diskname`` scopes the
-deletion to a specific disk; without it, the named partition is removed from
-all disks.
+If a scoping flag is given without any sub-field flags, the entire named
+sub-entity is removed. For ``--partname``, an optional ``--diskname`` scopes
+the deletion to a specific disk; without it, the named partition is removed
+from all disks.
 
 .. code-block:: shell
 
-   wwctl node unset n1 --net=secondary
-   wwctl node unset n1 --part=swap --diskname=/dev/vda
+   wwctl node unset n1 --netname=secondary
+   wwctl node unset n1 --partname=swap --diskname=/dev/vda
 
 Tags can be selectively removed with ``--tag``, ``--nettag``, and
 ``--ipmitag``.
@@ -151,8 +151,8 @@ A full list of available flags is shown by ``wwctl node unset --help``.
 
 .. note::
 
-   You can also un-set a field by setting its value to ``UNDEF`` or ``UNSET``
-   with ``wwctl node set``.
+   You can also un-set some fields by setting their value to ``UNDEF`` or
+   ``UNSET`` with ``wwctl node set``.
 
    .. code-block:: shell
 

--- a/userdocs/nodes/nodes.rst
+++ b/userdocs/nodes/nodes.rst
@@ -130,11 +130,14 @@ use the scoping flags ``--netname``, ``--diskname``, ``--partname``, and
    wwctl node unset n1 --netname=secondary --ipaddr
 
 Entire sub-objects can be removed by name using ``--net``, ``--disk``,
-``--part``, and ``--fs``.
+``--part``, and ``--fs``. For ``--part``, an optional ``--diskname`` scopes the
+deletion to a specific disk; without it, the named partition is removed from
+all disks.
 
 .. code-block:: shell
 
    wwctl node unset n1 --net=secondary
+   wwctl node unset n1 --part=swap --diskname=/dev/vda
 
 Tags can be selectively removed with ``--tag``, ``--nettag``, and
 ``--ipmitag``.

--- a/userdocs/nodes/nodes.rst
+++ b/userdocs/nodes/nodes.rst
@@ -113,13 +113,47 @@ To include an explicit comma in the value, enclose the value in inner-quotes.
 Un-setting Node Fields
 ----------------------
 
-To un-set a field value, set the value to ``UNDEF`` or ``UNSET`` (both are
-accepted).
+Node fields can be cleared using the ``wwctl node unset`` command. Each field is
+specified as a boolean flag; the field is cleared when the flag is present.
 
 .. code-block:: shell
 
-   wwctl node set n1 \
-     --image=UNDEF
+   wwctl node unset n1 --image
+   wwctl node unset n1 --kernelargs
+
+To unset fields on a specific network interface, disk, partition, or filesystem,
+use the scoping flags ``--netname``, ``--diskname``, ``--partname``, and
+``--fsname``.
+
+.. code-block:: shell
+
+   wwctl node unset n1 --netname=secondary --ipaddr
+
+Entire sub-objects can be removed by name using ``--net``, ``--disk``,
+``--part``, and ``--fs``.
+
+.. code-block:: shell
+
+   wwctl node unset n1 --net=secondary
+
+Tags can be selectively removed with ``--tag``, ``--nettag``, and
+``--ipmitag``.
+
+.. code-block:: shell
+
+   wwctl node unset n1 --tag=localtime
+   wwctl node unset n1 --nettag=DNS1
+
+A full list of available flags is shown by ``wwctl node unset --help``.
+
+.. note::
+
+   You can also un-set a field by setting its value to ``UNDEF`` or ``UNSET``
+   with ``wwctl node set``.
+
+   .. code-block:: shell
+
+      wwctl node set n1 --image=UNDEF
 
 Configuring an Image
 ====================

--- a/userdocs/nodes/profiles.rst
+++ b/userdocs/nodes/profiles.rst
@@ -76,6 +76,17 @@ make sense anywhere but a node (e.g., ``--hwaddr`` and ``--ipaddr``).
      --image=rockylinux-9 \
      --netmask=255.255.255.0
 
+Un-setting Profile Fields
+-------------------------
+
+Profile fields can be cleared using the ``wwctl profile unset`` command, which
+works the same way as ``wwctl node unset``.
+
+.. code-block:: shell
+
+   wwctl profile unset default --image
+   wwctl profile unset default --netname=default --netmask
+
 Multiple Profiles
 =================
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add wwctl node unset and wwctl profile unset subcommands. These provide a dedicated way to clear individual configuration properties from nodes and profiles without needing to pass use values like UNDEF or UNSET, which don't work in all cases (e.g., with IP-address values).

- wwctl node unset — clear properties on nodes matching a hostlist pattern
- wwctl profile unset — clear properties on named profiles

Each command includes per-field boolean flags auto-generated from the Node/Profile struct tags (same fields as set).

Tag deletion is done with --tag, --ipmitag, and --nettag which accept comma-separated key names to remove

Sub-entity deletion is done with --net, --disk, --part, --fs.

Sub-entity field unsets are scoped with --netname, --diskname, --partname, --fsname, matching the scoping behavior of the set command. Attempting to unset a sub-entity field (e.g., --partnumber) without the required scoping flags produces an error.

Hostlist expansion — n[01-10] patterns work as expected.

Comprehensive test coverage: ~100 test cases across both commands, including scoped and unscoped sub-entity operations, error cases, and regression tests for the scoping behavior.

## This fixes or addresses the following GitHub issues:

- Fixes #1954

## Other changes

- Fields in datastructure.go are now verb-neutral (e.g., "the IPMI username" instead of "Set the IPMI username"), so both set and unset commands can use them directly without string manipulation.

- Added nil-pointer guards to recursiveCreateFlags and recursiveCreateUnsetFlags for pointer fields, matching the existing guard in recursiveApplyUnset.

- Fixed a plural typo in the hostlist docstring.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary

## Examples

```
# Remove a node-level netmask override, exposing the profile's value
wwctl node unset --netmask n01

# Clear the image assignment from a profile
wwctl profile unset --image default

# Unset IP and netmask on the default network device
wwctl node unset --ipaddr --netmask n01

# Unset gateway on a specific network device
wwctl node unset --netname eth1 --gateway n01

# Delete an entire network device
wwctl node unset --net=eth1 n01

# Delete a disk and all its partitions
wwctl node unset --disk=/dev/vdb n01

# Delete a single partition (searched across all disks)
wwctl node unset --part=swap n01

# Delete a filesystem entry
wwctl node unset --fs=/dev/disk/by-partlabel/scratch n01

# Delete multiple network devices at once
wwctl node unset --net=eth1,eth2 n01

# Remove specific node tags
wwctl node unset --tag=mykey,otherkey n01

# Remove an IPMI tag
wwctl node unset --ipmitag=location n01

# Remove a network device tag on a specific network
wwctl node unset --netname eth0 --nettag=vlan n01

# Clear the comment on a range of nodes
wwctl node unset --comment n[001-100]

# Clear overlays from a profile
wwctl profile unset --runtime-overlays compute

# Remove a disk definition from a profile
wwctl profile unset --disk=/dev/vda compute

# Unset a partition field on a specific disk and partition
wwctl node unset --diskname=/dev/vda --partname=root --partnumber n01

# Unset a filesystem field on a specific filesystem
wwctl node unset --fsname=/dev/disk/by-partlabel/var --fsformat n01
```