### PR TITLE
Rebuild host overlay when running 'wwctl configure -a' (fixes #2181)

### DIFF
--- a/internal/app/wwctl/configure/main.go
+++ b/internal/app/wwctl/configure/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
 	"github.com/warewulf/warewulf/internal/pkg/configure"
+	"github.com/warewulf/warewulf/internal/pkg/overlay"
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
@@ -20,6 +21,15 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if allFunctions {
+		if conf.Warewulf.EnableHostOverlay() {
+			wwlog.Info("Building overlay...")
+			if err = overlay.BuildHostOverlay(); err != nil {
+				wwlog.Warn("host overlay could not be built: %s", err)
+			}
+		} else {
+			wwlog.Info("host overlays are disabled")
+		}
+
 		if _, err = configure.TLS(false); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Bug

Running `wwctl configure -a` on a controller where DHCP, NFS, and the SSH host-key step are all disabled (or otherwise skipped) does not regenerate the host overlay. Subsequent boots / services see stale overlay contents.

## Root cause

The host overlay rebuild (`overlay.BuildHostOverlay()`) is implemented inside the per-service `configure.DHCP`, `configure.NFS`, and `configure.SSH` functions — and each is gated on that service being enabled (`controller.DHCP.Enabled()`, `controller.NFS.Enabled()`, `os.Getuid() == 0` for SSH). `configure.TLS`, `WAREWULFD`, `TFTP`, and `Hostfile` never rebuild it.

So under `-a`, if none of DHCP/NFS/SSH actually run their overlay branch, the overlay is never rebuilt — even though running e.g. `wwctl configure dhcp` individually on a DHCP-enabled host would rebuild it.

## Fix

Rebuild the host overlay once at the top of the `-a` branch in `internal/app/wwctl/configure/main.go`, using the same `EnableHostOverlay()` guard and warn-on-error pattern already used in `configure.DHCP`. This makes `-a` always do at least as much overlay work as the union of the individual subcommands.

The per-service rebuilds are left in place so the individual subcommands' behavior is unchanged. A redundant second rebuild during `-a` is harmless (idempotent).

Fixes #2181