### PR TITLE
Add --renumber-inodes to BuildFsImage cpio flags

### DIFF
--- a/internal/pkg/image/build.go
+++ b/internal/pkg/image/build.go
@@ -46,7 +46,9 @@ func Build(name string, buildForce bool) error {
 		ignore,
 		// ignore cross-device files
 		true,
-		"newc")
+		"newc",
+		// cpio args
+		"--renumber-inodes")
 
 	return err
 }

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -937,7 +937,9 @@ func BuildOverlay(nodeConf node.Node, allNodes []node.Node, context string, over
 		[]string{},
 		// ignore cross-device files
 		true,
-		"newc")
+		"newc",
+		// cpio args
+		"--renumber-inodes")
 
 	return err
 }


### PR DESCRIPTION
This fixes cpio sometimes corrupting hardlinks. Warewulf uses cpio to pack the chroots into bootable cpio initramfs images. When cpio encounters hardlinks it looks up the
(major, minor, inode): tuple of the file and attaches the data typicallys to the last instance of the link [0].

Problem is that in cpios archive format inodes are represented by as 32-bit but many filesystems support 64-bit inodes. cpio solves this by truncating the inode number to 32-bit [1].

In some cases this will cause collisions when there are multiple hardlink groups that with inode number truncation map to the same (major, minor, inode) tuple. In this case the extracted archive in the booted node will contain incorrectly hardlink files, linking first matching files of the tuple to the later files, even though their original referred inodes where not the same.

cpio has an option `--renumber-inodes` to circumvent this by mapping the inodes of all files to 0 since the information is not really needed for extraction. For hardlinks it starts with 1 and then incrementally numbers each hardlink group with a unique 32-bit inode number, circumventing the issue.

This commit enables this option in both instances of building cpio images.

[0] https://docs.kernel.org/driver-api/early-userspace/buffer-format.html
[1] https://gist.github.com/ruario/b09334336f202bef0c3e1b1c6f5b145

## This fixes or addresses the following GitHub issues:

- Fixes #2090 


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
