### PR TITLE
build: default source-install PREFIX to /opt/warewulf

### DIFF
--- a/Variables.mk
+++ b/Variables.mk
@@ -28,7 +28,15 @@ endif
 
 # System directory paths
 VARLIST += PREFIX BINDIR SYSCONFDIR SRVDIR DATADIR MANDIR DOCDIR LOCALSTATEDIR RELEASE CACHEDIR
-PREFIX ?= /usr/local
+# When building from source on a system without an OS-release-detected install
+# (i.e. not a distro package build), default to /opt/warewulf to avoid
+# conflicts with package-manager-installed files. Distro packagers and users
+# who prefer /usr/local can override with: make PREFIX=/usr/local install
+ifeq ($(USE_LSB_PATHS),)
+  PREFIX ?= /opt/warewulf
+else
+  PREFIX ?= /usr/local
+endif
 BINDIR ?= $(PREFIX)/bin
 SYSCONFDIR ?= $(PREFIX)/etc
 DATADIR ?= $(PREFIX)/share


### PR DESCRIPTION
Closes #2094

When Warewulf is built from source with `make install` the current default `PREFIX` is `/usr/local`. On systems where Warewulf was also installed via an OS package (RPM or DEB) this causes the source-built binaries and config files to overwrite or conflict with package-manager-tracked files.

**Change**
When `USE_LSB_PATHS` is not set (i.e. no OS type was detected, which is the case for a plain source build), the default `PREFIX` is now `/opt/warewulf`. All Warewulf files then install under a single self-contained directory, making it easy to inspect and remove a source build without touching system paths.

Distro packagers and users who prefer the traditional layout are unaffected: RPM/DEB builds set `USE_LSB_PATHS` before `PREFIX` is evaluated, so they continue to use `/usr/local` (or their own `PREFIX` override).

Users can still override explicitly:
```
make PREFIX=/usr/local install
```