### PR TITLE
Allow wwdoc comments to have trimmed whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Remove requisite dependency between ignition disk target and ignition service. #2083
 - Return HTTP 409 status when creating an existing overlay
+- Allow whitespace to be trimmed for wwdoc comments. #2109
 
 ### Added
 

--- a/internal/app/wwctl/overlay/info/main_test.go
+++ b/internal/app/wwctl/overlay/info/main_test.go
@@ -325,6 +325,44 @@ Config: {{ .Tags.value }}
 				".Tags.enabled          string  \n" +
 				".Tags.value            string  \n",
 		},
+		{
+			name: "wwdoc comments with trimmed whitespace",
+			writeFiles: map[string]string{
+				"var/lib/warewulf/overlays/test-overlay/trimmed-doc.ww": `
+{{- /* wwdoc: Configuration for GPU MIG partitions with trimmed whitespace */ -}}
+{{- /* wwdoc-details: This template demonstrates wwdoc comments with {{- -}} syntax */ -}}
+{{- /* .Tags.gpuMigProfiles: List of MIG profile IDs with GPU indices */ -}}}
+GPU Profile: {{ .Tags.gpuMigProfiles }}
+`,
+			},
+			args:        []string{"test-overlay", "trimmed-doc.ww"},
+			expectError: false,
+			expectedOutput: "Configuration for GPU MIG partitions with trimmed whitespace\n" +
+				"This template demonstrates wwdoc comments with {{- -}} syntax\n" +
+				"\n" +
+				"VARIABLE              OPTION  TYPE    HELP\n" +
+				"--------              ------  ----    ----\n" +
+				".Tags.gpuMigProfiles          string  List of MIG profile IDs with GPU indices\n",
+		},
+		{
+			name: "wwdoc comments with half-trimmed whitespace",
+			writeFiles: map[string]string{
+				"var/lib/warewulf/overlays/test-overlay/half-trimmed-doc.ww": `
+{{- /* wwdoc: Configuration for GPU MIG partitions with half-trimmed whitespace */}}
+{{- /* wwdoc-details: This template demonstrates wwdoc comments with {{- }} syntax */}}
+{{- /* .Tags.gpuMigProfiles: List of MIG profile IDs with GPU indices */}}}
+GPU Profile: {{ .Tags.gpuMigProfiles }}
+`,
+			},
+			args:        []string{"test-overlay", "half-trimmed-doc.ww"},
+			expectError: false,
+			expectedOutput: "Configuration for GPU MIG partitions with half-trimmed whitespace\n" +
+				"This template demonstrates wwdoc comments with {{- }} syntax\n" +
+				"\n" +
+				"VARIABLE              OPTION  TYPE    HELP\n" +
+				"--------              ------  ----    ----\n" +
+				".Tags.gpuMigProfiles          string  List of MIG profile IDs with GPU indices\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -335,7 +335,7 @@ func (overlay Overlay) ParseCommentVars(file string) (retMap map[string]string) 
 		return nil
 	}
 
-	re := regexp.MustCompile(`{{\s*/\*\s*(.*?):\s*(.*?)\s*\*/\s*}}`)
+	re := regexp.MustCompile(`{{-?\s*/\*\s*(.*?):\s*(.*?)\s*\*/\s*-?}}`)
 	matches := re.FindAllStringSubmatch(string(content), -1)
 	if len(matches) > 0 {
 		wwlog.Debug("matches: %v len(%d:%d)", matches, len(matches), len(matches[0]))


### PR DESCRIPTION
## Description of the Pull Request (PR):

Adjusts regex in parsing wwdoc comments to match `{{ ... }}`, `{{- ... }}`, `{{ ... -}}`, and `{{- ... -}}` instead of only  `{{ ... }}`.


## This fixes or addresses the following GitHub issues:

- Fixes #2109 


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
