### PR TITLE
Ignore local coding agent files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@
 /wwapid
 /wwapird
 
+# local files
+/.local/
+.claude/
+CLAUDE.md
+AGENTS.md
+
 # other created files
 /docs/man/man1
 /docs/man/man5/*.5.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Initial one-page quick reference guide
 - Document configuring the arp cache for large clusters
 - Expand troubleshooting documentation for container runtimes
+- Ignore local coding agent files
 
 ### Removed
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Put local agent files in `.gitignore` to allow for local use.  Add `/.local/` to project to allow local storage as well, this can be used for storing agent configurations, tooling, and other project related files in dev-containers or other similar environments that provide project isolation.

## This fixes or addresses the following GitHub issues:

N/A

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
