### PR TITLE
add DNS to netplan overlay

### DIFF
--- a/overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww
+++ b/overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww
@@ -6,13 +6,13 @@ network:
 {{- $ethernets := list }}
 {{- $bonds := list }}
 {{- range $devname, $netdev := $NetDevs }}
-  {{- if $netdev.Device }}
-    {{- if eq (default "ethernet" (lower $netdev.Type)) "ethernet" }}
-      {{- $ethernets = append $ethernets $devname }}
-    {{- else if eq (lower $netdev.Type) "bond" }}
-      {{- $bonds = append $bonds $devname }}
-    {{- end }}
-  {{- end }}
+{{- if $netdev.Device }}
+{{- if eq (default "ethernet" (lower $netdev.Type)) "ethernet" }}
+{{- $ethernets = append $ethernets $devname }}
+{{- else if eq (lower $netdev.Type) "bond" }}
+{{- $bonds = append $bonds $devname }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- if $ethernets }}
   ethernets:
@@ -93,9 +93,9 @@ network:
         mii-monitor-interval: {{ default 100 $netdev.Tags.miimon }}
 {{- $interfaces := list }}
 {{- range $iface := $NetDevs }}
-  {{- if eq $iface.Tags.master $netdev.Device }}
-    {{- $interfaces = append $interfaces $iface.Device }}
-  {{- end }}
+{{- if eq $iface.Tags.master $netdev.Device }}
+{{- $interfaces = append $interfaces $iface.Device }}
+{{- end }}
 {{- end }}
 {{- if $interfaces }}
       interfaces:

--- a/overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww
+++ b/overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww
@@ -39,6 +39,7 @@ network:
 {{- if $netdev.MTU}}
       mtu: {{$netdev.MTU}}
 {{- end }}
+{{- $nameservers := list }}
 {{- range $tk, $tv := $netdev.Tags }}
   {{- if regexMatch "^DNS[0-9]*$" $tk }}
     {{- $nameservers = append $nameservers $tv }}
@@ -49,13 +50,13 @@ network:
 {{- if $nameservers }}
       addresses:
 {{- range $addr := $nameservers }}
-      - $addr
+      - {{ $addr }}
 {{- end }}
 {{- end }}
 {{- if $netdev.Tags.DNSSEARCH }}
       search:
-{{- range $domain := $netdev.Tags.DNSSEARCH }}
-      - $domain
+{{- range $domain := (split " " $netdev.Tags.DNSSEARCH) }}
+      - {{ $domain }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -90,9 +91,9 @@ network:
         mii-monitor-interval: {{ default 100 $netdev.Tags.miimon }}
 {{- $interfaces := list }}
 {{- range $iface := $NetDevs }}
-{{- if eq $iface.Tags.master $netdev.Device }}
-{{- $interfaces = append $interfaces $iface.Device }}
-{{- end }}
+  {{- if eq $iface.Tags.master $netdev.Device }}
+    {{- $interfaces = append $interfaces $iface.Device }}
+  {{- end }}
 {{- end }}
 {{- if $interfaces }}
       interfaces:

--- a/overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww
+++ b/overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww
@@ -55,7 +55,7 @@ network:
 {{- end }}
 {{- if $netdev.Tags.DNSSEARCH }}
       search:
-{{- range $domain := (split " " $netdev.Tags.DNSSEARCH) }}
+{{- range $domain := (regexSplit "[ \t]+" $netdev.Tags.DNSSEARCH -1) }}
       - {{ $domain }}
 {{- end }}
 {{- end }}

--- a/overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww
+++ b/overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww
@@ -6,13 +6,13 @@ network:
 {{- $ethernets := list }}
 {{- $bonds := list }}
 {{- range $devname, $netdev := $NetDevs }}
-{{- if $netdev.Device }}
-{{- if eq (default "ethernet" (lower $netdev.Type)) "ethernet" }}
-{{- $ethernets = append $ethernets $devname }}
-{{- else if eq (lower $netdev.Type) "bond" }}
-{{- $bonds = append $bonds $devname }}
-{{- end }}
-{{- end }}
+  {{- if $netdev.Device }}
+    {{- if eq (default "ethernet" (lower $netdev.Type)) "ethernet" }}
+      {{- $ethernets = append $ethernets $devname }}
+    {{- else if eq (lower $netdev.Type) "bond" }}
+      {{- $bonds = append $bonds $devname }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 {{- if $ethernets }}
   ethernets:
@@ -38,6 +38,24 @@ network:
 {{- end }}
 {{- if $netdev.MTU}}
       mtu: {{$netdev.MTU}}
+{{- end }}
+{{- range $tk, $tv := $netdev.Tags }}
+  {{- if regexMatch "^DNS[0-9]*$" $tk }}
+    {{- $nameservers = append $nameservers $tv }}
+  {{- end }}
+{{- end }}
+{{- if or $nameservers $netdev.Tags.DNSSEARCH }}
+    nameservers:
+{{- if $nameservers }}
+      addresses:
+{{- range $addr := $nameservers }}
+      - $addr
+{{- end }}
+{{- end }}
+{{- if $netdev.Tags.DNSSEARCH }}
+      search:
+{{- range $domain := $netdev.Tags.DNSSEARCH }}
+      - $domain
 {{- end }}
 {{- end }}
 {{- end }}

--- a/overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww
+++ b/overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww
@@ -61,6 +61,8 @@ network:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}
+{{- end }}
 {{- if $bonds }}
   bonds:
 {{- range $netdev := $NetDevs }}

--- a/overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww
+++ b/overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww
@@ -46,17 +46,17 @@ network:
   {{- end }}
 {{- end }}
 {{- if or $nameservers $netdev.Tags.DNSSEARCH }}
-    nameservers:
+      nameservers:
 {{- if $nameservers }}
-      addresses:
+        addresses:
 {{- range $addr := $nameservers }}
-      - {{ $addr }}
+        - {{ $addr }}
 {{- end }}
 {{- end }}
 {{- if $netdev.Tags.DNSSEARCH }}
-      search:
+        search:
 {{- range $domain := (regexSplit "[ \t]+" $netdev.Tags.DNSSEARCH -1) }}
-      - {{ $domain }}
+        - {{ $domain }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
I can't test the latest version of the template in my current environment because the version of warewulf I'm running doesn't understand `Gateway6`. So I tested just the DNS portion of the template:

```console
$ cat /srv/warewulf/overlays/netplan/rootfs/etc/netplan/warewulf.yaml.ww
{{- $NetDevs := .NetDevs }}
{{- range $devname, $netdev := $NetDevs }}

{{- $nameservers := list }}
{{- range $tk, $tv := $netdev.Tags }}
  {{- if regexMatch "^DNS[0-9]*$" $tk }}
    {{- $nameservers = append $nameservers $tv }}
  {{- end }}
{{- end }}
{{- if or $nameservers $netdev.Tags.DNSSEARCH }}
    nameservers:
{{- if $nameservers }}
      addresses:
{{- range $addr := $nameservers }}
      - {{ $addr }}
{{- end }}
{{- end }}
{{- if $netdev.Tags.DNSSEARCH }}
      search:
{{- range $domain := (regexSplit "[ \t]+" $netdev.Tags.DNSSEARCH -1) }}
      - {{ $domain }}
{{- end }}
{{- end }}
{{- end }}

{{- end }}
$ wwctl node export dnstest
dnstest:
  profiles:
    - default
  system overlay:
    - netplan
  network devices:
    default:
      type: ethernet
      device: eno0
      netmask: 255.255.0.0
      gateway: 10.100.0.1
      mtu: "9000"
      tags:
        DNS1: foo
        DNS2: bar
        DNSSEARCH: example.org
  primary network: default
$ wwctl overlay cat --render dnstest netplan /etc/netplan/warewulf.yaml.ww
backupFile: true
writeFile: true
Filename: /etc/netplan/warewulf.yaml

    nameservers:
      addresses:
      - foo
      - bar
      search:
      - example.org
```

Note: I haven't ensured that the nameserver addresses are in the right order.

Note: I'm not sure what will happen if you provide search domains without also providing addresses.