### PR TITLE
Fix a typo in ipmiwrite comment

### DIFF
--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -64,7 +64,7 @@ type IpmiConf struct {
 	Port       string            `yaml:"port,omitempty"       json:"port,omitempty"       lopt:"ipmiport"       comment:"Set the IPMI port"`
 	Interface  string            `yaml:"interface,omitempty"  json:"interface,omitempty"  lopt:"ipmiinterface"  comment:"Set the node's IPMI interface (defaults: 'lan')"`
 	EscapeChar string            `yaml:"escapechar,omitempty" json:"escapechar,omitempty" lopt:"ipmiescapechar" comment:"Set the IPMI escape character (defaults: '~')"`
-	Write      wwtype.WWbool     `yaml:"write,omitempty"      json:"write,omitempty"      lopt:"ipmiwrite"      comment:"Enable the write of impi configuration (true/false)"`
+	Write      wwtype.WWbool     `yaml:"write,omitempty"      json:"write,omitempty"      lopt:"ipmiwrite"      comment:"Enable the write of ipmi configuration (true/false)"`
 	Template   string            `yaml:"template,omitempty"   json:"template,omitempty"   lopt:"ipmitemplate"   comment:"template used for ipmi command"`
 	Tags       map[string]string `yaml:"tags,omitempty"       json:"tags,omitempty"`
 }


### PR DESCRIPTION
## Description of the Pull Request (PR):

Attempt to fix this ugly typo

```
wwctl node set --help | grep ipmiwrite
      --ipmiwrite WWbool[=true]      Enable the write of impi configuration (true/false)
```

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
