### PR TITLE
don't hide curl output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Remove `dsa` from default `ssh: key types`; sshd silently skips DSA host keys
   on EL9 / OpenSSH 8.7p1+, leaving nodes with no usable host keys. #1185
-- Add an `ipv6_method` node tag to set the NetworkManager `[ipv6]` method, e.g. `auto` for SLAAC.
+- Add an `ipv6_method` node tag to set the NetworkManager `[ipv6]` method, e.g.
+  `auto` for SLAAC.
+- Don't silence curl when downloading with dracut. #2200
 
 ### Fixed
 

--- a/dracut/modules.d/90wwinit/load-wwinit.sh
+++ b/dracut/modules.d/90wwinit/load-wwinit.sh
@@ -44,7 +44,7 @@ get_stage() {
         runtime) uri="${base}/runtime/${hwaddr}" ;;
     esac
     (
-        curl --location --silent --get ${localport} ${cacert_opt} \
+        curl --location --get ${localport} ${cacert_opt} \
             --retry 60 --retry-connrefused --retry-delay 1 \
             --data-urlencode "assetkey=${wwinit_assetkey}" \
             --data-urlencode "uuid=${wwinit_uuid}" \


### PR DESCRIPTION
I am having a tough time getting my node to boot with dracut. I was getting this error message in console:

```
Starting dracut-pre-mount.service - dracut pre-mount hook...
dracut-pre-mount: gzip: stdin: unexpected end of file
dracut-pre-mount: cpio: premature end of archive
dracut: FATAL: Unable to load stage: system
dracut: refusing to continue
```

Which comes from here:

https://github.com/warewulf/warewulf/blob/5cc2177a6e3d27a2c91b0b7a94140f9d8b28d1c4/dracut/modules.d/90wwinit/load-wwinit.sh#L47-L54

After adding the `rc.shell` and `rc.break` kernel arguments, I was able to open a shell, and to my surprise, the `curl | gzip | cpio` pipeline worked just fine for me.

I modified the `load-wwinit.sh` script inside my node image to remove the `--silent` argument from `curl`, re-ran `dracut --force --no-hostonly --add wwinit --regenerate-all`, regenerated my node image, `systemctl reload warewulfd`, power cycled my node, and now I can see the problem:

```
Starting dracut-pre-mount.service - dracut pre-mount hook...
dracut-pre-mount: % Total % Received % Xfered Average Speed    Time    Time    Time   Current
dracut-pre-mount:                             Dload  Upload    Total   Spent   Left   Speed
dracut-pre-mount: 0       0          0        0      0         0       0       0      0
dracut-pre-mount: curl: (7) Failed to connect to <warewulf IP here> port 9873 after 0 ms: Couldn't connect to server
dracut-pre-mount: gzip: stdin: unexpected end of file
dracut-pre-mount: cpio: premature end of archive
dracut: FATAL: Unable to load stage: system
dracut: refusing to continue
```

I'm not sure why it couldn't connect, and I'm not sure why it didn't retry, but I am sure that it would have been nice if the dracut script hadn't hid this error from me.

It would be nice if curl had a more fine-grained CLI option to squash the progress output without also squashing error messages. Maybe such an option does exist and I overlooked it.