### PR TITLE
Clarify that type: infiniband must be set for NetworkManager IPoIB config

### DIFF
--- a/userdocs/nodes/network.rst
+++ b/userdocs/nodes/network.rst
@@ -21,6 +21,7 @@ specifying  ``--netname``.
 
    wwctl node set n1 \
      --netname=infiniband \
+     --type=infiniband \
      --netdev=ib1 \
      --ipaddr=10.0.3.1 \
      --netmask=255.255.255.0
@@ -111,3 +112,11 @@ using a network tag of the form ``route<N>=<dest>,<gateway>``.
 
    wwctl node set n001 \
      --nettagadd "route1=192.168.2.0/24,192.168.1.254"
+
+Type
+====
+
+When using the NetworkManager overlay template the ``type`` attribute
+determines how the connection is configured.  If not set, it
+defaults to ``ethernet``. To correctly configure IPoIB with NetworkManager it
+is required that ``type`` is set to ``infiniband``.


### PR DESCRIPTION
## Description of the Pull Request (PR):

If following the instructions to setup an infiniband interface with ipoib, it fails since the ww4-managed.ww template will default to 'ethernet' and not include the [infiniband] section.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
