### PR TITLE
added formated output for node list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - New --partwipe flag for profile and node set
 - Updated arguments for `ValidString` to match `regexp.MatchString`
 - New `mig` overlay to configure NVIDIA MIG devices. #2102
-- Updated arguments for `ValidString` to match `regexp.MatchString`
-- New `mig` overlay to configure NVIDIA MIG devices. #2102
+- New `--format` flag for list commands
 
 ## v4.6.5, 2026-01-12
 

--- a/internal/app/wwctl/node/list/main.go
+++ b/internal/app/wwctl/node/list/main.go
@@ -1,49 +1,85 @@
 package list
 
 import (
+	"fmt"
+	"slices"
+	"sort"
 	"strings"
+	"text/template"
 
 	"github.com/spf13/cobra"
 
 	"github.com/warewulf/warewulf/internal/app/wwctl/table"
 	apinode "github.com/warewulf/warewulf/internal/pkg/api/node"
 	"github.com/warewulf/warewulf/internal/pkg/api/routes/wwapiv1"
+	"github.com/warewulf/warewulf/internal/pkg/hostlist"
+	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
 func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err error) {
 	return func(cmd *cobra.Command, args []string) (err error) {
-		req := wwapiv1.GetNodeList{
-			Nodes: args,
-			Type:  wwapiv1.GetNodeList_Simple,
-		}
-		if vars.showAll {
-			req.Type = wwapiv1.GetNodeList_All
-		} else if vars.showIpmi {
-			req.Type = wwapiv1.GetNodeList_Ipmi
-		} else if vars.showNet {
-			req.Type = wwapiv1.GetNodeList_Network
-		} else if vars.showLong {
-			req.Type = wwapiv1.GetNodeList_Long
-		} else if vars.showYaml {
-			req.Type = wwapiv1.GetNodeList_YAML
-		} else if vars.showJson {
-			req.Type = wwapiv1.GetNodeList_JSON
-		}
-		nodeInfo, err := apinode.NodeList(&req)
-
-		if len(nodeInfo.Output) > 0 {
-			if req.Type == wwapiv1.GetNodeList_YAML || req.Type == wwapiv1.GetNodeList_JSON {
-				wwlog.Info(nodeInfo.Output[0])
-			} else {
-				t := table.New(cmd.OutOrStdout())
-				t.AddHeader(table.Prep(strings.Split(nodeInfo.Output[0], ":=:"))...)
-				for _, val := range nodeInfo.Output[1:] {
-					t.AddLine(table.Prep(strings.Split(val, ":=:"))...)
-				}
-				t.Print()
+		if vars.format == "" {
+			req := wwapiv1.GetNodeList{
+				Nodes: args,
+				Type:  wwapiv1.GetNodeList_Simple,
 			}
+			if vars.showAll {
+				req.Type = wwapiv1.GetNodeList_All
+			} else if vars.showIpmi {
+				req.Type = wwapiv1.GetNodeList_Ipmi
+			} else if vars.showNet {
+				req.Type = wwapiv1.GetNodeList_Network
+			} else if vars.showLong {
+				req.Type = wwapiv1.GetNodeList_Long
+			} else if vars.showYaml {
+				req.Type = wwapiv1.GetNodeList_YAML
+			} else if vars.showJson {
+				req.Type = wwapiv1.GetNodeList_JSON
+			}
+			nodeInfo, err := apinode.NodeList(&req)
+			if len(nodeInfo.Output) > 0 {
+				if req.Type == wwapiv1.GetNodeList_YAML || req.Type == wwapiv1.GetNodeList_JSON {
+					wwlog.Info(nodeInfo.Output[0])
+				} else {
+					t := table.New(cmd.OutOrStdout())
+					t.AddHeader(table.Prep(strings.Split(nodeInfo.Output[0], ":=:"))...)
+					for _, val := range nodeInfo.Output[1:] {
+						t.AddLine(table.Prep(strings.Split(val, ":=:"))...)
+					}
+					t.Print()
+				}
+			}
+			return err
+		} else {
+			tmpl, err := template.New("list").Parse(vars.format)
+			if err != nil {
+				return fmt.Errorf("error parsing template: %v", err)
+			}
+			nodeDB, err := node.New()
+			if err != nil {
+				return err
+			}
+			allNodes, err := nodeDB.FindAllNodes()
+			if err != nil {
+				return err
+			}
+			reqNodes := hostlist.Expand(args)
+			if len(reqNodes) == 0 {
+				for _, n := range allNodes {
+					reqNodes = append(reqNodes, n.Id())
+				}
+			}
+			sort.Strings(reqNodes)
+			for _, n := range allNodes {
+				if slices.Contains(reqNodes, n.Id()) {
+					if err := tmpl.Execute(wwlog.GetLogOut(), n); err != nil {
+						return fmt.Errorf("error executing template: %v", err)
+					}
+				}
+			}
+			return nil
+
 		}
-		return
 	}
 }

--- a/internal/app/wwctl/node/list/main_test.go
+++ b/internal/app/wwctl/node/list/main_test.go
@@ -549,6 +549,32 @@ nodes:
         ipaddr: 1.1.1.1
 `,
 		},
+		{
+			name:    "formatted test",
+			args:    []string{"--format", "{{ .Id }} profiles: {{range .Profiles}}{{ . }} ips: {{end}}{{range .NetDevs}}{{ .Ipaddr}}{{end}}\n"},
+			wantErr: false,
+			stdout: `
+n01 profiles: default ips: 1.1.1.1
+n02 profiles: default ips: 1.1.1.1`,
+			inDb: `nodeprofiles:
+  default: {}
+nodes:
+  n01:
+    profiles:
+    - default
+    network devices:
+      default:
+        hwaddr: aa:bb:cc:dd:ee:ff
+        ipaddr: 1.1.1.1
+  n02:
+    profiles:
+    - default
+    network devices:
+      default:
+        hwaddr: aa:bb:cc:dd:ee:ff
+        ipaddr: 1.1.1.1
+`,
+		},
 	}
 
 	warewulfd.SetNoDaemon()

--- a/internal/app/wwctl/node/list/root.go
+++ b/internal/app/wwctl/node/list/root.go
@@ -13,6 +13,7 @@ type variables struct {
 	showLong bool
 	showYaml bool
 	showJson bool
+	format   string
 }
 
 func GetCommand() *cobra.Command {
@@ -34,6 +35,7 @@ func GetCommand() *cobra.Command {
 	baseCmd.PersistentFlags().BoolVarP(&vars.showLong, "long", "l", false, "Show long or wide format")
 	baseCmd.PersistentFlags().BoolVarP(&vars.showYaml, "yaml", "y", false, "Show yaml format")
 	baseCmd.PersistentFlags().BoolVarP(&vars.showJson, "json", "j", false, "Show json format")
+	baseCmd.PersistentFlags().StringVarP(&vars.format, "format", "f", "", "Show formatted output, as the format must be a template")
 
 	return baseCmd
 }

--- a/internal/pkg/node/methods.go
+++ b/internal/pkg/node/methods.go
@@ -327,31 +327,31 @@ type TemplateVarDetails struct {
 /*
 Returns the id of the node
 */
-func (node *Node) Id() string {
+func (node Node) Id() string {
 	return node.id
 }
 
 /*
 Returns the id of the profile
 */
-func (node *Profile) Id() string {
+func (node Profile) Id() string {
 	return node.id
 }
 
 // ContainerName returns the value of the ImageName field for backwards-compatibility.
-func (node *Node) ContainerName() string {
+func (node Node) ContainerName() string {
 	return node.ImageName
 }
 
 // ContainerName returns the value of the ImageName field for backwards-compatibility.
-func (profile *Profile) ContainerName() string {
+func (profile Profile) ContainerName() string {
 	return profile.ImageName
 }
 
 /*
 Returns if the node is a valid in the database
 */
-func (node *Node) Valid() bool {
+func (node Node) Valid() bool {
 	return node.valid
 }
 
@@ -420,7 +420,7 @@ func cleanList(list []string) (ret []string) {
 Return the ipv4 address and mask in CIDR format. Aimed for the use in
 templates.
 */
-func (netdev *NetDev) IpCIDR() string {
+func (netdev NetDev) IpCIDR() string {
 	if netdev.Ipaddr == nil || netdev.Ipaddr.IsUnspecified() || netdev.Netmask == nil || netdev.Netmask.IsUnspecified() {
 		return ""
 	}
@@ -435,7 +435,7 @@ func (netdev *NetDev) IpCIDR() string {
 Return the ipv6 address with prefix CIDR format. Aimed for the use in
 template, symmetric with IpCIDR.
 */
-func (netdev *NetDev) IpCIDR6() string {
+func (netdev NetDev) IpCIDR6() string {
 	if netdev.Ipaddr6 == nil || netdev.Ipaddr6.IsUnspecified() || netdev.PrefixLen6 == "" {
 		return ""
 	}

--- a/internal/pkg/wwlog/wwlog.go
+++ b/internal/pkg/wwlog/wwlog.go
@@ -56,6 +56,11 @@ var (
 	logFormatter LogFormatter = DefaultFormatter
 )
 
+// get output of the log
+func GetLogOut() io.Writer {
+	return logOut
+}
+
 func LevelNameEff(level int) (int, int, string) {
 	n := len(levelNums)
 	idx := sort.SearchInts(levelNums, level)


### PR DESCRIPTION
Allow the the possiblity for freely formated output via
```
wwctl node list --format "{{ .Id }} profiles: {{range .Profiles}}{{ . }} ips: {{end}}{{range .NetDevs}}{{ .Ipaddr}}{{end}}"
```
Could also be adapated for profiles.
Needed also some modifications for methos as `func(n *Node) foo()` string won't work in templates, but `func(n Node) foo()` works like a charm. 
