### PR TITLE
Added a missing `goto` in `default.ipxe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   is set on ethernet or bond devices (Netplan `routes` with `to: default` and
   `to: "::/0"`).
 - Fixed incorrect help docs for `wwctl overlay chown`. #2166
+- Added a missing `goto` in `default.ipxe`. #2177
 
 ### Dependencies
 

--- a/etc/ipxe/default.ipxe
+++ b/etc/ipxe/default.ipxe
@@ -116,7 +116,7 @@ boot kernel initrd=image initrd=system ${runtime_initrd} wwid={{.Hwaddr}} {{.Ker
 
 :boot_two_stage_dracut
 echo Booting dracut (first stage)...
-boot kernel initrd=initramfs ${dracut_net} ${dracut_wwinit} wwid={{.Hwaddr}} {{.KernelArgs}} || error_reboot
+boot kernel initrd=initramfs ${dracut_net} ${dracut_wwinit} wwid={{.Hwaddr}} {{.KernelArgs}} || goto error_reboot
 
 :error_reboot
 echo !!


### PR DESCRIPTION
## This fixes or addresses the following GitHub issues:

- Fixes #2177


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
