### PR TITLE
Updating MAINTAINING.md to document golang version policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## v4.6.6, unreleased
+## v4.7.0, unreleased
 
 ### Fixed
 
 - Remove requisite dependency between ignition disk target and ignition service. #2083
 - Return HTTP 409 status when creating an existing overlay
 - Allow whitespace to be trimmed for wwdoc comments. #2109
-- update go-chi to 5.2.5 to fix  CVE-2025-69725
+- update go-chi to 5.2.5 to fix CVE-2025-69725
 - Prevented profile `comment` field from being inherited by nodes. #2078
 
 ### Added
@@ -20,6 +20,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated arguments for `ValidString` to match `regexp.MatchString`
 - New `mig` overlay to configure NVIDIA MIG devices. #2102
 - Documented that booting a node twice fixes broken partition tables
+
+### Changed
+
+- Updated `MAINTAINING.md` to document golang version policy
 
 ## v4.6.5, 2026-01-12
 

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -131,3 +131,19 @@ by vote of the remaining TSC members.
 
 - A patch release may be published by the TSC whenever one or more
   changes have been ported to a minor branch.
+
+## Golang version
+
+- Warewulf is built with the most recent version of Go that is available
+  as a system package across the Linux distributions for which Warewulf
+  [publishes official packages](https://github.com/warewulf/warewulf/blob/main/.github/workflows/release.yml),
+  in consultation with the OpenHPC project and its Go version requirements.
+
+- The minimum Go version declared in `go.mod` is updated at the start
+  of each minor release cycle to reflect the Go version available
+  across all supported distributions.
+
+### Notes
+
+- On EL8, Go is installed using the `go-toolset` module from the
+  appstream repository.


### PR DESCRIPTION
## Description of the Pull Request (PR):

After discussing with TSC on 2026-03-04 this PR documents our official Go version policy. The goal here is to make it more transparent how (and when) we will update the Go version in Warewulf.

## This fixes or addresses the following GitHub issues:

- Fixes: https://github.com/warewulf/warewulf/issues/2122


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
