### PR TITLE
Fix kernel version detection for kernels with a version-like suffix after the dist tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Kernel version detection for kernels whose RPM release field contains a
   version-like suffix after the dist tag (e.g. `5.14.0-687.10.1.el9_8.0.1`).
   These were mis-detected (e.g. `8.0.1` instead of `5.14.0-687.10.1`) because
-  `ParseVersion` returned the last regex match found in the kernel path.
+  `ParseVersion` returned the last regex match found in the kernel path. This
+  also caused the wrong kernel to be selected as the default. #2199
 
 ## v4.7.0, 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove `dsa` from default `ssh: key types`; sshd silently skips DSA host keys
   on EL9 / OpenSSH 8.7p1+, leaving nodes with no usable host keys. #1185
 
+### Fixed
+
+- Kernel version detection for kernels whose RPM release field contains a
+  version-like suffix after the dist tag (e.g. `5.14.0-687.10.1.el9_8.0.1`).
+  These were mis-detected (e.g. `8.0.1` instead of `5.14.0-687.10.1`) because
+  `ParseVersion` returned the last regex match found in the kernel path.
+
 ## v4.7.0, 2026-05-12
 
 ### Fixed

--- a/internal/pkg/util/version.go
+++ b/internal/pkg/util/version.go
@@ -17,8 +17,8 @@ func init() {
 
 func ParseVersion(versionString string) *version.Version {
 	matches := versionPattern.FindAllString(versionString, -1)
-	for i := len(matches) - 1; i >= 0; i-- {
-		if version_, err := version.NewVersion(strings.TrimSuffix(matches[i], ".")); err == nil {
+	for _, match := range matches {
+		if version_, err := version.NewVersion(strings.TrimSuffix(match, ".")); err == nil {
 			return version_
 		}
 	}

--- a/internal/pkg/util/version_test.go
+++ b/internal/pkg/util/version_test.go
@@ -12,7 +12,9 @@ func TestParseVersion(t *testing.T) {
 		"el10_2 with suffix after dist": {"/lib/modules/6.12.0-211.16.1.el10_2.0.1.x86_64/vmlinuz", "6.12.0-211.16.1"},
 		"el9_8 with suffix after dist":  {"/lib/modules/5.14.0-687.10.1.el9_8.0.1.x86_64/vmlinuz", "5.14.0-687.10.1"},
 		"el9_8 plain dist tag":          {"/lib/modules/5.14.0-687.10.1.el9_8.x86_64/vmlinuz", "5.14.0-687.10.1"},
+		"el9_7 respin suffix (#2199)":   {"/boot/vmlinuz-5.14.0-611.55.1.el9_7.0.3.x86_64", "5.14.0-611.55.1"},
 		"boot path with .gz":            {"/boot/vmlinuz-5.14.0-427.24.1.el9_4.x86_64.gz", "5.14.0-427.24.1"},
+		"leap16":                        {"/lib/modules/6.12.0-160000.33-default/vmlinuz", "6.12.0-160000.33"},
 		"no version in path":            {"/boot/vmlinuz-linux", ""},
 	}
 	for name, tt := range tests {

--- a/internal/pkg/util/version_test.go
+++ b/internal/pkg/util/version_test.go
@@ -1,0 +1,29 @@
+package util
+
+import "testing"
+
+func TestParseVersion(t *testing.T) {
+	tests := map[string]struct {
+		path     string
+		expected string
+	}{
+		"el9_4 module path":             {"/lib/modules/5.14.0-427.37.1.el9_4.aarch64/vmlinuz", "5.14.0-427.37.1"},
+		"el8_6 boot path":               {"/boot/vmlinuz-4.18.0-372.13.1.el8_6.x86_64", "4.18.0-372.13.1"},
+		"el10_2 with suffix after dist": {"/lib/modules/6.12.0-211.16.1.el10_2.0.1.x86_64/vmlinuz", "6.12.0-211.16.1"},
+		"el9_8 with suffix after dist":  {"/lib/modules/5.14.0-687.10.1.el9_8.0.1.x86_64/vmlinuz", "5.14.0-687.10.1"},
+		"el9_8 plain dist tag":          {"/lib/modules/5.14.0-687.10.1.el9_8.x86_64/vmlinuz", "5.14.0-687.10.1"},
+		"boot path with .gz":            {"/boot/vmlinuz-5.14.0-427.24.1.el9_4.x86_64.gz", "5.14.0-427.24.1"},
+		"no version in path":            {"/boot/vmlinuz-linux", ""},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := ""
+			if v := ParseVersion(tt.path); v != nil {
+				got = v.String()
+			}
+			if got != tt.expected {
+				t.Errorf("ParseVersion(%q) = %q, want %q", tt.path, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Problem

`internal/pkg/util/version.go` `ParseVersion` returns the **last** `\d+\.\d+\.\d+(-[\d\.]+|)` match found in the kernel path. Some kernel RPMs carry a version-like suffix in the release field _after_ the dist tag — for example `5.14.0-687.10.1.el9_8.0.1.x86_64`, where `el9_8.0.1` yields a second, spurious match `8.0.1` to the right of the real release `5.14.0-687.10.1`. Because the loop returns the last match, `wwctl image kernels` and the `.Kernel.Version` overlay variable report `8.0.1`. The same shape affects e.g. `el10_2.0.1` (→ `2.0.1`). Kernels without such a suffix produce a single match and are unaffected, which is why this went unnoticed.

This also breaks default-kernel selection: an image with `el9_7.0.1` / `el9_7.0.3` / `el9_8` kernels parses the first two as `7.0.1` / `7.0.3`, which `go-version` ranks above the genuinely newer `5.14.0-687.12.1` (major `7 > 5`), so `kernel.collection.Default()` boots the older kernel.

### Fix

Iterate the matches forward and return the **first** valid version. The real kernel release is always the leftmost version token in the search-glob paths (`/boot/vmlinuz-<ver>`, `/lib/modules/<ver>/vmlinuz`); any dist-tag fragment is to its right.

### Tests

*   Added `internal/pkg/util/version_test.go` (there was no test for `ParseVersion`) covering plain `el9_4`/`el8_6` paths, paths with a version-like suffix after the dist tag (`el9_8.0.1`, `el10_2.0.1`), a plain `el9_8` path, a `.gz` path, a path with no version, and an `el9_7` respin case using the exact path from #2199. The suffix cases fail before this change and pass after.
*   Existing `internal/pkg/kernel` tests are unaffected (their paths have a single version match).

### Note for reviewers

I changed the selection order rather than the regex. I couldn't determine the original rationale for iterating in reverse; if there was a case that required it, an alternative is to select the longest match — happy to adjust.

Also fixes #2199.
