### PR TITLE
Remove requisite relationship between ignition disk target and service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v4.6.6, unreleased
+
+### Fixed
+
+- Remove requisite dependency between ignition disk target and ignition service. #2083
+
 ## v4.6.5, 2026-01-12
 
 ### Added

--- a/overlays/ignition/internal/ignition_test.go
+++ b/overlays/ignition/internal/ignition_test.go
@@ -46,7 +46,6 @@ Description=mount ww4 disks
 # make sure that the disks are available
 Requires=ww-ignition.service
 After=ww-ignition.service
-Requisite=ww-ignition.service
 # Get the mounts
 Wants=scratch.mount
 Wants=dev-disk-by\x2dpartlabel-swap.swap
@@ -85,7 +84,6 @@ Description=mount ww4 disks
 # make sure that the disks are available
 Requires=ww-ignition.service
 After=ww-ignition.service
-Requisite=ww-ignition.service
 # Get the mounts
 Wants=scratch.mount
 Wants=dev-disk-by\x2dpartlabel-swap.swap

--- a/overlays/ignition/rootfs/etc/systemd/system/ww-ignition-disks.target.ww
+++ b/overlays/ignition/rootfs/etc/systemd/system/ww-ignition-disks.target.ww
@@ -5,7 +5,6 @@ Description=mount ww4 disks
 # make sure that the disks are available
 Requires=ww-ignition.service
 After=ww-ignition.service
-Requisite=ww-ignition.service
 # Get the mounts
 {{- if .FileSystems }}
 {{- range $fsdevice, $fs := .FileSystems }}


### PR DESCRIPTION


## Description of the Pull Request (PR):

Remove requisite relationship between ignition disk target and service. This requisite caused the target to fail when ignition is skipped due to it having already been run by dracut.


## This fixes or addresses the following GitHub issues:

- Fixes #2083


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
