### PR TITLE
adding dracut_static ipxe method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Document configuring the arp cache for large clusters
 - Expand troubleshooting documentation for container runtimes
 - Ignore local coding agent files
+- Add dracut_static ipxe method
 
 ### Removed
 

--- a/etc/ipxe/default.ipxe
+++ b/etc/ipxe/default.ipxe
@@ -35,6 +35,7 @@ item imgextract Single-stage with imgextract
 item initrd Single-stage with initrd
 item initrd_nocompress Single stage with initrd (no compression)
 item dracut Two stage with dracut
+item dracut_static Two stage with dracut and static ips
 item shell iPXE shell
 choose --default ${method} --timeout 2000 method && goto ${method} || goto menu
 
@@ -95,6 +96,17 @@ echo
 echo Downloading dracut initramfs...
 initrd --name initramfs ${base}/initramfs/${hwaddr}?${params} || goto error_reboot
 set dracut_net rd.neednet=1 {{range $devname, $netdev := .NetDevs}}{{if and $netdev.Hwaddr $netdev.Device}} ifname={{$netdev.Device}}:{{$netdev.Hwaddr}} ip={{$netdev.Device}}:dhcp {{end}}{{end}}
+set dracut_wwinit root=wwinit:{{default "tmpfs" .Root}} wwinit.server=${base} wwinit.uri=${base}/provision/${hwaddr} init=/warewulf/run-init
+goto boot_two_stage_dracut
+
+:dracut_static
+set next dracut_static_continue
+goto metadata
+:dracut_static_continue
+echo
+echo Downloading dracut initramfs...
+initrd --name initramfs ${base}/initramfs/${hwaddr}?${params} || goto error_reboot
+set dracut_net rd.neednet=1 {{range $devname, $netdev := .NetDevs}}{{if and $netdev.Hwaddr $netdev.Device}} ifname={{$netdev.Device}}:{{$netdev.Hwaddr}} ip={{$netdev.Ipaddr}}::{{$netdev.Gateway}}:{{$netdev.Netmask}}::{{$netdev.Device}}:on {{end}}{{end}}
 set dracut_wwinit root=wwinit:{{default "tmpfs" .Root}} wwinit.server=${base} wwinit.uri=${base}/provision/${hwaddr} init=/warewulf/run-init
 goto boot_two_stage_dracut
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

There are situations where someone might want to boot dracut with static network config in place instead of relying on dhcp. I've had a custom ipxe template in play for a while to work around an issue where the ipxe client on infiniband cards uses the 48bit form of the guid for the mac address, whereas networkmanager uses the full 64 bits. Figure it might be useful to upstream it.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
