### PR TITLE
Fix breaking Dockerfile build due to upstream change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM opensuse/tumbleweed:latest AS builder
 
-RUN zypper  -n install --no-recommends git go1.25 unzip &&\
+RUN zypper  -n install --no-recommends gawk git go1.25 unzip &&\
   zypper -n install -t pattern devel_basis
 
 # now build the warewulf


### PR DESCRIPTION
## Description of the Pull Request (PR):

The devel_basis pattern requires patterns-devel-base-devel_basis, which pulls in the real GNU gawk package. But the Tumbleweed base image now ships busybox-gawk (part of the recent move to busybox for base utilities), which already provides the gawk capability. zypper sees a conflict (two packages can't both own /usr/bin/gawk) and won't auto-swap one for the other in non-interactive mode, so it aborts.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
