### PR TITLE
Add --renumber-inodes to cpio image builds to prevent hardlink corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Prevent cpio hardlink corruption caused by 64-bit inode numbers truncating to
+  colliding 32-bit values when building node images and overlays: pass
+  `--renumber-inodes` to cpio when the installed version supports it (GNU cpio
+  >= 2.13). #2091
 - Kernel version detection for kernels whose RPM release field contains a
   version-like suffix after the dist tag (e.g. `5.14.0-687.10.1.el9_8.0.1`).
   These were mis-detected (e.g. `8.0.1` instead of `5.14.0-687.10.1`) because

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,7 +32,7 @@
 - Andreas Skau <andreas@scheen.no> @buzh
 - Dietmar Rieder <dietmar.rieder@i-med.ac.at>
 - Andreas Henkel <henkel@uni-mainz.de>
-- Timothy Middelkoop <tmiddelkoop@internet2.edu>
+- Timothy Middelkoop <tmiddelkoop@internet2.edu> @middelkoopt
 - Shane Nehring <snehring@iastate.edu>
 - Tobias Ribizel <mail@ribizel.de>
 - Tobias Poschwatta <poschwatta@zib.de>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM opensuse/tumbleweed:latest AS builder
 
-RUN zypper  -n install --no-recommends git go1.25 unzip &&\
+RUN zypper  -n install --no-recommends gawk git go1.25 unzip &&\
   zypper -n install -t pattern devel_basis
 
 # now build the warewulf

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -366,6 +367,21 @@ func AppendLines(fileName string, lines []string) (err error) {
 	return nil
 }
 
+var (
+	cpioRenumberInodesOnce   sync.Once
+	cpioRenumberInodesCached bool
+)
+
+// cpioRenumberInodesSupported returns true if the installed cpio supports
+// --renumber-inodes (GNU cpio >= 2.13). Result is cached after the first call.
+func cpioRenumberInodesSupported() bool {
+	cpioRenumberInodesOnce.Do(func() {
+		out, _ := exec.Command("cpio", "--help").CombinedOutput()
+		cpioRenumberInodesCached = strings.Contains(string(out), "--renumber-inodes")
+	})
+	return cpioRenumberInodesCached
+}
+
 /*
 ******************************************************************************
 
@@ -384,6 +400,10 @@ func CpioCreate(
 		"--directory", rootdir,
 		"--format", format,
 		"--file=" + ofile,
+	}
+
+	if cpioRenumberInodesSupported() {
+		args = append(args, "--renumber-inodes")
 	}
 
 	args = append(args, cpio_args...)


### PR DESCRIPTION
## Summary

When 64-bit inode numbers truncate to colliding 32-bit values, cpio incorrectly
merges distinct hardlink groups, corrupting files in the extracted archive on
booted nodes. GNU cpio's `--renumber-inodes` remaps each hardlink group to a
unique 32-bit inode, avoiding the collision.

This fix passes `--renumber-inodes` to both `CpioCreate` call sites (node images
and overlays) when the installed cpio supports it. Support is detected at runtime
via `cpio --help` and cached (sync.Once) — this handles distros that backport the
flag to older cpio versions (e.g. RHEL/Rocky/Alma 8 ship cpio 2.12 with the flag
backported). Verified present on all warewulf target distros: EL8/9/10, Leap 15.6/16,
Debian 12/13, Ubuntu 24.04/26.04.

Fixes #2091

## Testing

End-to-end tested via hpc-lab warewulf workflow (qemu, aarch64):

- AlmaLinux 10: built from branch, c1 booted, NFS mounted, `strace` confirmed `cpio ... --renumber-inodes` fires on overlay build ✓
- AlmaLinux 9: node booted, NFS mounted, munge+slurm active, `srun` job ran, `strace` confirmed ✓
- Debian 13: node booted, NFS mounted, munge+slurm active, `srun` job ran, `strace` confirmed ✓

## Reviewer checklist

- [ ] PR is based on main
- [ ] Commits are signed off (DCO)
- [ ] CHANGELOG updated
- [ ] Contributors file updated
- [ ] Tests updated if necessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)