### PR TITLE
Updating / clarifying version policy

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -99,27 +99,20 @@ by vote of the remaining TSC members.
 
 - All releases occur within major version “4.”
 
+- Any new major release is preceeded by one or more release candidates.
+
 ### Minor releases
 
 - A minor release is denoted by a tag named `v4.MINOR.0`.
+
+- Minor releases are defined by a previously-planned milestone named
+  for the projected release.
 
 - A minor release candidate is denoted by a tag named
   `v4.MINOR.0rcNUMBER`, where `NUMBER` begins at “1” and increments
   for each candidate for the given minor release.
 
-- Minor releases are defined by a previously-planned milestone named
-  for the projected release.
-
-- A minor release candidate may be published by the TSC when all
-  functional issues and pull requests in the associated milestone are
-  closed. (e.g., documentation issues and pull requests may remain.)
-  This may also be accomplished by the TSC re-scoping the associated
-  milestone (e.g., by moving issues or pull requests to a different
-  milestone).
-
-- A minor release may be published by the TSC two weeks after a
-  release candidate if no major defects have been found in the release
-  candidate and there are no open issues or pull requests.
+- A minor release may be preceeded by one or more release candidates.
 
 ### Patch releases
 
@@ -131,6 +124,21 @@ by vote of the remaining TSC members.
 
 - A patch release may be published by the TSC whenever one or more
   changes have been ported to a minor branch.
+
+- Patch releases are not typically preceeded by release candidates.
+
+### Release candidates
+
+- A release candidate may be published by the TSC when all functional issues and
+  pull requests in the associated milestone are closed. (e.g., documentation
+  issues and pull requests may remain.) This may also be accomplished by the TSC
+  re-scoping the associated milestone (e.g., by moving issues or pull requests
+  to a different milestone).
+
+- Once a release candidate has been published, the related final release may be
+  published by the TSC two weeks after a release candidate if no major defects
+  have been found in the release candidate and there are no open issues or pull
+  requests.
 
 ## Golang version
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Updating / clarifying version policy based on TSC 1 April 2026 discussion.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
