### PR TITLE
Fixing profile comment field from being inherited on nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove requisite dependency between ignition disk target and ignition service. #2083
 - Return HTTP 409 status when creating an existing overlay
 - Allow whitespace to be trimmed for wwdoc comments. #2109
-- update go-chi to 5.2.5 to fix  CVE-2025-69725	
+- update go-chi to 5.2.5 to fix  CVE-2025-69725
+- Prevented profile `comment` field from being inherited by nodes. #2078
 
 ### Added
 

--- a/internal/app/wwctl/node/list/main_test.go
+++ b/internal/app/wwctl/node/list/main_test.go
@@ -157,7 +157,6 @@ nodes:
 NODE  FIELD     PROFILE  VALUE
 ----  -----     -------  -----
 n01   Profiles  --       default
-n01   Comment   default  profilecomment
 `,
 			inDb: `nodeprofiles:
   default:
@@ -173,10 +172,10 @@ nodes:
 			args:    []string{"-a"},
 			wantErr: false,
 			stdout: `
-NODE  FIELD     PROFILE     VALUE
-----  -----     -------     -----
-n01   Profiles  --          default
-n01   Comment   SUPERSEDED  nodecomment
+NODE  FIELD     PROFILE  VALUE
+----  -----     -------  -----
+n01   Profiles  --       default
+n01   Comment   --       nodecomment
 `,
 			inDb: `nodeprofiles:
   default:

--- a/internal/pkg/node/mergo.go
+++ b/internal/pkg/node/mergo.go
@@ -168,6 +168,14 @@ func (config *NodesYaml) MergeNode(id string) (node Node, fields fieldMap, err e
 		delete(fields, "Profiles")
 	}
 
+	node.Comment = originalNode.Comment
+	if node.Comment != "" {
+		fields.Set("Comment", "", node.Comment)
+		fields["Comment"].Source = ""
+	} else {
+		delete(fields, "Comment")
+	}
+
 	node.setIds(id)
 	node.valid = true
 	node.updatePrimaryNetDev()

--- a/internal/pkg/node/mergo_test.go
+++ b/internal/pkg/node/mergo_test.go
@@ -239,7 +239,7 @@ nodes:
 			source: "",
 			value:  "n1 comment",
 		},
-		"profile comment": {
+		"profile comment not inherited": {
 			nodesConf: `
 nodes:
   n1:
@@ -250,10 +250,10 @@ nodeprofiles:
     comment: p1 comment`,
 			node:   "n1",
 			field:  "Comment",
-			source: "p1",
-			value:  "p1 comment",
+			source: "",
+			value:  "",
 		},
-		"multiple profile comments": {
+		"multiple profile comments not inherited": {
 			nodesConf: `
 nodes:
   n1:
@@ -267,10 +267,10 @@ nodeprofiles:
     comment: p2 comment`,
 			node:   "n1",
 			field:  "Comment",
-			source: "p2",
-			value:  "p2 comment",
+			source: "",
+			value:  "",
 		},
-		"node comment supersedes profile comment": {
+		"node comment with profile comment": {
 			nodesConf: `
 nodes:
   n1:
@@ -282,10 +282,10 @@ nodeprofiles:
     comment: p1 comment`,
 			node:   "n1",
 			field:  "Comment",
-			source: "SUPERSEDED",
+			source: "",
 			value:  "n1 comment",
 		},
-		"node comment supersedes multiple profile comments": {
+		"node comment with multiple profile comments": {
 			nodesConf: `
 nodes:
   n1:
@@ -300,10 +300,10 @@ nodeprofiles:
     comment: p2 comment`,
 			node:   "n1",
 			field:  "Comment",
-			source: "SUPERSEDED",
+			source: "",
 			value:  "n1 comment",
 		},
-		"nested profile comments": {
+		"nested profile comments not inherited": {
 			nodesConf: `
 nodes:
   n1:
@@ -318,8 +318,8 @@ nodeprofiles:
     comment: p2 comment`,
 			node:   "n1",
 			field:  "Comment",
-			source: "p2",
-			value:  "p2 comment",
+			source: "",
+			value:  "",
 		},
 		"node kernel args": {
 			nodesConf: `


### PR DESCRIPTION
## Description of the Pull Request (PR):

PR is a fix for 2078: Nodes without comments are currently inheriting profile comments. After review - this wasn't the desired behavior and led to user confusion. This is a targeted change (with test updates) to resolve this.

## This fixes or addresses the following GitHub issues:

- Fixes #2078 

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
