### PR TITLE
Added --partwipe flag for set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove requisite dependency between ignition disk target and ignition service. #2083
 - Return HTTP 409 status when creating an existing overlay
 
+### Added
+
+- New --partwipe flag for profile and node set
+
 ## v4.6.5, 2026-01-12
 
 ### Added

--- a/internal/app/wwctl/node/set/main_test.go
+++ b/internal/app/wwctl/node/set/main_test.go
@@ -659,6 +659,28 @@ nodeprofiles: {}
 nodes:
   n1: {}`,
 		},
+		"--partwipe": {
+			args:    []string{"--partwipe", "--partname=var", "--diskname=/dev/vda", "n01"},
+			wantErr: false,
+			inDB: `
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          var:
+            number: "1"`,
+			outDB: `
+nodeprofiles: {}
+nodes:
+  n01:
+    disks:
+      /dev/vda:
+        partitions:
+          var:
+            number: "1"
+            wipe_partition_entry: true`,
+		},
 	}
 
 	for name, tt := range tests {

--- a/internal/app/wwctl/profile/set/main_test.go
+++ b/internal/app/wwctl/profile/set/main_test.go
@@ -229,6 +229,38 @@ nodeprofiles:
         path: /var
 nodes: {}`,
 		},
+		"single set partwipe to true": {
+			args:    []string{"--partwipe=true", "--partname=var", "--diskname=/dev/vda", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          var:
+            number: "1"
+    filesystems:
+      /dev/disk/by-partlabel/var:
+        format: btrfs
+        path: /var
+nodes: {}
+`,
+			outDb: `
+nodeprofiles:
+  default:
+    disks:
+      /dev/vda:
+        partitions:
+          var:
+            number: "1"
+            wipe_partition_entry: true
+    filesystems:
+      /dev/disk/by-partlabel/var:
+        format: btrfs
+        path: /var
+nodes: {}`,
+		},
 	}
 
 	for name, tt := range tests {

--- a/internal/pkg/node/datastructure.go
+++ b/internal/pkg/node/datastructure.go
@@ -110,7 +110,7 @@ type Partition struct {
 	StartMiB            string `yaml:"start_mib,omitempty"            json:"start_mib,omitempty"                              comment:"the start of the partition" type:"uint"`
 	TypeGuid            string `yaml:"type_guid,omitempty"            json:"type_guid,omitempty"            lopt:"parttype"   comment:"Set the partition type GUID"`
 	Guid                string `yaml:"guid,omitempty"                 json:"guid,omitempty"                                   comment:"the GPT unique partition GUID"`
-	WipePartitionEntryP *bool  `yaml:"wipe_partition_entry,omitempty" json:"wipe_partition_entry,omitempty"                   comment:"if true, Ignition will clobber an existing partition if it does not match the config" name:"WipePartitionEntry"`
+	WipePartitionEntryP *bool  `yaml:"wipe_partition_entry,omitempty" json:"wipe_partition_entry,omitempty" lopt:"partwipe"   comment:"if true, Ignition will clobber an existing partition if it does not match the config" name:"WipePartitionEntry"`
 	ShouldExistP        *bool  `yaml:"should_exist,omitempty"         json:"should_exist,omitempty"         lopt:"partcreate" comment:"Create partition if it does not exist" name:"ShouldExist"`
 	ResizeP             *bool  `yaml:"resize,omitempty"               json:"resize,omitempty"                                 comment:"whether or not the existing partition should be resize" name:"Resize"`
 }

--- a/userdocs/nodes/disks.rst
+++ b/userdocs/nodes/disks.rst
@@ -54,15 +54,15 @@ but specifying it is recommended as Ignition may fail without it. Partition
 sizes should also be set (specified in MiB), except for the last partition: if
 no size is given, the maximum available size is used. Each partition has the
 switches ``should_exist`` and ``wipe_partition_entry`` which control the
-partition creation process. When omitting a partition number the
-`wipe_partition_entry` should be true, as this allows ignition to replace the
-existing partition.
+partition creation process (via the ``--partcreate`` and ``--partwipe`` flags).
+When omitting a partition number the `wipe_partition_entry` should be true, as
+this allows ignition to replace the existing partition.
 
 .. code-block:: shell
 
    wwctl node set n1 \
      --diskname /dev/vda --diskwipe \
-     --partname scratch --partcreate --partnumber 1
+     --partname scratch --partcreate --partwipe --partnumber 1
 
 File systems
 ============


### PR DESCRIPTION
The wipe_partition_entry for partitions in node or profiles could only be set via `wwctl node/profile edit`.
Added a commandline option for this.
