### PR TITLE
More fixes for snyk reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix path traversal vulnerability (CWE-23) in overlay cleanup function
 - Fix `wwctl image build --all` to build all images
 - Fix `wwctl node set --all` to set values on all nodes
+- Fix path traversal vulnerability (CWE-23)
+- Bump minimum golang version to 1.25.5 to address stdlib CVEs
 
 ### Dependencies
 

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -147,3 +147,4 @@ by vote of the remaining TSC members.
 
 - On EL8, Go is installed using the `go-toolset` module from the
   appstream repository.
+- OpenHPC uses https://eur.openeuler.openatom.cn/coprs/openhpc/OpenHPC/packages/ to build for openEuler.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/warewulf/warewulf
 
-go 1.25.0
+go 1.25.5
 
 require (
 	dario.cat/mergo v1.0.2

--- a/internal/pkg/overlay/config.go
+++ b/internal/pkg/overlay/config.go
@@ -17,7 +17,9 @@ import (
 
 var validOverlayName = regexp.MustCompile(`^[a-zA-Z0-9\-._:]+$`)
 
-func validateOverlayName(name string) error {
+// ValidateName validates that an overlay name consists only of safe characters.
+// It does not check whether the overlay actually exists.
+func ValidateName(name string) error {
 	if name == "" {
 		return fmt.Errorf("overlay name must not be empty")
 	}
@@ -29,7 +31,7 @@ func validateOverlayName(name string) error {
 
 // Get returns the filesystem path of an overlay identified by its name,
 func Get(name string) (overlay Overlay, err error) {
-	if err := validateOverlayName(name); err != nil {
+	if err := ValidateName(name); err != nil {
 		return "", err
 	}
 	overlay = getSiteOverlay(name)
@@ -47,7 +49,7 @@ func Get(name string) (overlay Overlay, err error) {
 //
 // Returns an error if the overlay already exists or if directory creation fails.
 func Create(name string) (overlay Overlay, err error) {
-	if err := validateOverlayName(name); err != nil {
+	if err := ValidateName(name); err != nil {
 		return "", err
 	}
 	overlay = getSiteOverlay(name)
@@ -104,6 +106,12 @@ func (overlay Overlay) CloneToSite() (siteOverlay Overlay, err error) {
 // If the context is empty and no overlays are specified, the empty
 // string is returned.
 func Image(nodeName string, context string, overlayNames []string) string {
+	for _, overlayName := range overlayNames {
+		if err := ValidateName(overlayName); err != nil {
+			wwlog.Warn("invalid overlay name: %s", overlayName)
+			return ""
+		}
+	}
 	var name string
 	if context != "" {
 		if len(overlayNames) > 0 {

--- a/internal/pkg/overlay/config_test.go
+++ b/internal/pkg/overlay/config_test.go
@@ -42,12 +42,12 @@ var validateOverlayNameTests = []struct {
 	{"foo\x00bar", true},
 }
 
-func Test_validateOverlayName(t *testing.T) {
+func Test_ValidateName(t *testing.T) {
 	for _, tt := range validateOverlayNameTests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateOverlayName(tt.name)
+			err := ValidateName(tt.name)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("validateOverlayName(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+				t.Errorf("ValidateName(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			}
 		})
 	}

--- a/internal/pkg/warewulfd/util.go
+++ b/internal/pkg/warewulfd/util.go
@@ -45,6 +45,11 @@ func sendFile(
 }
 
 func getOverlayFile(n node.Node, context string, stage_overlays []string, autobuild bool) (stage_file string, err error) {
+	for _, name := range stage_overlays {
+		if err := overlay.ValidateName(name); err != nil {
+			return "", err
+		}
+	}
 	stage_file = overlay.Image(n.Id(), context, stage_overlays)
 	build := !util.IsFile(stage_file)
 	wwlog.Verbose("stage file: %s", stage_file)


### PR DESCRIPTION
## Description of the Pull Request (PR):

- Update golang to v1.25.5 to address as many CVEs as possible
- Fix more instances of path traversal vulnerabilities

Can't go beyond v1.25.5 right now because that's what OpenHPC is using to build for openEuler.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
