### PR TITLE
wwclient unitfile update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- wwclient.service changed to allow internal retry logic to continue forever,
+  instead of being terminated after 60s if startup is slow (f.ex temporary
+  network failure). Attempt restart if wwclient terminates abnormally.
 - Remove `dsa` from default `ssh: key types`; sshd silently skips DSA host keys
   on EL9 / OpenSSH 8.7p1+, leaving nodes with no usable host keys. #1185
 
 ### Fixed
 
+- Remove obsolete PIDFile directive from wwclient.service
 - Kernel version detection for kernels whose RPM release field contains a
   version-like suffix after the dist tag (e.g. `5.14.0-687.10.1.el9_8.0.1`).
   These were mis-detected (e.g. `8.0.1` instead of `5.14.0-687.10.1`) because

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  
 ### Changed
 
+- wwclient.service changed to accommodate internal retry logic. #2203
 - Remove `dsa` from default `ssh: key types`; sshd silently skips DSA host keys
   on EL9 / OpenSSH 8.7p1+, leaving nodes with no usable host keys. #1185
 - Add an `ipv6_method` node tag to set the NetworkManager `[ipv6]` method, e.g.
@@ -51,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   colliding 32-bit values when building node images and overlays: pass
   `--renumber-inodes` to cpio when the installed version supports it (GNU cpio
   >= 2.13). #2091
+- Remove obsolete PIDFile directive from wwclient.service. #2203
 - Kernel version detection for kernels whose RPM release field contains a
   version-like suffix after the dist tag (e.g. `5.14.0-687.10.1.el9_8.0.1`).
   These were mis-detected (e.g. `8.0.1` instead of `5.14.0-687.10.1`) because

--- a/overlays/wwclient/rootfs/etc/systemd/system/wwclient.service
+++ b/overlays/wwclient/rootfs/etc/systemd/system/wwclient.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Warewulf node runtime overlay update
+Documentation=https://warewulf.org/
+Wants=network.target
 After=network.target
 After=local-fs.target
 
@@ -8,8 +10,11 @@ Type=notify
 EnvironmentFile=-/etc/default/wwclient
 ExecStart=/warewulf/wwclient
 ExecReload=/bin/kill -s SIGHUP "$MAINPID"
-PIDFile=/var/run/wwclient.pid
-TimeoutSec=60
+TimeoutStartSec=infinity
+TimeoutStopSec=30
+Restart=on-failure
+RestartSec=5
+StartLimitIntervalSec=0
 
 [Install]
 WantedBy=multi-user.target

--- a/overlays/wwclient/rootfs/etc/systemd/system/wwclient.service
+++ b/overlays/wwclient/rootfs/etc/systemd/system/wwclient.service
@@ -1,15 +1,19 @@
 [Unit]
 Description=Warewulf node runtime overlay update
+Documentation=https://warewulf.org/
 After=network.target
 After=local-fs.target
+StartLimitIntervalSec=0
 
 [Service]
 Type=notify
 EnvironmentFile=-/etc/default/wwclient
 ExecStart=/warewulf/wwclient
 ExecReload=/bin/kill -s SIGHUP "$MAINPID"
-PIDFile=/var/run/wwclient.pid
-TimeoutSec=60
+TimeoutStartSec=infinity
+TimeoutStopSec=90
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Description of the Pull Request (PR):

Update unit file to avoid systemd terminating wwclient if startup is slow, f.ex if networking takes a while to be ready.

wwclient has internal retry logic, but the previous unit config didn't take this into account and would just kill the process after 60 seconds regardless, due to TimeoutSec being set.

This PR changes the behaviour to wait forever on startup and allow up to 30s for service stops.

It also adds Restart=on-failure so that if wwclient crashes or fails it won't require manual intervention to come back up should the cause of failure disappear.  Stopping or killing wwclient will _not_ trigger a restart.

In addition, the obsolete pidfile directive is removed and a documentation link is provided

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
