### PR TITLE
Add gateway netplan overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   to use state-based routing instead of sentinel strings, so whitespace-trimming
   syntax (e.g. `{{- file "name" -}}`) correctly creates all named files and
   symlinks. #2118
+- Emit default routes in the `netplan` overlay when `gateway` or `gateway6`
+  is set on ethernet or bond devices (Netplan `routes` with `to: default` and
+  `to: "::/0"`).
 
 ### Dependencies
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,6 +37,7 @@
 - Tobias Ribizel <mail@ribizel.de>
 - Tobias Poschwatta <poschwatta@zib.de>
 - Josh Burks <jeburks2@asu.edu>
+- Jacob Sommerville <jsommerville@tenstorrent.com>
 - Elmar Pruesse <pruessee@njhealth.org> @epruesse
 - Adam Michel <elfurbe@furbism.com> [@elfurbe](https://github.com/elfurbe)
 - Brandon Biggs <brandonsbiggs@gmail.com>

--- a/overlays/netplan/internal/netplan_test.go
+++ b/overlays/netplan/internal/netplan_test.go
@@ -49,6 +49,9 @@ network:
       optional: true
       addresses:
       - 192.168.3.21/24
+      routes:
+      - to: default
+        via: 192.168.3.1
       mtu: 1500
 `,
 		},
@@ -87,12 +90,18 @@ network:
       optional: true
       addresses:
       - 192.168.3.21/24
+      routes:
+      - to: default
+        via: 192.168.3.1
       mtu: 1500
     wwnet1:
       dhcp4: no
       optional: true
       addresses:
       - 192.168.3.22/24
+      routes:
+      - to: default
+        via: 192.168.3.1
       mtu: 9000
 `,
 		},

--- a/overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww
+++ b/overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww
@@ -25,6 +25,17 @@ network:
       addresses:
       - {{$netdev.IpCIDR}}
 {{- end }}
+{{- if or $netdev.Gateway $netdev.Gateway6 }}
+      routes:
+{{- if $netdev.Gateway }}
+      - to: default
+        via: {{$netdev.Gateway}}
+{{- end }}
+{{- if $netdev.Gateway6 }}
+      - to: "::/0"
+        via: {{$netdev.Gateway6}}
+{{- end }}
+{{- end }}
 {{- if $netdev.MTU}}
       mtu: {{$netdev.MTU}}
 {{- end }}
@@ -41,6 +52,17 @@ network:
 {{- if $netdev.IpCIDR }}
       addresses:
       - {{$netdev.IpCIDR}}
+{{- end }}
+{{- if or $netdev.Gateway $netdev.Gateway6 }}
+      routes:
+{{- if $netdev.Gateway }}
+      - to: default
+        via: {{$netdev.Gateway}}
+{{- end }}
+{{- if $netdev.Gateway6 }}
+      - to: "::/0"
+        via: {{$netdev.Gateway6}}
+{{- end }}
 {{- end }}
 {{- if $netdev.MTU}}
       mtu: {{$netdev.MTU}}


### PR DESCRIPTION
## Description of the Pull Request (PR):

The netplan overlay (`overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww`) rendered addresses and MTU for ethernet and bond interfaces but omitted IPv4 and IPv6 default gateways from the Warewulf node/network device configuration. Nodes using static addressing therefore had no default route in the generated Netplan file.

This change adds Netplan `routes` stanzas when `gateway` and/or `gateway6` are present on a netdev:
IPv4 uses `to: default` with `via: <gateway>`, and IPv6 uses `to: "::/0"` with `via: <gateway6>`. The same logic is applied for both `ethernets` and `bonds` sections.

Overlay tests in `overlays/netplan/internal/netplan_test.go` are updated so the single- and dual-interface cases (which already set `gateway`) expect the new `routes` output. Bond devices use the same template logic when `gateway` / `gateway6` are configured.


## This fixes or addresses the following GitHub issues:

- Fixes #


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
