### PR TITLE
bmc base VM management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Ignore local coding agent files
 - Add dracut_static ipxe method
 - Added `wwctl <node|profile> unset` #1954
+- Added the possibilty to create virtual machines with bmc templates which means that 
+  `wwctl power up vn01` would create a 'local' virtaul machine
 
 ### Removed
 

--- a/internal/pkg/bmc/bmc.go
+++ b/internal/pkg/bmc/bmc.go
@@ -9,10 +9,9 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/Masterminds/sprig/v3"
-
 	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/node"
+	"github.com/warewulf/warewulf/internal/pkg/overlay"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
@@ -44,12 +43,22 @@ func (tstruct *TemplateStruct) getCommand() (cmdStr string, err error) {
 	if err != nil {
 		return "", fmt.Errorf("couldn't find the template which defines the bmc command: %s", err)
 	}
-	cmdTmpl, err := template.New("bmc command").Funcs(sprig.TxtFuncMap()).Parse(string(fbuf))
+
+	// Use overlay's BuildTemplateFuncMap for full template function support
+	result := &overlay.RenderedTemplate{
+		WriteFile:  true,
+		BackupFile: true,
+		Files:      []*overlay.RenderedFile{{Name: ""}},
+	}
+	var tbuffer bytes.Buffer
+	writer := &overlay.MultiFileWriter{Current: &tbuffer}
+	funcMap := overlay.BuildTemplateFuncMap(tstruct.Template, *tstruct, result, writer)
+
+	cmdTmpl, err := template.New("bmc command").Funcs(funcMap).Parse(string(fbuf))
 	if err != nil {
 		return "", err
 	}
-	var tbuffer bytes.Buffer
-	err = cmdTmpl.Execute(&tbuffer, *tstruct)
+	err = cmdTmpl.Execute(writer, *tstruct)
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/bmc/bmc_test.go
+++ b/internal/pkg/bmc/bmc_test.go
@@ -2,6 +2,7 @@ package bmc
 
 import (
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -77,5 +78,412 @@ func Test_Ipmitool(t *testing.T) {
 				assert.Equal(t, test.cmdStr, cmdStr)
 			}
 		})
+	}
+}
+
+func Test_VirtualBMC_Kind(t *testing.T) {
+	tests := map[string]struct {
+		bmc         TemplateStruct
+		err         bool
+		containsStr []string
+	}{
+		"kind PowerOn default": {
+			bmc: TemplateStruct{
+				Cmd: "PowerOn",
+				IpmiConf: node.IpmiConf{
+					Template: "kind.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+				},
+			},
+			containsStr: []string{
+				"docker inspect 192-168-1-100",
+				"docker start 192-168-1-100",
+				"docker run -d",
+				"--name 192-168-1-100",
+				"--cpus 2",
+				"--memory 2g",
+				"kindest/node:latest",
+			},
+		},
+		"kind PowerOn custom": {
+			bmc: TemplateStruct{
+				Cmd: "PowerOn",
+				IpmiConf: node.IpmiConf{
+					Template: "kind.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+					Tags: map[string]string{
+						"nodename": "testnode",
+						"cpu":      "4",
+						"memory":   "8g",
+						"disk":     "50g",
+						"image":    "ubuntu:22.04",
+					},
+				},
+			},
+			containsStr: []string{
+				"docker inspect testnode",
+				"docker start testnode",
+				"--name testnode",
+				"--cpus 4",
+				"--memory 8g",
+				"ubuntu:22.04",
+			},
+		},
+		"kind PowerOff": {
+			bmc: TemplateStruct{
+				Cmd: "PowerOff",
+				IpmiConf: node.IpmiConf{
+					Template: "kind.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+				},
+			},
+			containsStr: []string{
+				"docker inspect 192-168-1-100",
+				"docker stop 192-168-1-100",
+			},
+		},
+		"kind PowerStatus": {
+			bmc: TemplateStruct{
+				Cmd: "PowerStatus",
+				IpmiConf: node.IpmiConf{
+					Template: "kind.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+				},
+			},
+			containsStr: []string{
+				"docker inspect 192-168-1-100",
+				"echo \"ON\"",
+				"echo \"OFF\"",
+				"echo \"NOT_EXIST\"",
+			},
+		},
+		"kind PowerCycle": {
+			bmc: TemplateStruct{
+				Cmd: "PowerCycle",
+				IpmiConf: node.IpmiConf{
+					Template: "kind.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+				},
+			},
+			containsStr: []string{
+				"docker inspect 192-168-1-100",
+				"docker restart 192-168-1-100",
+			},
+		},
+		"kind SDRList": {
+			bmc: TemplateStruct{
+				Cmd: "SDRList",
+				IpmiConf: node.IpmiConf{
+					Template: "kind.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+					Tags: map[string]string{
+						"cpu":    "4",
+						"memory": "8g",
+						"disk":   "50g",
+					},
+				},
+			},
+			containsStr: []string{
+				"echo \"CPU: 4\"",
+				"echo \"Memory: 8g\"",
+				"echo \"Disk: 50g\"",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		env := testenv.New(t)
+		defer env.RemoveAll()
+		env.ImportFile("usr/share/warewulf/bmc/kind.tmpl", "../../../lib/warewulf/bmc/kind.tmpl")
+
+		t.Run(name, func(t *testing.T) {
+			cmdStr, err := test.bmc.getCommand()
+			if test.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				for _, substr := range test.containsStr {
+					assert.Contains(t, cmdStr, substr, "Command should contain: %s", substr)
+				}
+			}
+		})
+	}
+}
+
+func Test_VirtualBMC_KindLibvirt(t *testing.T) {
+	tests := map[string]struct {
+		bmc         TemplateStruct
+		err         bool
+		containsStr []string
+	}{
+		"libvirt PowerOn default": {
+			bmc: TemplateStruct{
+				Cmd: "PowerOn",
+				IpmiConf: node.IpmiConf{
+					Template: "kind-libvirt.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+				},
+			},
+			containsStr: []string{
+				"virsh dominfo 192-168-1-100",
+				"virsh start 192-168-1-100",
+				"qemu-img create -f qcow2",
+				"virt-install",
+				"--name 192-168-1-100",
+				"--vcpus 2",
+				"--memory 2048",
+			},
+		},
+		"libvirt PowerOn custom": {
+			bmc: TemplateStruct{
+				Cmd: "PowerOn",
+				IpmiConf: node.IpmiConf{
+					Template: "kind-libvirt.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+					Tags: map[string]string{
+						"nodename":   "testvm",
+						"cpu":        "8",
+						"memory":     "16384",
+						"disk":       "100",
+						"disk_path":  "/custom/path",
+						"os_variant": "ubuntu22.04",
+					},
+				},
+			},
+			containsStr: []string{
+				"virsh dominfo testvm",
+				"--name testvm",
+				"--vcpus 8",
+				"--memory 16384",
+				"/custom/path/testvm.qcow2",
+				"--os-variant ubuntu22.04",
+			},
+		},
+		"libvirt PowerOff": {
+			bmc: TemplateStruct{
+				Cmd: "PowerOff",
+				IpmiConf: node.IpmiConf{
+					Template: "kind-libvirt.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+				},
+			},
+			containsStr: []string{
+				"virsh dominfo 192-168-1-100",
+				"virsh shutdown 192-168-1-100",
+			},
+		},
+		"libvirt PowerStatus": {
+			bmc: TemplateStruct{
+				Cmd: "PowerStatus",
+				IpmiConf: node.IpmiConf{
+					Template: "kind-libvirt.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+				},
+			},
+			containsStr: []string{
+				"virsh dominfo 192-168-1-100",
+				"virsh domstate 192-168-1-100",
+				"echo \"ON\"",
+				"echo \"OFF\"",
+			},
+		},
+		"libvirt SDRList": {
+			bmc: TemplateStruct{
+				Cmd: "SDRList",
+				IpmiConf: node.IpmiConf{
+					Template: "kind-libvirt.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+				},
+			},
+			containsStr: []string{
+				"virsh dominfo 192-168-1-100",
+				"qemu-img info",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		env := testenv.New(t)
+		defer env.RemoveAll()
+		env.ImportFile("usr/share/warewulf/bmc/kind-libvirt.tmpl", "../../../lib/warewulf/bmc/kind-libvirt.tmpl")
+
+		t.Run(name, func(t *testing.T) {
+			cmdStr, err := test.bmc.getCommand()
+			if test.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				for _, substr := range test.containsStr {
+					assert.Contains(t, cmdStr, substr, "Command should contain: %s", substr)
+				}
+			}
+		})
+	}
+}
+
+func Test_VirtualBMC_KindQemu(t *testing.T) {
+	tests := map[string]struct {
+		bmc         TemplateStruct
+		err         bool
+		containsStr []string
+	}{
+		"qemu PowerOn default": {
+			bmc: TemplateStruct{
+				Cmd: "PowerOn",
+				IpmiConf: node.IpmiConf{
+					Template: "kind-qemu.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+				},
+			},
+			containsStr: []string{
+				"/var/run/qemu-192-168-1-100.pid",
+				"qemu-img create -f qcow2",
+				"qemu-system-x86_64",
+				"-name 192-168-1-100",
+				"-m 2048",
+				"-smp 2",
+				"/var/lib/qemu/images/192-168-1-100.qcow2",
+			},
+		},
+		"qemu PowerOn custom": {
+			bmc: TemplateStruct{
+				Cmd: "PowerOn",
+				IpmiConf: node.IpmiConf{
+					Template: "kind-qemu.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+					Tags: map[string]string{
+						"nodename":  "qemutest",
+						"cpu":       "4",
+						"memory":    "8192",
+						"disk":      "80",
+						"disk_path": "/var/qemu",
+						"mac":       "52:54:00:12:34:56",
+					},
+				},
+			},
+			containsStr: []string{
+				"/var/run/qemu-qemutest.pid",
+				"-name qemutest",
+				"-m 8192",
+				"-smp 4",
+				"/var/qemu/qemutest.qcow2",
+				"mac=52:54:00:12:34:56",
+			},
+		},
+		"qemu PowerOff": {
+			bmc: TemplateStruct{
+				Cmd: "PowerOff",
+				IpmiConf: node.IpmiConf{
+					Template: "kind-qemu.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+				},
+			},
+			containsStr: []string{
+				"/var/run/qemu-192-168-1-100.pid",
+				"system_powerdown",
+				"/var/run/qemu-192-168-1-100.monitor",
+			},
+		},
+		"qemu PowerStatus": {
+			bmc: TemplateStruct{
+				Cmd: "PowerStatus",
+				IpmiConf: node.IpmiConf{
+					Template: "kind-qemu.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+				},
+			},
+			containsStr: []string{
+				"/var/run/qemu-192-168-1-100.pid",
+				"echo \"ON\"",
+				"echo \"OFF\"",
+			},
+		},
+		"qemu PowerReset": {
+			bmc: TemplateStruct{
+				Cmd: "PowerReset",
+				IpmiConf: node.IpmiConf{
+					Template: "kind-qemu.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+				},
+			},
+			containsStr: []string{
+				"system_reset",
+				"/var/run/qemu-192-168-1-100.monitor",
+			},
+		},
+		"qemu SDRList": {
+			bmc: TemplateStruct{
+				Cmd: "SDRList",
+				IpmiConf: node.IpmiConf{
+					Template: "kind-qemu.tmpl",
+					Ipaddr:   net.IP{192, 168, 1, 100},
+					Tags: map[string]string{
+						"cpu":    "8",
+						"memory": "16384",
+					},
+				},
+			},
+			containsStr: []string{
+				"echo \"CPU: 8\"",
+				"echo \"Memory: 16384MB\"",
+				"qemu-img info",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		env := testenv.New(t)
+		defer env.RemoveAll()
+		env.ImportFile("usr/share/warewulf/bmc/kind-qemu.tmpl", "../../../lib/warewulf/bmc/kind-qemu.tmpl")
+
+		t.Run(name, func(t *testing.T) {
+			cmdStr, err := test.bmc.getCommand()
+			if test.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				for _, substr := range test.containsStr {
+					assert.Contains(t, cmdStr, substr, "Command should contain: %s", substr)
+				}
+			}
+		})
+	}
+}
+
+func Test_AllVirtualBMC_AllCommands(t *testing.T) {
+	templates := []string{"kind.tmpl", "kind-libvirt.tmpl", "kind-qemu.tmpl"}
+	commands := []string{"PowerOn", "PowerOff", "PowerCycle", "PowerReset", "PowerSoft", "PowerStatus", "SDRList", "SensorList"}
+
+	env := testenv.New(t)
+	defer env.RemoveAll()
+	env.ImportFile("usr/share/warewulf/bmc/kind.tmpl", "../../../lib/warewulf/bmc/kind.tmpl")
+	env.ImportFile("usr/share/warewulf/bmc/kind-libvirt.tmpl", "../../../lib/warewulf/bmc/kind-libvirt.tmpl")
+	env.ImportFile("usr/share/warewulf/bmc/kind-qemu.tmpl", "../../../lib/warewulf/bmc/kind-qemu.tmpl")
+
+	for _, tmpl := range templates {
+		for _, cmd := range commands {
+			testName := tmpl + "_" + cmd
+			t.Run(testName, func(t *testing.T) {
+				bmc := TemplateStruct{
+					Cmd: cmd,
+					IpmiConf: node.IpmiConf{
+						Template: tmpl,
+						Ipaddr:   net.IP{10, 0, 0, 1},
+						Tags: map[string]string{
+							"nodename": "testnode",
+						},
+					},
+				}
+
+				cmdStr, err := bmc.getCommand()
+				assert.NoError(t, err, "Template %s with command %s should not error", tmpl, cmd)
+				assert.NotEmpty(t, cmdStr, "Template %s with command %s should produce non-empty command", tmpl, cmd)
+
+				// Verify the command contains the node name
+				assert.True(t,
+					strings.Contains(cmdStr, "testnode") || strings.Contains(cmdStr, "10-0-0-1"),
+					"Command should reference the node: %s", cmdStr)
+			})
+		}
 	}
 }

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -299,8 +299,8 @@ func (overlay Overlay) ParseVarFields(file string) map[string]FieldInfo {
 			{Name: ""},
 		},
 	}
-	renderWriter := &multiFileWriter{current: &renderState.Files[0].Buffer}
-	funcMap := buildTemplateFuncMap(fullPath, TemplateStruct{}, renderState, renderWriter)
+	renderWriter := &MultiFileWriter{Current: &renderState.Files[0].Buffer}
+	funcMap := BuildTemplateFuncMap(fullPath, TemplateStruct{}, renderState, renderWriter)
 	tmpl, err := template.New(path.Base(fullPath)).Option("missingkey=default").Funcs(funcMap).ParseFiles(fullPath)
 	if err != nil {
 		wwlog.Error("Could not parse template file %s: %s", fullPath, err)
@@ -1146,20 +1146,27 @@ type RenderedTemplate struct {
 	Files      []*RenderedFile
 }
 
-type multiFileWriter struct {
-	current *bytes.Buffer // redirected by file() and softlink() closures
+// MultiFileWriter is used by BuildTemplateFuncMap for stateful template functions.
+// External packages using BuildTemplateFuncMap should create an instance pointing
+// to their output buffer.
+type MultiFileWriter struct {
+	Current *bytes.Buffer // redirected by file() and softlink() closures
 }
 
-func (w *multiFileWriter) Write(p []byte) (n int, err error) {
-	return w.current.Write(p)
+func (w *MultiFileWriter) Write(p []byte) (n int, err error) {
+	return w.Current.Write(p)
 }
 
-// buildTemplateFuncMap constructs the template FuncMap for a .ww template.
+// BuildTemplateFuncMap constructs the template FuncMap for a .ww template.
 // result and writer are the shared mutable state closed over by the stateful
 // template functions (file, softlink, ImportLink, abort, nobackup). They must
 // be allocated by the caller so RenderTemplate and ParseVarFields can each
 // supply their own isolated state.
-func buildTemplateFuncMap(fileName string, data TemplateStruct, result *RenderedTemplate, writer *multiFileWriter) template.FuncMap {
+//
+// The data parameter accepts any type; functions that require specific data
+// types (like IgnitionJson which needs TemplateStruct) will fail gracefully
+// if the wrong type is provided.
+func BuildTemplateFuncMap(fileName string, data interface{}, result *RenderedTemplate, writer *MultiFileWriter) template.FuncMap {
 	softlinkFn := func(target string) string {
 		if len(result.Files) > 0 {
 			last := result.Files[len(result.Files)-1]
@@ -1182,7 +1189,7 @@ func buildTemplateFuncMap(fileName string, data TemplateStruct, result *Rendered
 	fileFn := func(name string) string {
 		f := &RenderedFile{Name: name}
 		result.Files = append(result.Files, f)
-		writer.current = &f.Buffer
+		writer.Current = &f.Buffer
 		return ""
 	}
 
@@ -1190,7 +1197,12 @@ func buildTemplateFuncMap(fileName string, data TemplateStruct, result *Rendered
 	decFn := func(i int) int { return i - 1 }
 
 	ignitionFn := func() string {
-		return createIgnitionJson(data.ThisNode)
+		// Type assert to TemplateStruct for overlay templates
+		if tstruct, ok := data.(TemplateStruct); ok {
+			return createIgnitionJson(tstruct.ThisNode)
+		}
+		wwlog.Warn("IgnitionJson function called with incompatible data type in %s", fileName)
+		return ""
 	}
 
 	abortFn := func() (string, error) {
@@ -1239,8 +1251,8 @@ func RenderTemplate(fileName string, data TemplateStruct) (*RenderedTemplate, er
 		BackupFile: true,
 		Files:      []*RenderedFile{{Name: ""}},
 	}
-	writer := &multiFileWriter{current: &result.Files[0].Buffer}
-	funcMap := buildTemplateFuncMap(fileName, data, result, writer)
+	writer := &MultiFileWriter{Current: &result.Files[0].Buffer}
+	funcMap := BuildTemplateFuncMap(fileName, data, result, writer)
 
 	tmpl, err := template.New(path.Base(fileName)).Option("missingkey=default").Funcs(funcMap).ParseGlob(fileName)
 	if err != nil {

--- a/lib/warewulf/bmc/kind-libvirt.tmpl
+++ b/lib/warewulf/bmc/kind-libvirt.tmpl
@@ -1,0 +1,116 @@
+{{- /* kind-libvirt.tmpl - Libvirt/KVM-based virtual node management for BMC simulation */ -}}
+{{- $nodeName := .Ipaddr | toString | replace "." "-" -}}
+{{- if .Tags.nodename }}{{ $nodeName = .Tags.nodename }}{{ end -}}
+{{- $cpu := "2" }}{{ if .Tags.cpu }}{{ $cpu = .Tags.cpu }}{{ end -}}
+{{- $memory := "2048" }}{{ if .Tags.memory }}{{ $memory = .Tags.memory }}{{ end -}}
+{{- $disk := "20" }}{{ if .Tags.disk }}{{ $disk = .Tags.disk }}{{ end -}}
+{{- $diskPath := "/var/lib/libvirt/images" }}{{ if .Tags.disk_path }}{{ $diskPath = .Tags.disk_path }}{{ end -}}
+{{- $osVariant := "generic" }}{{ if .Tags.os_variant }}{{ $osVariant = .Tags.os_variant }}{{ end -}}
+{{- if eq .Cmd "PowerOn" -}}
+if virsh dominfo {{ $nodeName }} &>/dev/null; then
+  state=$(virsh domstate {{ $nodeName }})
+  if [ "$state" == "shut off" ] || [ "$state" == "paused" ]; then
+    virsh start {{ $nodeName }}
+    echo "Node {{ $nodeName }} started"
+  else
+    echo "Node {{ $nodeName }} already running"
+  fi
+else
+  # Create disk if it doesn't exist
+  if [ ! -f {{ $diskPath }}/{{ $nodeName }}.qcow2 ]; then
+    qemu-img create -f qcow2 {{ $diskPath }}/{{ $nodeName }}.qcow2 {{ $disk }}G
+  fi
+
+  # Create and start VM
+  virt-install \
+    --name {{ $nodeName }} \
+    --vcpus {{ $cpu }} \
+    --memory {{ $memory }} \
+    --disk path={{ $diskPath }}/{{ $nodeName }}.qcow2,format=qcow2 \
+    --os-variant {{ $osVariant }} \
+    --network network=default \
+    --graphics none \
+    --console pty,target_type=serial \
+    --noautoconsole \
+    --boot network,hd \
+    --import 2>/dev/null || true
+
+  echo "Node {{ $nodeName }} created and started (CPU: {{ $cpu }}, Memory: {{ $memory }}MB, Disk: {{ $disk }}GB)"
+fi
+{{- else if eq .Cmd "PowerOff" -}}
+if virsh dominfo {{ $nodeName }} &>/dev/null; then
+  state=$(virsh domstate {{ $nodeName }})
+  if [ "$state" == "running" ]; then
+    virsh shutdown {{ $nodeName }}
+    echo "Node {{ $nodeName }} shutdown initiated"
+  else
+    echo "Node {{ $nodeName }} already stopped"
+  fi
+else
+  echo "Node {{ $nodeName }} does not exist"
+fi
+{{- else if eq .Cmd "PowerCycle" -}}
+if virsh dominfo {{ $nodeName }} &>/dev/null; then
+  virsh reboot {{ $nodeName }}
+  echo "Node {{ $nodeName }} rebooted"
+else
+  echo "Node {{ $nodeName }} does not exist"
+fi
+{{- else if eq .Cmd "PowerReset" -}}
+if virsh dominfo {{ $nodeName }} &>/dev/null; then
+  virsh reset {{ $nodeName }}
+  echo "Node {{ $nodeName }} reset"
+else
+  echo "Node {{ $nodeName }} does not exist"
+fi
+{{- else if eq .Cmd "PowerSoft" -}}
+if virsh dominfo {{ $nodeName }} &>/dev/null; then
+  virsh reboot {{ $nodeName }}
+  echo "Node {{ $nodeName }} soft reboot"
+else
+  echo "Node {{ $nodeName }} does not exist"
+fi
+{{- else if eq .Cmd "PowerStatus" -}}
+if virsh dominfo {{ $nodeName }} &>/dev/null; then
+  state=$(virsh domstate {{ $nodeName }})
+  if [ "$state" == "running" ]; then
+    echo "ON"
+  else
+    echo "OFF"
+  fi
+else
+  echo "NOT_EXIST"
+fi
+{{- else if eq .Cmd "SDRList" -}}
+if virsh dominfo {{ $nodeName }} &>/dev/null; then
+  echo "=== Node {{ $nodeName }} Configuration ==="
+  virsh dominfo {{ $nodeName }}
+  echo ""
+  echo "Disk: {{ $diskPath }}/{{ $nodeName }}.qcow2"
+  if [ -f {{ $diskPath }}/{{ $nodeName }}.qcow2 ]; then
+    qemu-img info {{ $diskPath }}/{{ $nodeName }}.qcow2 | grep -E "(virtual size|disk size|format)"
+  fi
+else
+  echo "Node {{ $nodeName }} does not exist"
+  echo "Configured: CPU={{ $cpu }}, Memory={{ $memory }}MB, Disk={{ $disk }}GB"
+fi
+{{- else if eq .Cmd "SensorList" -}}
+if virsh dominfo {{ $nodeName }} &>/dev/null; then
+  virsh domstats {{ $nodeName }}
+else
+  echo "Node {{ $nodeName }} does not exist"
+fi
+{{- else if eq .Cmd "Console" -}}
+if virsh dominfo {{ $nodeName }} &>/dev/null; then
+  state=$(virsh domstate {{ $nodeName }})
+  if [ "$state" == "running" ]; then
+    virsh console {{ $nodeName }}
+  else
+    echo "Node {{ $nodeName }} not running (state: $state)"
+  fi
+else
+  echo "Node {{ $nodeName }} does not exist"
+fi
+{{- else -}}
+echo "Unknown command: {{ .Cmd }}"
+{{- end -}}

--- a/lib/warewulf/bmc/kind-qemu.tmpl
+++ b/lib/warewulf/bmc/kind-qemu.tmpl
@@ -1,0 +1,117 @@
+{{- /* kind-qemu.tmpl - QEMU-based virtual node management for BMC simulation */ -}}
+{{- $nodeName := .Ipaddr | toString | replace "." "-" -}}
+{{- if .Tags.nodename }}{{ $nodeName = .Tags.nodename }}{{ end -}}
+{{- $cpu := "2" }}{{ if .Tags.cpu }}{{ $cpu = .Tags.cpu }}{{ end -}}
+{{- $memory := "2048" }}{{ if .Tags.memory }}{{ $memory = .Tags.memory }}{{ end -}}
+{{- $disk := "20" }}{{ if .Tags.disk }}{{ $disk = .Tags.disk }}{{ end -}}
+{{- $diskPath := "/var/lib/qemu/images" }}{{ if .Tags.disk_path }}{{ $diskPath = .Tags.disk_path }}{{ end -}}
+{{- $macAddr := "" }}{{ if .Tags.mac }}{{ $macAddr = .Tags.mac }}{{ end -}}
+{{- $pidFile := printf "/var/run/qemu-%s.pid" $nodeName -}}
+{{- $monitorSocket := printf "/var/run/qemu-%s.monitor" $nodeName -}}
+{{- $diskFile := printf "%s/%s.qcow2" $diskPath $nodeName -}}
+{{- if eq .Cmd "PowerOn" -}}
+if [ -f {{ $pidFile }} ] && kill -0 $(cat {{ $pidFile }}) 2>/dev/null; then
+  echo "Node {{ $nodeName }} already running"
+else
+  # Create disk if it doesn't exist
+  if [ ! -d {{ $diskPath }} ]; then
+    mkdir -p {{ $diskPath }}
+  fi
+  if [ ! -f {{ $diskFile }} ]; then
+    qemu-img create -f qcow2 {{ $diskFile }} {{ $disk }}G
+  fi
+
+  # Build QEMU command
+  qemu_cmd="qemu-system-x86_64 \
+    -name {{ $nodeName }} \
+    -m {{ $memory }} \
+    -smp {{ $cpu }} \
+    -drive file={{ $diskFile }},format=qcow2,if=virtio \
+    -boot order=nc \
+    -netdev user,id=net0 \
+    -device virtio-net-pci,netdev=net0{{ if $macAddr }},mac={{ $macAddr }}{{ end }} \
+    -daemonize \
+    -pidfile {{ $pidFile }} \
+    -monitor unix:{{ $monitorSocket }},server,nowait \
+    -nographic \
+    -serial null"
+
+  # Start QEMU
+  eval $qemu_cmd
+  if [ $? -eq 0 ]; then
+    echo "Node {{ $nodeName }} created and started (CPU: {{ $cpu }}, Memory: {{ $memory }}MB, Disk: {{ $disk }}GB)"
+  else
+    echo "Failed to start node {{ $nodeName }}"
+    exit 1
+  fi
+fi
+{{- else if eq .Cmd "PowerOff" -}}
+if [ -f {{ $pidFile }} ] && kill -0 $(cat {{ $pidFile }}) 2>/dev/null; then
+  echo "system_powerdown" | socat - UNIX-CONNECT:{{ $monitorSocket }} || kill $(cat {{ $pidFile }})
+  echo "Node {{ $nodeName }} shutdown initiated"
+else
+  echo "Node {{ $nodeName }} not running"
+fi
+{{- else if eq .Cmd "PowerCycle" -}}
+if [ -f {{ $pidFile }} ] && kill -0 $(cat {{ $pidFile }}) 2>/dev/null; then
+  echo "system_reset" | socat - UNIX-CONNECT:{{ $monitorSocket }}
+  echo "Node {{ $nodeName }} reset"
+else
+  echo "Node {{ $nodeName }} not running"
+fi
+{{- else if eq .Cmd "PowerReset" -}}
+if [ -f {{ $pidFile }} ] && kill -0 $(cat {{ $pidFile }}) 2>/dev/null; then
+  echo "system_reset" | socat - UNIX-CONNECT:{{ $monitorSocket }}
+  echo "Node {{ $nodeName }} hard reset"
+else
+  echo "Node {{ $nodeName }} not running"
+fi
+{{- else if eq .Cmd "PowerSoft" -}}
+if [ -f {{ $pidFile }} ] && kill -0 $(cat {{ $pidFile }}) 2>/dev/null; then
+  echo "system_powerdown" | socat - UNIX-CONNECT:{{ $monitorSocket }}
+  echo "Node {{ $nodeName }} soft shutdown initiated"
+else
+  echo "Node {{ $nodeName }} not running"
+fi
+{{- else if eq .Cmd "PowerStatus" -}}
+if [ -f {{ $pidFile }} ] && kill -0 $(cat {{ $pidFile }}) 2>/dev/null; then
+  echo "ON"
+else
+  echo "OFF"
+fi
+{{- else if eq .Cmd "SDRList" -}}
+echo "=== Node {{ $nodeName }} Configuration ==="
+echo "CPU: {{ $cpu }}"
+echo "Memory: {{ $memory }}MB"
+echo "Disk: {{ $diskFile }}"
+if [ -f {{ $diskFile }} ]; then
+  qemu-img info {{ $diskFile }} | grep -E "(virtual size|disk size|format)"
+else
+  echo "Disk not created yet"
+fi
+if [ -f {{ $pidFile }} ]; then
+  echo "PID file: {{ $pidFile }}"
+  if kill -0 $(cat {{ $pidFile }}) 2>/dev/null; then
+    echo "Status: Running (PID: $(cat {{ $pidFile }}))"
+  else
+    echo "Status: Stopped (stale PID file)"
+  fi
+else
+  echo "Status: Not created"
+fi
+{{- else if eq .Cmd "SensorList" -}}
+if [ -f {{ $pidFile }} ] && kill -0 $(cat {{ $pidFile }}) 2>/dev/null; then
+  echo "info status" | socat - UNIX-CONNECT:{{ $monitorSocket }}
+else
+  echo "Node {{ $nodeName }} not running"
+fi
+{{- else if eq .Cmd "Console" -}}
+if [ -f {{ $pidFile }} ] && kill -0 $(cat {{ $pidFile }}) 2>/dev/null; then
+  echo "Cannot attach console - node started in daemon mode"
+  echo "Consider restarting with -serial stdio for console access"
+else
+  echo "Node {{ $nodeName }} not running"
+fi
+{{- else -}}
+echo "Unknown command: {{ .Cmd }}"
+{{- end -}}

--- a/lib/warewulf/bmc/kind.tmpl
+++ b/lib/warewulf/bmc/kind.tmpl
@@ -1,0 +1,96 @@
+{{- /* kind.tmpl - Docker-based virtual node management for BMC simulation */ -}}
+{{- $nodeName := .Ipaddr | toString | replace "." "-" -}}
+{{- if .Tags.nodename }}{{ $nodeName = .Tags.nodename }}{{ end -}}
+{{- $cpu := "2" }}{{ if .Tags.cpu }}{{ $cpu = .Tags.cpu }}{{ end -}}
+{{- $memory := "2g" }}{{ if .Tags.memory }}{{ $memory = .Tags.memory }}{{ end -}}
+{{- $disk := "20g" }}{{ if .Tags.disk }}{{ $disk = .Tags.disk }}{{ end -}}
+{{- $image := "kindest/node:latest" }}{{ if .Tags.image }}{{ $image = .Tags.image }}{{ end -}}
+{{- if eq .Cmd "PowerOn" -}}
+if docker inspect {{ $nodeName }} &>/dev/null; then
+  if [ "$(docker inspect -f '{{`{{.State.Running}}`}}' {{ $nodeName }})" == "false" ]; then
+    docker start {{ $nodeName }}
+    echo "Node {{ $nodeName }} started"
+  else
+    echo "Node {{ $nodeName }} already running"
+  fi
+else
+  docker run -d \
+    --name {{ $nodeName }} \
+    --hostname {{ $nodeName }} \
+    --cpus {{ $cpu }} \
+    --memory {{ $memory }} \
+    --tmpfs /tmp \
+    --tmpfs /run \
+    --volume /var \
+    --volume /lib/modules:/lib/modules:ro \
+    --privileged \
+    {{ $image }}
+  echo "Node {{ $nodeName }} created and started (CPU: {{ $cpu }}, Memory: {{ $memory }}, Disk: {{ $disk }})"
+fi
+{{- else if eq .Cmd "PowerOff" -}}
+if docker inspect {{ $nodeName }} &>/dev/null; then
+  if [ "$(docker inspect -f '{{`{{.State.Running}}`}}' {{ $nodeName }})" == "true" ]; then
+    docker stop {{ $nodeName }}
+    echo "Node {{ $nodeName }} stopped"
+  else
+    echo "Node {{ $nodeName }} already stopped"
+  fi
+else
+  echo "Node {{ $nodeName }} does not exist"
+fi
+{{- else if eq .Cmd "PowerCycle" -}}
+if docker inspect {{ $nodeName }} &>/dev/null; then
+  docker restart {{ $nodeName }}
+  echo "Node {{ $nodeName }} restarted"
+else
+  echo "Node {{ $nodeName }} does not exist"
+fi
+{{- else if eq .Cmd "PowerReset" -}}
+if docker inspect {{ $nodeName }} &>/dev/null; then
+  docker restart {{ $nodeName }}
+  echo "Node {{ $nodeName }} reset"
+else
+  echo "Node {{ $nodeName }} does not exist"
+fi
+{{- else if eq .Cmd "PowerSoft" -}}
+if docker inspect {{ $nodeName }} &>/dev/null; then
+  docker exec {{ $nodeName }} reboot 2>/dev/null || docker restart {{ $nodeName }}
+  echo "Node {{ $nodeName }} soft reboot"
+else
+  echo "Node {{ $nodeName }} does not exist"
+fi
+{{- else if eq .Cmd "PowerStatus" -}}
+if docker inspect {{ $nodeName }} &>/dev/null; then
+  if [ "$(docker inspect -f '{{`{{.State.Running}}`}}' {{ $nodeName }})" == "true" ]; then
+    echo "ON"
+  else
+    echo "OFF"
+  fi
+else
+  echo "NOT_EXIST"
+fi
+{{- else if eq .Cmd "SDRList" -}}
+if docker inspect {{ $nodeName }} &>/dev/null; then
+  echo "Node: {{ $nodeName }}"
+  echo "CPU: {{ $cpu }}"
+  echo "Memory: {{ $memory }}"
+  echo "Disk: {{ $disk }}"
+  echo "Image: {{ $image }}"
+else
+  echo "Node {{ $nodeName }} does not exist"
+fi
+{{- else if eq .Cmd "SensorList" -}}
+if docker inspect {{ $nodeName }} &>/dev/null && [ "$(docker inspect -f '{{`{{.State.Running}}`}}' {{ $nodeName }})" == "true" ]; then
+  docker stats {{ $nodeName }} --no-stream --no-trunc
+else
+  echo "Node {{ $nodeName }} not running"
+fi
+{{- else if eq .Cmd "Console" -}}
+if docker inspect {{ $nodeName }} &>/dev/null && [ "$(docker inspect -f '{{`{{.State.Running}}`}}' {{ $nodeName }})" == "true" ]; then
+  docker exec -it {{ $nodeName }} /bin/bash
+else
+  echo "Node {{ $nodeName }} not running"
+fi
+{{- else -}}
+echo "Unknown command: {{ .Cmd }}"
+{{- end -}}

--- a/userdocs/nodes/ipmi.rst
+++ b/userdocs/nodes/ipmi.rst
@@ -151,3 +151,133 @@ subcommand.
 * ``SDRList``
 * ``SensorList``
 * ``Console``
+
+Virtual BMC Templates
+======================
+
+Warewulf includes templates for managing virtual machines as simulated cluster
+nodes for testing and development. These templates use IPMI tags to configure
+virtual machine resources like CPU, memory, and disk size.
+
+Available Virtual BMC Templates
+--------------------------------
+
+kind.tmpl (Docker-based)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Uses Docker containers to simulate virtual nodes. Lightweight and doesn't require
+full hardware virtualization.
+
+.. code-block:: console
+
+   wwctl node set vnode1 \
+     --ipmiaddr=10.0.0.100 \
+     --ipmitemplate=kind.tmpl \
+     --ipmitagadd nodename=vnode1 \
+     --ipmitagadd cpu=4 \
+     --ipmitagadd memory=4g \
+     --ipmitagadd disk=50g \
+     --ipmitagadd image=kindest/node:latest
+
+kind-libvirt.tmpl (KVM/Libvirt-based)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Uses libvirt and KVM for full hardware virtualization. Provides more realistic
+virtual machines with better isolation.
+
+.. code-block:: console
+
+   wwctl node set vnode2 \
+     --ipmiaddr=10.0.0.101 \
+     --ipmitemplate=kind-libvirt.tmpl \
+     --ipmitagadd nodename=vnode2 \
+     --ipmitagadd cpu=4 \
+     --ipmitagadd memory=4096 \
+     --ipmitagadd disk=50 \
+     --ipmitagadd disk_path=/var/lib/libvirt/images \
+     --ipmitagadd os_variant=ubuntu22.04
+
+kind-qemu.tmpl (QEMU-based)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Uses QEMU directly for virtual machine management. Provides fine-grained control
+over VM configuration and doesn't require libvirt.
+
+.. code-block:: console
+
+   wwctl node set vnode3 \
+     --ipmiaddr=10.0.0.102 \
+     --ipmitemplate=kind-qemu.tmpl \
+     --ipmitagadd nodename=vnode3 \
+     --ipmitagadd cpu=2 \
+     --ipmitagadd memory=2048 \
+     --ipmitagadd disk=20 \
+     --ipmitagadd disk_path=/var/lib/qemu/images \
+     --ipmitagadd mac=52:54:00:12:34:56
+
+Virtual BMC Configuration Tags
+-------------------------------
+
+The following IPMI tags can be used to configure virtual machine resources:
+
++-------------------+------------------------------------+-----------------------------+
+| Tag               | Description                        | Default                     |
++===================+====================================+=============================+
+| ``nodename``      | Custom VM name                     | IP address with dashes      |
++-------------------+------------------------------------+-----------------------------+
+| ``cpu``           | Number of CPUs                     | 2                           |
++-------------------+------------------------------------+-----------------------------+
+| ``memory``        | Memory size                        | 2g (kind), 2048 (others)    |
++-------------------+------------------------------------+-----------------------------+
+| ``disk``          | Disk size                          | 20g (kind), 20 (others)     |
++-------------------+------------------------------------+-----------------------------+
+| ``disk_path``     | Path for VM disk images            | /var/lib/libvirt/images or  |
+|                   |                                    | /var/lib/qemu/images        |
++-------------------+------------------------------------+-----------------------------+
+| ``image``         | Docker image (kind.tmpl only)      | kindest/node:latest         |
++-------------------+------------------------------------+-----------------------------+
+| ``os_variant``    | OS variant (kind-libvirt.tmpl)     | generic                     |
++-------------------+------------------------------------+-----------------------------+
+| ``mac``           | MAC address (kind-qemu.tmpl)       | Auto-generated              |
++-------------------+------------------------------------+-----------------------------+
+
+Virtual Node Power Management
+------------------------------
+
+Virtual nodes can be managed using the same ``wwctl power`` commands as physical
+nodes:
+
+.. code-block:: console
+
+   # Power on creates the VM if it doesn't exist
+   wwctl power on vnode1
+
+   # Power status checks if VM is running
+   wwctl power status vnode1
+
+   # SDR list shows VM configuration
+   wwctl power sdr vnode1
+
+   # Power off stops the VM but doesn't destroy it
+   wwctl power off vnode1
+
+**PowerOn Behavior**: When powering on a virtual node, the template will:
+
+1. Check if the VM already exists
+2. If it exists and is stopped, start it
+3. If it doesn't exist, create it with the configured resources, then start it
+
+**PowerOff Behavior**: Powering off stops the VM but preserves it for future use.
+The VM and its disk are not destroyed.
+
+Template Access
+---------------
+
+IPMI tags can be accessed in templates using the ``.Tags`` map:
+
+.. code-block::
+
+   {{ $cpu := "2" }}{{ if .Tags.cpu }}{{ $cpu = .Tags.cpu }}{{ end }}
+   {{ $memory := "2048" }}{{ if .Tags.memory }}{{ $memory = .Tags.memory }}{{ end }}
+   {{ $nodeName := .Ipaddr | toString | replace "." "-" }}
+   {{ if .Tags.nodename }}{{ $nodeName = .Tags.nodename }}{{ end }}


### PR DESCRIPTION
It's Adrian's fault!
When checking the new integrated tests where a "fake" ipmitool command is used to create VMs I had the idea to have this as an feature.
This also makes any API call to `power` much more complicated, but may be incredibly useful for day to day work for admins, e.g. when they want to test new images or templates!