### PR TITLE
Remove DSA from default SSH key types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Changed
+
+- Remove `dsa` from default `ssh: key types`; sshd silently skips DSA host keys
+  on EL9 / OpenSSH 8.7p1+, leaving nodes with no usable host keys. #1185
+
 ## v4.7.0, 2026-05-12
 
 ### Fixed

--- a/etc/warewulf.conf
+++ b/etc/warewulf.conf
@@ -37,4 +37,3 @@ ssh:
     - ed25519
     - ecdsa
     - rsa
-    - dsa

--- a/etc/warewulf.conf-suse
+++ b/etc/warewulf.conf-suse
@@ -37,4 +37,3 @@ ssh:
     - ed25519
     - ecdsa
     - rsa
-    - dsa

--- a/internal/pkg/config/root_test.go
+++ b/internal/pkg/config/root_test.go
@@ -38,7 +38,6 @@ ssh:
   - ed25519
   - ecdsa
   - rsa
-  - dsa
 tftp:
   enabled: true
   ipxe:
@@ -85,7 +84,6 @@ ssh:
   - ed25519
   - ecdsa
   - rsa
-  - dsa
 tftp:
   enabled: true
   ipxe:
@@ -134,7 +132,6 @@ ssh:
   - ed25519
   - ecdsa
   - rsa
-  - dsa
 tftp:
   enabled: true
   ipxe:
@@ -180,7 +177,6 @@ ssh:
   - ed25519
   - ecdsa
   - rsa
-  - dsa
 tftp:
   enabled: true
   ipxe:
@@ -263,7 +259,6 @@ ssh:
   - ed25519
   - ecdsa
   - rsa
-  - dsa
 tftp:
   enabled: true
   ipxe:

--- a/internal/pkg/config/ssh.go
+++ b/internal/pkg/config/ssh.go
@@ -1,5 +1,5 @@
 package config
 
 type SSHConf struct {
-	KeyTypes []string `yaml:"key types,omitempty" default:"[\"ed25519\",\"ecdsa\",\"rsa\",\"dsa\"]"`
+	KeyTypes []string `yaml:"key types,omitempty" default:"[\"ed25519\",\"ecdsa\",\"rsa\"]"`
 }

--- a/overlays/debug/internal/debug_test.go
+++ b/overlays/debug/internal/debug_test.go
@@ -120,7 +120,6 @@ data from other structures.
   - ed25519
   - ecdsa
   - rsa
-  - dsa
 - First key type: ed25519
 
 ## Node

--- a/userdocs/server/configuration.rst
+++ b/userdocs/server/configuration.rst
@@ -50,7 +50,6 @@ Re-run both of these commands when making changes to ``warewulf.conf``.
        - ed25519
        - ecdsa
        - rsa
-       - dsa
    image mounts:
      - source: /etc/resolv.conf
        dest: /etc/resolv.conf
@@ -254,7 +253,6 @@ Warewulf server.
        - ed25519
        - ecdsa
        - rsa
-       - dsa
 
 * ``ssh:key types``: Warewulf generates host keys for each listed key type.
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

DSA (ssh-dss) has been disabled at runtime by default since OpenSSH 7.0 (2015). On EL9 / OpenSSH 8.7p1 sshd explicitly skips DSA host keys with "ssh-dss is disabled" and exits if no other host keys are configured, causing `wwctl configure ssh` to leave nodes with no usable host keys. EL8 / OpenSSH 8.0p1 still loads DSA keys, but the key type is deprecated and will be removed from OpenSSH entirely in a future release.

warewulf.conf-el10 already omitted dsa; align warewulf.conf, warewulf.conf-suse, and the Go default to match.

This fix was identified while upstreaming OpenHPC (OHPC) packaging fixes for Warewulf 4.7.0. OpenHPC carries a patched warewulf.conf-el10 without dsa; the intent is to fix the issue upstream so downstream distributions do not need to carry workarounds.

Tested with docker containers on AlmaLinux 8.10, AlmaLinux 9.7, RockyLinux 8.10, and RockyLinux 9 — confirmed DSA key generation succeeds on all four but sshd refuses to load the key on EL9.



## This fixes or addresses the following GitHub issues:

- Fixes #1185


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [X] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [X] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [X] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [X] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [X] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [X] The test suite has been updated, if necessary
