### PR TITLE
Fix genders overlay template to use current API fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `to: "::/0"`).
 - Fixed incorrect help docs for `wwctl overlay chown`. #2166
 - Added a missing `goto` in `default.ipxe`. #2177
+- Fix path traversal vulnerability (CWE-23) by validating overlay names in `overlay.Get()` and `overlay.Create()`
+- Upgrade golang version to 1.25 to resolve stdlib CVEs (CVE-2025-4673, CVE-2025-58187, CVE-2025-61723, CVE-2025-58188, CVE-2025-61725, CVE-2025-61726, CVE-2025-47907, CVE-2025-58189, CVE-2025-47906, CVE-2025-58186, CVE-2025-61727, CVE-2025-61724, CVE-2025-58185, CVE-2025-47912, CVE-2025-61729, CVE-2025-0913, CVE-2025-22873, CVE-2024-45336, CVE-2024-45341, CVE-2025-58183, CVE-2025-68121, CVE-2025-61730)
+- Fix example `genders.ww` file
+
+### Dependencies
+
+- Bump golang.org/x/term from 0.28.0 to 0.40.0 #2037
+- Bump golang.org/x/sys from 0.29.0 to 0.42.0 #2036
+- Bump golang.org/x/crypto from 0.31.0 to 0.48.0
+- Bump golang.org/x/net from 0.33.0 to 0.49.0 #1819
+- Bump github.com/grpc-ecosystem/grpc-gateway/v2 from 2.26.1 to 2.28.0 #2032
+- Bump google.golang.org/grpc from 1.70.0 to 1.79.2
+- Bump google.golang.org/protobuf from 1.36.3 to 1.36.11
+- Bump github.com/containers/image/v5 from 5.32.2 to 5.36.2 #1996
+- Bump github.com/containers/storage from 1.57.1 to 1.59.1 #1970
+- Bump github.com/coreos/ignition/v2 from 2.20.0 to 2.26.0
+- Bump github.com/coreos/go-systemd/v22 from 22.5.0 to 22.7.0
+- Bump github.com/spf13/cobra from 1.9.1 to 1.10.2
+- Bump github.com/stretchr/testify from 1.10.0 to 1.11.1
+- Bump github.com/swaggest/openapi-go from 0.2.55 to 0.2.60
+- Bump github.com/swaggest/rest from 0.2.73 to 0.2.75
+- Bump github.com/swaggest/swgui from 1.8.2 to 1.8.5
+- Bump github.com/hashicorp/go-version from 1.7.0 to 1.8.0
+- Bump github.com/opencontainers/umoci from 0.4.7 to 0.6.0
+- Migrate github.com/talos-systems/go-smbios to github.com/siderolabs/go-smbios v0.3.3 (module renamed)
 
 ### Added
 

--- a/etc/examples/genders.ww
+++ b/etc/examples/genders.ww
@@ -3,8 +3,8 @@
 # Time:   {{.BuildTime}}
 # Source: {{.BuildSource}}
 {{- range $node := $.AllNodes}}                  {{/* for each node */}}
-{{ $node.Id.Get }} {{ range $i,$profile := $node.Profiles.GetSlice }}
+{{ $node.Id }} {{ range $i,$profile := $node.Profiles }}
 {{- if $i }},{{end}}
 {{- $profile }}{{ end }}
-{{- range $key,$value := $node.Tags }},{{$value.Get}}{{ end }}
+{{- range $key,$value := $node.Tags }},{{$value}}{{ end }}
 {{- end }}


### PR DESCRIPTION
## Description of the Pull Request (PR):

The genders overlay template (`etc/examples/genders.ww`) uses deprecated `.Get` and `.GetSlice` method calls that fail at render time.

## This fixes or addresses the following GitHub issues:

This updates the template to use direct field access:
  - $node.Id.Get → $node.Id
  - $node.Profiles.GetSlice → $node.Profiles
  - $value.Get → **$value**

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
