### PR TITLE
Properly package new chrony overlay

### DIFF
--- a/warewulf.spec.in
+++ b/warewulf.spec.in
@@ -195,6 +195,7 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %dir %{_overlaydir}/*
 %dir %{_overlaydir}/*/rootfs
 %{_overlaydir}/NetworkManager/rootfs/*
+%{_overlaydir}/chrony/rootfs/*
 %{_overlaydir}/debian.interfaces/rootfs/*
 %{_overlaydir}/debug/rootfs/*
 %{_overlaydir}/fstab/rootfs/*


### PR DESCRIPTION
## Description of the Pull Request (PR):

The chrony overlay added at #2087 didn't update `warewulf.spec.in`, so it wasn't included in packages. This further caused the packaging to fail due to unexpected files.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
