### PR TITLE
Display changes in confirmation prompt when doing "wwctl [node/profile] set"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- `wwctl node set` and `wwctl profile set` now display a per-field
+  before/after diff of the changes they are about to apply before prompting
+  for confirmation. Nodes (or profiles) receiving identical changes are
+  grouped onto a single header. Suppressed by `-y`/`--yes`.
+
 ### Changed
 
 - Remove `dsa` from default `ssh: key types`; sshd silently skips DSA host keys

--- a/internal/app/wwctl/node/set/main.go
+++ b/internal/app/wwctl/node/set/main.go
@@ -2,7 +2,6 @@ package set
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -171,7 +170,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 				wwlog.Info("No changes to apply.")
 				return nil
 			}
-			fmt.Fprint(os.Stderr, summary)
+			wwlog.Output("%s", summary)
 			if !util.Confirm(fmt.Sprintf("Apply these changes to %d node(s)?", len(nodeChanges))) {
 				return nil
 			}

--- a/internal/app/wwctl/node/set/main.go
+++ b/internal/app/wwctl/node/set/main.go
@@ -66,7 +66,6 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 		}
 
 		changed := cmd.Flags().Changed
-		var count uint
 		nodeChanges := map[string][]node.Change{}
 		for _, nId := range args {
 			wwlog.Debug("evaluating node: %s", nId)
@@ -78,6 +77,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 			var before *node.Node
 			if !vars.setYes {
 				before = nodePtr.Clone()
+				before.Flatten()
 			}
 			nodePtr.UpdateFrom(&vars.nodeConf, changed)
 			if vars.nodeDel.NetDel != "" {
@@ -159,9 +159,10 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 			}
 			nodePtr.Flatten()
 			if before != nil {
-				nodeChanges[nId] = node.DiffProfile(&before.Profile, &nodePtr.Profile)
+				if ch := node.Diff(before, nodePtr); len(ch) > 0 {
+					nodeChanges[nId] = ch
+				}
 			}
-			count++
 		}
 
 		if !vars.setYes {
@@ -171,7 +172,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 				return nil
 			}
 			fmt.Fprint(os.Stderr, summary)
-			if !util.Confirm(fmt.Sprintf("Apply these changes to %d node(s)?", count)) {
+			if !util.Confirm(fmt.Sprintf("Apply these changes to %d node(s)?", len(nodeChanges))) {
 				return nil
 			}
 		}

--- a/internal/app/wwctl/node/set/main.go
+++ b/internal/app/wwctl/node/set/main.go
@@ -2,6 +2,7 @@ package set
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -66,12 +67,17 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 
 		changed := cmd.Flags().Changed
 		var count uint
+		nodeChanges := map[string][]node.Change{}
 		for _, nId := range args {
 			wwlog.Debug("evaluating node: %s", nId)
 			nodePtr, err := nodeDB.GetNodeOnlyPtr(nId)
 			if err != nil {
 				wwlog.Warn("invalid node: %s", nId)
 				continue
+			}
+			var before *node.Node
+			if !vars.setYes {
+				before = nodePtr.Clone()
 			}
 			nodePtr.UpdateFrom(&vars.nodeConf, changed)
 			if vars.nodeDel.NetDel != "" {
@@ -152,11 +158,20 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 				}
 			}
 			nodePtr.Flatten()
+			if before != nil {
+				nodeChanges[nId] = node.DiffProfile(&before.Profile, &nodePtr.Profile)
+			}
 			count++
 		}
 
 		if !vars.setYes {
-			if !util.Confirm(fmt.Sprintf("Are you sure you want to modify %d nodes(s)", count)) {
+			summary := node.FormatChanges(nodeChanges)
+			if summary == "" {
+				wwlog.Info("No changes to apply.")
+				return nil
+			}
+			fmt.Fprint(os.Stderr, summary)
+			if !util.Confirm(fmt.Sprintf("Apply these changes to %d node(s)?", count)) {
 				return nil
 			}
 		}

--- a/internal/app/wwctl/node/set/main.go
+++ b/internal/app/wwctl/node/set/main.go
@@ -73,11 +73,8 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 				wwlog.Warn("invalid node: %s", nId)
 				continue
 			}
-			var before *node.Node
-			if !vars.setYes {
-				before = nodePtr.Clone()
-				before.Flatten()
-			}
+			before := nodePtr.Clone()
+			before.Flatten()
 			nodePtr.UpdateFrom(&vars.nodeConf, changed)
 			if vars.nodeDel.NetDel != "" {
 				if _, ok := nodePtr.NetDevs[vars.nodeDel.NetDel]; !ok {
@@ -164,16 +161,19 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 			}
 		}
 
+		summary := node.FormatChanges(nodeChanges)
 		if !vars.setYes {
-			summary := node.FormatChanges(nodeChanges)
 			if summary == "" {
 				wwlog.Info("No changes to apply.")
 				return nil
 			}
 			wwlog.Output("%s", summary)
 			if !util.Confirm(fmt.Sprintf("Apply these changes to %d node(s)?", len(nodeChanges))) {
+				wwlog.Info("No changes made!")
 				return nil
 			}
+		} else {
+			wwlog.Output("Applying following changes:\n%s", summary)
 		}
 
 		if err := nodeDB.Persist(); err != nil {

--- a/internal/app/wwctl/node/unset/main.go
+++ b/internal/app/wwctl/node/unset/main.go
@@ -43,24 +43,7 @@ func CobraRunE(vars *wwctlunset.Vars) func(cmd *cobra.Command, args []string) er
 			return err
 		}
 
-		// Confirmation prompt
-		if !vars.UnsetYes {
-			count := 0
-			for _, nodeName := range args {
-				if _, ok := nodeDB.Nodes[nodeName]; ok {
-					count++
-				}
-			}
-			if count == 0 {
-				return fmt.Errorf("no valid nodes found")
-			}
-			wwctlunset.WarnDeletions(vars)
-			yes := util.Confirm(fmt.Sprintf("Are you sure you want to modify %d node(s)", count))
-			if !yes {
-				return nil
-			}
-		}
-
+		nodeChanges := map[string][]node.Change{}
 		modifiedCount := 0
 		for _, nodeName := range args {
 			nodePtr, ok := nodeDB.Nodes[nodeName]
@@ -72,14 +55,40 @@ func CobraRunE(vars *wwctlunset.Vars) func(cmd *cobra.Command, args []string) er
 				continue
 			}
 
+			before := nodePtr.Clone()
+			before.Flatten()
+
 			if err := wwctlunset.UpdateEntity(nodePtr, vars); err != nil {
 				return err
 			}
 			modifiedCount++
+
+			nodePtr.Flatten()
+			if before != nil {
+				if ch := node.Diff(before, nodePtr); len(ch) > 0 {
+					nodeChanges[nodeName] = ch
+				}
+			}
 		}
 
 		if modifiedCount == 0 {
 			return fmt.Errorf("no nodes were modified")
+		}
+
+		summary := node.FormatChanges(nodeChanges)
+		if !vars.UnsetYes {
+			if summary == "" {
+				wwlog.Info("No changes to apply.")
+				return nil
+			}
+			wwlog.Output("%s", summary)
+			wwctlunset.WarnDeletions(vars)
+			if !util.Confirm(fmt.Sprintf("Apply these changes to %d node(s)?", len(nodeChanges))) {
+				wwlog.Info("No changes made!")
+				return nil
+			}
+		} else {
+			wwlog.Output("Applying following changes:\n%s", summary)
 		}
 
 		if err := nodeDB.Persist(); err != nil {

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -2,7 +2,6 @@ package set
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -168,7 +167,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 				wwlog.Info("No changes to apply.")
 				return nil
 			}
-			fmt.Fprint(os.Stderr, summary)
+			wwlog.Output("%s", summary)
 			if !util.Confirm(fmt.Sprintf("Apply these changes to %d profile(s)?", len(profileChanges))) {
 				return nil
 			}

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -61,7 +61,6 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 		}
 
 		changed := cmd.Flags().Changed
-		var count uint
 		profileChanges := map[string][]node.Change{}
 		for _, profileId := range args {
 			wwlog.Verbose("evaluating profile: %s", profileId)
@@ -73,6 +72,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 			var before *node.Profile
 			if !vars.setYes {
 				before = profilePtr.Clone()
+				before.Flatten()
 			}
 			profilePtr.UpdateFrom(&vars.profileConf, changed)
 			if vars.profileDel.NetDel != "" {
@@ -156,9 +156,10 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 			}
 			profilePtr.Flatten()
 			if before != nil {
-				profileChanges[profileId] = node.DiffProfile(before, profilePtr)
+				if ch := node.Diff(before, profilePtr); len(ch) > 0 {
+					profileChanges[profileId] = ch
+				}
 			}
-			count++
 		}
 
 		if !vars.setYes {
@@ -168,7 +169,7 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 				return nil
 			}
 			fmt.Fprint(os.Stderr, summary)
-			if !util.Confirm(fmt.Sprintf("Apply these changes to %d profile(s)?", count)) {
+			if !util.Confirm(fmt.Sprintf("Apply these changes to %d profile(s)?", len(profileChanges))) {
 				return nil
 			}
 		}

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -68,11 +68,8 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 				wwlog.Warn("invalid profile: %s", profileId)
 				continue
 			}
-			var before *node.Profile
-			if !vars.setYes {
-				before = profilePtr.Clone()
-				before.Flatten()
-			}
+			before := profilePtr.Clone()
+			before.Flatten()
 			profilePtr.UpdateFrom(&vars.profileConf, changed)
 			if vars.profileDel.NetDel != "" {
 				if _, ok := profilePtr.NetDevs[vars.profileDel.NetDel]; !ok {
@@ -161,16 +158,19 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 			}
 		}
 
+		summary := node.FormatChanges(profileChanges)
 		if !vars.setYes {
-			summary := node.FormatChanges(profileChanges)
 			if summary == "" {
 				wwlog.Info("No changes to apply.")
 				return nil
 			}
 			wwlog.Output("%s", summary)
 			if !util.Confirm(fmt.Sprintf("Apply these changes to %d profile(s)?", len(profileChanges))) {
+				wwlog.Info("No changes made!")
 				return nil
 			}
+		} else {
+			wwlog.Output("Applying following changes:\n %s", summary)
 		}
 
 		if err := nodeDB.Persist(); err != nil {

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -2,6 +2,7 @@ package set
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -61,12 +62,17 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 
 		changed := cmd.Flags().Changed
 		var count uint
+		profileChanges := map[string][]node.Change{}
 		for _, profileId := range args {
 			wwlog.Verbose("evaluating profile: %s", profileId)
 			profilePtr, err := nodeDB.GetProfilePtr(profileId)
 			if err != nil {
 				wwlog.Warn("invalid profile: %s", profileId)
 				continue
+			}
+			var before *node.Profile
+			if !vars.setYes {
+				before = profilePtr.Clone()
 			}
 			profilePtr.UpdateFrom(&vars.profileConf, changed)
 			if vars.profileDel.NetDel != "" {
@@ -149,12 +155,20 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 				}
 			}
 			profilePtr.Flatten()
+			if before != nil {
+				profileChanges[profileId] = node.DiffProfile(before, profilePtr)
+			}
 			count++
 		}
 
 		if !vars.setYes {
-			yes := util.Confirm(fmt.Sprintf("Are you sure you want to modify %d profile(s)", count))
-			if !yes {
+			summary := node.FormatChanges(profileChanges)
+			if summary == "" {
+				wwlog.Info("No changes to apply.")
+				return nil
+			}
+			fmt.Fprint(os.Stderr, summary)
+			if !util.Confirm(fmt.Sprintf("Apply these changes to %d profile(s)?", count)) {
 				return nil
 			}
 		}

--- a/internal/app/wwctl/profile/unset/main.go
+++ b/internal/app/wwctl/profile/unset/main.go
@@ -39,24 +39,7 @@ func CobraRunE(vars *wwctlunset.Vars) func(cmd *cobra.Command, args []string) er
 			return err
 		}
 
-		// Confirmation prompt
-		if !vars.UnsetYes {
-			count := 0
-			for _, profileName := range args {
-				if _, ok := nodeDB.NodeProfiles[profileName]; ok {
-					count++
-				}
-			}
-			if count == 0 {
-				return fmt.Errorf("no valid profiles found")
-			}
-			wwctlunset.WarnDeletions(vars)
-			yes := util.Confirm(fmt.Sprintf("Are you sure you want to modify %d profile(s)", count))
-			if !yes {
-				return nil
-			}
-		}
-
+		profileChanges := map[string][]node.Change{}
 		modifiedCount := 0
 		for _, profileName := range args {
 			profilePtr, ok := nodeDB.NodeProfiles[profileName]
@@ -68,14 +51,40 @@ func CobraRunE(vars *wwctlunset.Vars) func(cmd *cobra.Command, args []string) er
 				continue
 			}
 
+			before := profilePtr.Clone()
+			before.Flatten()
+
 			if err := wwctlunset.UpdateEntity(profilePtr, vars); err != nil {
 				return err
 			}
 			modifiedCount++
+
+			profilePtr.Flatten()
+			if before != nil {
+				if ch := node.Diff(before, profilePtr); len(ch) > 0 {
+					profileChanges[profileName] = ch
+				}
+			}
 		}
 
 		if modifiedCount == 0 {
 			return fmt.Errorf("no profiles were modified")
+		}
+
+		summary := node.FormatChanges(profileChanges)
+		if !vars.UnsetYes {
+			if summary == "" {
+				wwlog.Info("No changes to apply.")
+				return nil
+			}
+			wwlog.Output("%s", summary)
+			wwctlunset.WarnDeletions(vars)
+			if !util.Confirm(fmt.Sprintf("Apply these changes to %d profile(s)?", len(profileChanges))) {
+				wwlog.Info("No changes made!")
+				return nil
+			}
+		} else {
+			wwlog.Output("Applying following changes:\n%s", summary)
 		}
 
 		if err := nodeDB.Persist(); err != nil {

--- a/internal/pkg/hostlist/hostlist.go
+++ b/internal/pkg/hostlist/hostlist.go
@@ -2,6 +2,7 @@ package hostlist
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -99,6 +100,87 @@ func splitTopLevel(s string) []string {
 	}
 	parts = append(parts, s[start:])
 	return parts
+}
+
+// Compress is the inverse of Expand: it returns a hostlist-style string in
+// which numeric suffixes sharing a prefix and zero-pad width are collapsed
+// into bracket notation. E.g. ["n01","n02","n03","n05"] -> "n[01-03,05]".
+// Names without a trailing digit run are emitted as-is.
+func Compress(ids []string) string {
+	type group struct {
+		prefix   string
+		width    int
+		nums     []int
+		single   string
+		firstIdx int
+	}
+	groups := map[string]*group{}
+	var order []string
+	for idx, id := range ids {
+		i := len(id)
+		for i > 0 && id[i-1] >= '0' && id[i-1] <= '9' {
+			i--
+		}
+		var key string
+		if i == len(id) {
+			key = "\x00" + id
+		} else {
+			key = id[:i] + "\x00" + strconv.Itoa(len(id)-i)
+		}
+		g, ok := groups[key]
+		if !ok {
+			g = &group{firstIdx: idx}
+			if i == len(id) {
+				g.single = id
+			} else {
+				g.prefix = id[:i]
+				g.width = len(id) - i
+			}
+			groups[key] = g
+			order = append(order, key)
+		}
+		if g.width > 0 {
+			n, _ := strconv.Atoi(id[i:])
+			g.nums = append(g.nums, n)
+		}
+	}
+	sort.SliceStable(order, func(i, j int) bool {
+		return groups[order[i]].firstIdx < groups[order[j]].firstIdx
+	})
+
+	var parts []string
+	for _, k := range order {
+		g := groups[k]
+		if g.width == 0 {
+			parts = append(parts, g.single)
+			continue
+		}
+		sort.Ints(g.nums)
+		if len(g.nums) == 1 {
+			parts = append(parts, fmt.Sprintf("%s%0*d", g.prefix, g.width, g.nums[0]))
+			continue
+		}
+		var ranges []string
+		start, prev := g.nums[0], g.nums[0]
+		flush := func() {
+			if start == prev {
+				ranges = append(ranges, fmt.Sprintf("%0*d", g.width, start))
+			} else {
+				ranges = append(ranges, fmt.Sprintf("%0*d-%0*d", g.width, start, g.width, prev))
+			}
+		}
+		for _, v := range g.nums[1:] {
+			if v == prev+1 {
+				prev = v
+				continue
+			}
+			flush()
+			start, prev = v, v
+		}
+		flush()
+		parts = append(parts, fmt.Sprintf("%s[%s]", g.prefix, strings.Join(ranges, ",")))
+	}
+	return strings.Join(parts, ",")
 }
 
 // toInt converts a numeric string to an integer. Assumes valid input.

--- a/internal/pkg/hostlist/hostlist_test.go
+++ b/internal/pkg/hostlist/hostlist_test.go
@@ -71,3 +71,26 @@ func TestHostList(t *testing.T) {
 		})
 	}
 }
+
+func TestCompress(t *testing.T) {
+	tests := map[string]struct {
+		input  []string
+		output string
+	}{
+		"empty":             {input: nil, output: ""},
+		"single":            {input: []string{"n01"}, output: "n01"},
+		"consecutive":       {input: []string{"n01", "n02", "n03"}, output: "n[01-03]"},
+		"sparse":            {input: []string{"n01", "n03", "n05"}, output: "n[01,03,05]"},
+		"mixed run + gap":   {input: []string{"n01", "n02", "n04"}, output: "n[01-02,04]"},
+		"different prefix":  {input: []string{"n01", "n02", "rack01"}, output: "n[01-02],rack01"},
+		"different width":   {input: []string{"n1", "n01"}, output: "n1,n01"},
+		"no digits":         {input: []string{"head", "login"}, output: "head,login"},
+		"cross-zero rollup": {input: []string{"n09", "n10", "n11"}, output: "n[09-11]"},
+		"out of order":      {input: []string{"n03", "n01", "n02"}, output: "n[01-03]"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.output, Compress(tt.input))
+		})
+	}
+}

--- a/internal/pkg/node/diff.go
+++ b/internal/pkg/node/diff.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/warewulf/warewulf/internal/pkg/hostlist"
 	"gopkg.in/yaml.v3"
 )
 
@@ -222,7 +223,7 @@ func FormatChanges(entityChanges map[string][]Change) string {
 		if i > 0 {
 			b.WriteString("\n")
 		}
-		fmt.Fprintf(&b, "%s:\n", strings.Join(g.ids, ", "))
+		fmt.Fprintf(&b, "%s:\n", hostlist.Compress(g.ids))
 		for _, c := range g.changes {
 			fmt.Fprintf(&b, "  %s: %s → %s\n", c.Path, c.Before, c.After)
 		}

--- a/internal/pkg/node/diff.go
+++ b/internal/pkg/node/diff.go
@@ -9,44 +9,41 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Change is a single field-level difference between two profiles.
+// Change is a single field-level difference.
 type Change struct {
 	Path   string
 	Before string
 	After  string
 }
 
-// Clone returns a deep copy of the profile via YAML round-trip.
+// Clone deep-copies the profile via YAML round-trip.
 func (p *Profile) Clone() *Profile {
 	data, err := yaml.Marshal(p)
 	if err != nil {
-		return nil
+		panic(fmt.Sprintf("Profile.Clone: marshal failed: %v", err))
 	}
 	out := NewProfile(p.Id())
 	if err := yaml.Unmarshal(data, &out); err != nil {
-		return nil
+		panic(fmt.Sprintf("Profile.Clone: unmarshal failed: %v", err))
 	}
 	return &out
 }
 
-// Clone returns a deep copy of the node via YAML round-trip.
+// Clone deep-copies the node via YAML round-trip.
 func (n *Node) Clone() *Node {
 	data, err := yaml.Marshal(n)
 	if err != nil {
-		return nil
+		panic(fmt.Sprintf("Node.Clone: marshal failed: %v", err))
 	}
 	out := NewNode(n.Id())
 	if err := yaml.Unmarshal(data, &out); err != nil {
-		return nil
+		panic(fmt.Sprintf("Node.Clone: unmarshal failed: %v", err))
 	}
 	return &out
 }
 
-// DiffProfile returns the field-level differences between before and after.
-// Paths use lopt-tag names when available (falling back to lowercase field
-// names) and bracket notation for map keys (e.g. "tags[hostname]",
-// "netdev[default].ipaddr"). The result is sorted by path.
-func DiffProfile(before, after *Profile) []Change {
+// Diff returns the field-level differences between before and after, sorted by path; paths use lopt-tag names with bracket notation for map keys (e.g. "tags[hostname]").
+func Diff[T Profile | Node](before, after *T) []Change {
 	var changes []Change
 	diffStruct(reflect.ValueOf(before).Elem(), reflect.ValueOf(after).Elem(), "", &changes)
 	sort.Slice(changes, func(i, j int) bool { return changes[i].Path < changes[j].Path })
@@ -104,7 +101,7 @@ func diffValue(before, after reflect.Value, path string, out *[]Change) {
 	case reflect.Map:
 		diffMap(before, after, path, out)
 	case reflect.Slice:
-		// Byte slices (e.g. net.IP) render via their Stringer rather than as a list of bytes.
+		// net.IP and other byte slices render via Stringer, not as a byte list.
 		if before.Type().Elem().Kind() == reflect.Uint8 {
 			bs, as := fmtScalar(before), fmtScalar(after)
 			if bs != as {
@@ -151,7 +148,6 @@ func diffMap(before, after reflect.Value, prefix string, out *[]Change) {
 
 func mapGet(m reflect.Value, key string) reflect.Value {
 	if !m.IsValid() || m.IsNil() {
-		// Return a zero value of the element type so callers can recurse safely.
 		return reflect.Zero(m.Type().Elem())
 	}
 	v := m.MapIndex(reflect.ValueOf(key))
@@ -193,9 +189,7 @@ func fmtScalar(v reflect.Value) string {
 	return "<unset>"
 }
 
-// FormatChanges renders a per-entity change map as a multi-line summary.
-// Entities (nodes or profiles) with the same change-set are grouped together
-// onto a single header line. Returns "" when there are no changes.
+// FormatChanges renders a per-entity change map; entities with identical change-sets share a header line. Returns "" when empty.
 func FormatChanges(entityChanges map[string][]Change) string {
 	type group struct {
 		ids     []string

--- a/internal/pkg/node/diff.go
+++ b/internal/pkg/node/diff.go
@@ -1,0 +1,256 @@
+package node
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Change is a single field-level difference between two profiles.
+type Change struct {
+	Path   string
+	Before string
+	After  string
+}
+
+// Clone returns a deep copy of the profile via YAML round-trip.
+func (p *Profile) Clone() *Profile {
+	data, err := yaml.Marshal(p)
+	if err != nil {
+		return nil
+	}
+	out := NewProfile(p.Id())
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		return nil
+	}
+	return &out
+}
+
+// Clone returns a deep copy of the node via YAML round-trip.
+func (n *Node) Clone() *Node {
+	data, err := yaml.Marshal(n)
+	if err != nil {
+		return nil
+	}
+	out := NewNode(n.Id())
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		return nil
+	}
+	return &out
+}
+
+// DiffProfile returns the field-level differences between before and after.
+// Paths use lopt-tag names when available (falling back to lowercase field
+// names) and bracket notation for map keys (e.g. "tags[hostname]",
+// "netdev[default].ipaddr"). The result is sorted by path.
+func DiffProfile(before, after *Profile) []Change {
+	var changes []Change
+	diffStruct(reflect.ValueOf(before).Elem(), reflect.ValueOf(after).Elem(), "", &changes)
+	sort.Slice(changes, func(i, j int) bool { return changes[i].Path < changes[j].Path })
+	return changes
+}
+
+func diffStruct(before, after reflect.Value, prefix string, out *[]Change) {
+	t := before.Type()
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		name := f.Tag.Get("lopt")
+		if name == "" {
+			name = strings.ToLower(f.Name)
+		}
+		path := name
+		if prefix != "" {
+			path = prefix + "." + name
+		}
+		if f.Anonymous {
+			path = prefix
+		}
+		diffValue(before.Field(i), after.Field(i), path, out)
+	}
+}
+
+func diffValue(before, after reflect.Value, path string, out *[]Change) {
+	switch before.Kind() {
+	case reflect.Struct:
+		diffStruct(before, after, path, out)
+	case reflect.Ptr:
+		bNil := !before.IsValid() || before.IsNil()
+		aNil := !after.IsValid() || after.IsNil()
+		if bNil && aNil {
+			return
+		}
+		var b, a reflect.Value
+		if bNil {
+			b = reflect.New(before.Type().Elem()).Elem()
+		} else {
+			b = before.Elem()
+		}
+		if aNil {
+			a = reflect.New(after.Type().Elem()).Elem()
+		} else {
+			a = after.Elem()
+		}
+		if b.Kind() == reflect.Struct {
+			diffStruct(b, a, path, out)
+		} else if bs, as := fmtScalar(b), fmtScalar(a); bs != as {
+			*out = append(*out, Change{Path: path, Before: bs, After: as})
+		}
+	case reflect.Map:
+		diffMap(before, after, path, out)
+	case reflect.Slice:
+		// Byte slices (e.g. net.IP) render via their Stringer rather than as a list of bytes.
+		if before.Type().Elem().Kind() == reflect.Uint8 {
+			bs, as := fmtScalar(before), fmtScalar(after)
+			if bs != as {
+				*out = append(*out, Change{Path: path, Before: bs, After: as})
+			}
+			return
+		}
+		bs, as := fmtSlice(before), fmtSlice(after)
+		if bs != as {
+			*out = append(*out, Change{Path: path, Before: bs, After: as})
+		}
+	default:
+		b, a := fmtScalar(before), fmtScalar(after)
+		if b != a {
+			*out = append(*out, Change{Path: path, Before: b, After: a})
+		}
+	}
+}
+
+func diffMap(before, after reflect.Value, prefix string, out *[]Change) {
+	keys := make(map[string]bool)
+	collect := func(v reflect.Value) {
+		if !v.IsValid() || v.IsNil() {
+			return
+		}
+		for _, k := range v.MapKeys() {
+			keys[k.String()] = true
+		}
+	}
+	collect(before)
+	collect(after)
+	ordered := make([]string, 0, len(keys))
+	for k := range keys {
+		ordered = append(ordered, k)
+	}
+	sort.Strings(ordered)
+	for _, k := range ordered {
+		bv := mapGet(before, k)
+		av := mapGet(after, k)
+		path := fmt.Sprintf("%s[%s]", prefix, k)
+		diffValue(bv, av, path, out)
+	}
+}
+
+func mapGet(m reflect.Value, key string) reflect.Value {
+	if !m.IsValid() || m.IsNil() {
+		// Return a zero value of the element type so callers can recurse safely.
+		return reflect.Zero(m.Type().Elem())
+	}
+	v := m.MapIndex(reflect.ValueOf(key))
+	if !v.IsValid() {
+		return reflect.Zero(m.Type().Elem())
+	}
+	return v
+}
+
+func fmtScalar(v reflect.Value) string {
+	if !v.IsValid() {
+		return "<unset>"
+	}
+	switch v.Kind() {
+	case reflect.String:
+		if v.String() == "" {
+			return "<unset>"
+		}
+		return fmt.Sprintf("%q", v.String())
+	case reflect.Bool:
+		return fmt.Sprintf("%t", v.Bool())
+	case reflect.Interface:
+		if v.IsNil() {
+			return "<unset>"
+		}
+		return fmt.Sprintf("%v", v.Interface())
+	}
+	if v.CanInterface() {
+		iv := v.Interface()
+		if s, ok := iv.(fmt.Stringer); ok {
+			out := s.String()
+			if out == "" || out == "<nil>" {
+				return "<unset>"
+			}
+			return out
+		}
+		return fmt.Sprintf("%v", iv)
+	}
+	return "<unset>"
+}
+
+// FormatChanges renders a per-entity change map as a multi-line summary.
+// Entities (nodes or profiles) with the same change-set are grouped together
+// onto a single header line. Returns "" when there are no changes.
+func FormatChanges(entityChanges map[string][]Change) string {
+	type group struct {
+		ids     []string
+		changes []Change
+	}
+	groups := map[string]*group{}
+	var order []string
+	for id, ch := range entityChanges {
+		if len(ch) == 0 {
+			continue
+		}
+		key := fingerprint(ch)
+		if g, ok := groups[key]; ok {
+			g.ids = append(g.ids, id)
+		} else {
+			groups[key] = &group{ids: []string{id}, changes: ch}
+			order = append(order, key)
+		}
+	}
+	if len(groups) == 0 {
+		return ""
+	}
+	sort.Slice(order, func(i, j int) bool {
+		return groups[order[i]].ids[0] < groups[order[j]].ids[0]
+	})
+	var b strings.Builder
+	for i, key := range order {
+		g := groups[key]
+		sort.Strings(g.ids)
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "%s:\n", strings.Join(g.ids, ", "))
+		for _, c := range g.changes {
+			fmt.Fprintf(&b, "  %s: %s → %s\n", c.Path, c.Before, c.After)
+		}
+	}
+	return b.String()
+}
+
+func fingerprint(changes []Change) string {
+	parts := make([]string, len(changes))
+	for i, c := range changes {
+		parts[i] = c.Path + "\x00" + c.Before + "\x00" + c.After
+	}
+	return strings.Join(parts, "\n")
+}
+
+func fmtSlice(v reflect.Value) string {
+	if !v.IsValid() || v.IsNil() || v.Len() == 0 {
+		return "[]"
+	}
+	parts := make([]string, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		parts[i] = fmt.Sprintf("%v", v.Index(i).Interface())
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}

--- a/internal/pkg/node/diff.go
+++ b/internal/pkg/node/diff.go
@@ -16,7 +16,7 @@ type Change struct {
 	After  string
 }
 
-// Clone deep-copies the profile via YAML round-trip.
+// Profile.Clone yaml deep copy
 func (p *Profile) Clone() *Profile {
 	data, err := yaml.Marshal(p)
 	if err != nil {
@@ -29,7 +29,7 @@ func (p *Profile) Clone() *Profile {
 	return &out
 }
 
-// Clone deep-copies the node via YAML round-trip.
+// Node.Clone yaml deep copy
 func (n *Node) Clone() *Node {
 	data, err := yaml.Marshal(n)
 	if err != nil {
@@ -42,7 +42,7 @@ func (n *Node) Clone() *Node {
 	return &out
 }
 
-// Diff returns the field-level differences between before and after, sorted by path; paths use lopt-tag names with bracket notation for map keys (e.g. "tags[hostname]").
+// Field-level diff between before and after, sorted by path; use lopt-tag names with bracket notation for map keys (e.g. "tags[hostname]").
 func Diff[T Profile | Node](before, after *T) []Change {
 	var changes []Change
 	diffStruct(reflect.ValueOf(before).Elem(), reflect.ValueOf(after).Elem(), "", &changes)
@@ -189,7 +189,7 @@ func fmtScalar(v reflect.Value) string {
 	return "<unset>"
 }
 
-// FormatChanges renders a per-entity change map; entities with identical change-sets share a header line. Returns "" when empty.
+// Render a per-entity change map; entities with identical change-sets share a header line. Returns "" when empty.
 func FormatChanges(entityChanges map[string][]Change) string {
 	type group struct {
 		ids     []string

--- a/internal/pkg/node/diff_test.go
+++ b/internal/pkg/node/diff_test.go
@@ -7,42 +7,42 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDiffProfile_NoChange(t *testing.T) {
+func TestDiff_NoChange(t *testing.T) {
 	a := NewNode("n01")
 	a.Comment = "hello"
 	a.SystemOverlay = []string{"wwinit"}
 	b := a.Clone()
 
-	changes := DiffProfile(&a.Profile, &b.Profile)
+	changes := Diff(&a.Profile, &b.Profile)
 	assert.Empty(t, changes)
 }
 
-func TestDiffProfile_ScalarString(t *testing.T) {
+func TestDiff_ScalarString(t *testing.T) {
 	a := NewNode("n01")
 	a.Comment = "old"
 	b := a.Clone()
 	b.Comment = "new"
 
-	changes := DiffProfile(&a.Profile, &b.Profile)
+	changes := Diff(&a.Profile, &b.Profile)
 	assert.Equal(t, []Change{{Path: "comment", Before: `"old"`, After: `"new"`}}, changes)
 }
 
-func TestDiffProfile_ScalarFromUnset(t *testing.T) {
+func TestDiff_ScalarFromUnset(t *testing.T) {
 	a := NewNode("n01")
 	b := a.Clone()
 	b.Comment = "hello"
 
-	changes := DiffProfile(&a.Profile, &b.Profile)
+	changes := Diff(&a.Profile, &b.Profile)
 	assert.Equal(t, []Change{{Path: "comment", Before: "<unset>", After: `"hello"`}}, changes)
 }
 
-func TestDiffProfile_Slice(t *testing.T) {
+func TestDiff_Slice(t *testing.T) {
 	a := NewNode("n01")
 	a.SystemOverlay = []string{"wwinit", "wwclient"}
 	b := a.Clone()
 	b.SystemOverlay = []string{"wwinit", "wwclient", "foo"}
 
-	changes := DiffProfile(&a.Profile, &b.Profile)
+	changes := Diff(&a.Profile, &b.Profile)
 	assert.Equal(t, []Change{{
 		Path:   "system-overlays",
 		Before: "[wwinit, wwclient]",
@@ -50,13 +50,13 @@ func TestDiffProfile_Slice(t *testing.T) {
 	}}, changes)
 }
 
-func TestDiffProfile_NestedKernelArgs(t *testing.T) {
+func TestDiff_NestedKernelArgs(t *testing.T) {
 	a := NewNode("n01")
 	a.Kernel = &KernelConf{Args: []string{"quiet"}}
 	b := a.Clone()
 	b.Kernel.Args = []string{"quiet", "console=ttyS0"}
 
-	changes := DiffProfile(&a.Profile, &b.Profile)
+	changes := Diff(&a.Profile, &b.Profile)
 	assert.Equal(t, []Change{{
 		Path:   "kernel.kernelargs",
 		Before: "[quiet]",
@@ -64,27 +64,27 @@ func TestDiffProfile_NestedKernelArgs(t *testing.T) {
 	}}, changes)
 }
 
-func TestDiffProfile_PointerAutoCreated(t *testing.T) {
+func TestDiff_PointerAutoCreated(t *testing.T) {
 	a := NewNode("n01")
 	b := a.Clone()
 	b.Ipmi = &IpmiConf{UserName: "root"}
 
-	changes := DiffProfile(&a.Profile, &b.Profile)
+	changes := Diff(&a.Profile, &b.Profile)
 	assert.Contains(t, changes, Change{Path: "ipmi.ipmiuser", Before: "<unset>", After: `"root"`})
 }
 
-func TestDiffProfile_TagMap(t *testing.T) {
+func TestDiff_TagMap(t *testing.T) {
 	a := NewNode("n01")
 	a.Tags = map[string]string{"role": "compute"}
 	b := a.Clone()
 	b.Tags = map[string]string{"role": "gpu", "rack": "A1"}
 
-	changes := DiffProfile(&a.Profile, &b.Profile)
+	changes := Diff(&a.Profile, &b.Profile)
 	assert.Contains(t, changes, Change{Path: "tags[role]", Before: `"compute"`, After: `"gpu"`})
 	assert.Contains(t, changes, Change{Path: "tags[rack]", Before: "<unset>", After: `"A1"`})
 }
 
-func TestDiffProfile_NetDevField(t *testing.T) {
+func TestDiff_NetDevField(t *testing.T) {
 	a := NewNode("n01")
 	a.NetDevs = map[string]*NetDev{
 		"default": {Ipaddr: net.ParseIP("10.0.0.1"), Device: "eth0"},
@@ -92,7 +92,7 @@ func TestDiffProfile_NetDevField(t *testing.T) {
 	b := a.Clone()
 	b.NetDevs["default"].Ipaddr = net.ParseIP("10.0.0.2")
 
-	changes := DiffProfile(&a.Profile, &b.Profile)
+	changes := Diff(&a.Profile, &b.Profile)
 	assert.Contains(t, changes, Change{Path: "netdevs[default].ipaddr", Before: "10.0.0.1", After: "10.0.0.2"})
 }
 
@@ -114,7 +114,31 @@ func TestFormatChanges_Empty(t *testing.T) {
 	assert.Equal(t, "", FormatChanges(map[string][]Change{"n01": nil}))
 }
 
-func TestDiffProfile_NetDevAdded(t *testing.T) {
+// Diff over &Profile drops node-only fields (Discoverable, AssetKey). Diff
+// over &Node must surface them so `wwctl node set --discoverable` and
+// `--asset` show up in the confirmation summary.
+func TestDiff_NodeOnlyFields(t *testing.T) {
+	a := NewNode("n01")
+	b := a.Clone()
+	b.AssetKey = "rack-A1-slot-3"
+	err := b.Discoverable.Set("true")
+	assert.NoError(t, err)
+	profileOnly := Diff(&a.Profile, &b.Profile)
+	assert.Empty(t, profileOnly, "diffing &Profile must not see Node-level fields")
+
+	changes := Diff(&a, b)
+	assert.Contains(t, changes, Change{Path: "asset", Before: "<unset>", After: `"rack-A1-slot-3"`})
+	var sawDiscoverable bool
+	for _, c := range changes {
+		if c.Path == "discoverable" {
+			sawDiscoverable = true
+			break
+		}
+	}
+	assert.True(t, sawDiscoverable, "discoverable change must be reported")
+}
+
+func TestDiff_NetDevAdded(t *testing.T) {
 	a := NewNode("n01")
 	a.NetDevs = map[string]*NetDev{
 		"default": {Device: "eth0"},
@@ -122,6 +146,6 @@ func TestDiffProfile_NetDevAdded(t *testing.T) {
 	b := a.Clone()
 	b.NetDevs["secondary"] = &NetDev{Device: "eth1"}
 
-	changes := DiffProfile(&a.Profile, &b.Profile)
+	changes := Diff(&a.Profile, &b.Profile)
 	assert.Contains(t, changes, Change{Path: "netdevs[secondary].netdev", Before: "<unset>", After: `"eth1"`})
 }

--- a/internal/pkg/node/diff_test.go
+++ b/internal/pkg/node/diff_test.go
@@ -1,0 +1,127 @@
+package node
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiffProfile_NoChange(t *testing.T) {
+	a := NewNode("n01")
+	a.Comment = "hello"
+	a.SystemOverlay = []string{"wwinit"}
+	b := a.Clone()
+
+	changes := DiffProfile(&a.Profile, &b.Profile)
+	assert.Empty(t, changes)
+}
+
+func TestDiffProfile_ScalarString(t *testing.T) {
+	a := NewNode("n01")
+	a.Comment = "old"
+	b := a.Clone()
+	b.Comment = "new"
+
+	changes := DiffProfile(&a.Profile, &b.Profile)
+	assert.Equal(t, []Change{{Path: "comment", Before: `"old"`, After: `"new"`}}, changes)
+}
+
+func TestDiffProfile_ScalarFromUnset(t *testing.T) {
+	a := NewNode("n01")
+	b := a.Clone()
+	b.Comment = "hello"
+
+	changes := DiffProfile(&a.Profile, &b.Profile)
+	assert.Equal(t, []Change{{Path: "comment", Before: "<unset>", After: `"hello"`}}, changes)
+}
+
+func TestDiffProfile_Slice(t *testing.T) {
+	a := NewNode("n01")
+	a.SystemOverlay = []string{"wwinit", "wwclient"}
+	b := a.Clone()
+	b.SystemOverlay = []string{"wwinit", "wwclient", "foo"}
+
+	changes := DiffProfile(&a.Profile, &b.Profile)
+	assert.Equal(t, []Change{{
+		Path:   "system-overlays",
+		Before: "[wwinit, wwclient]",
+		After:  "[wwinit, wwclient, foo]",
+	}}, changes)
+}
+
+func TestDiffProfile_NestedKernelArgs(t *testing.T) {
+	a := NewNode("n01")
+	a.Kernel = &KernelConf{Args: []string{"quiet"}}
+	b := a.Clone()
+	b.Kernel.Args = []string{"quiet", "console=ttyS0"}
+
+	changes := DiffProfile(&a.Profile, &b.Profile)
+	assert.Equal(t, []Change{{
+		Path:   "kernel.kernelargs",
+		Before: "[quiet]",
+		After:  "[quiet, console=ttyS0]",
+	}}, changes)
+}
+
+func TestDiffProfile_PointerAutoCreated(t *testing.T) {
+	a := NewNode("n01")
+	b := a.Clone()
+	b.Ipmi = &IpmiConf{UserName: "root"}
+
+	changes := DiffProfile(&a.Profile, &b.Profile)
+	assert.Contains(t, changes, Change{Path: "ipmi.ipmiuser", Before: "<unset>", After: `"root"`})
+}
+
+func TestDiffProfile_TagMap(t *testing.T) {
+	a := NewNode("n01")
+	a.Tags = map[string]string{"role": "compute"}
+	b := a.Clone()
+	b.Tags = map[string]string{"role": "gpu", "rack": "A1"}
+
+	changes := DiffProfile(&a.Profile, &b.Profile)
+	assert.Contains(t, changes, Change{Path: "tags[role]", Before: `"compute"`, After: `"gpu"`})
+	assert.Contains(t, changes, Change{Path: "tags[rack]", Before: "<unset>", After: `"A1"`})
+}
+
+func TestDiffProfile_NetDevField(t *testing.T) {
+	a := NewNode("n01")
+	a.NetDevs = map[string]*NetDev{
+		"default": {Ipaddr: net.ParseIP("10.0.0.1"), Device: "eth0"},
+	}
+	b := a.Clone()
+	b.NetDevs["default"].Ipaddr = net.ParseIP("10.0.0.2")
+
+	changes := DiffProfile(&a.Profile, &b.Profile)
+	assert.Contains(t, changes, Change{Path: "netdevs[default].ipaddr", Before: "10.0.0.1", After: "10.0.0.2"})
+}
+
+func TestFormatChanges_Collapse(t *testing.T) {
+	common := []Change{{Path: "system-overlays", Before: "[wwinit]", After: "[wwinit, foo]"}}
+	uniq := []Change{{Path: "comment", Before: "<unset>", After: `"x"`}}
+
+	out := FormatChanges(map[string][]Change{
+		"n01": common,
+		"n02": common,
+		"n03": uniq,
+	})
+
+	assert.Equal(t, "n01, n02:\n  system-overlays: [wwinit] → [wwinit, foo]\n\nn03:\n  comment: <unset> → \"x\"\n", out)
+}
+
+func TestFormatChanges_Empty(t *testing.T) {
+	assert.Equal(t, "", FormatChanges(map[string][]Change{}))
+	assert.Equal(t, "", FormatChanges(map[string][]Change{"n01": nil}))
+}
+
+func TestDiffProfile_NetDevAdded(t *testing.T) {
+	a := NewNode("n01")
+	a.NetDevs = map[string]*NetDev{
+		"default": {Device: "eth0"},
+	}
+	b := a.Clone()
+	b.NetDevs["secondary"] = &NetDev{Device: "eth1"}
+
+	changes := DiffProfile(&a.Profile, &b.Profile)
+	assert.Contains(t, changes, Change{Path: "netdevs[secondary].netdev", Before: "<unset>", After: `"eth1"`})
+}

--- a/internal/pkg/node/diff_test.go
+++ b/internal/pkg/node/diff_test.go
@@ -27,15 +27,6 @@ func TestDiff_ScalarString(t *testing.T) {
 	assert.Equal(t, []Change{{Path: "comment", Before: `"old"`, After: `"new"`}}, changes)
 }
 
-func TestDiff_ScalarFromUnset(t *testing.T) {
-	a := NewNode("n01")
-	b := a.Clone()
-	b.Comment = "hello"
-
-	changes := Diff(&a.Profile, &b.Profile)
-	assert.Equal(t, []Change{{Path: "comment", Before: "<unset>", After: `"hello"`}}, changes)
-}
-
 func TestDiff_Slice(t *testing.T) {
 	a := NewNode("n01")
 	a.SystemOverlay = []string{"wwinit", "wwclient"}
@@ -84,16 +75,18 @@ func TestDiff_TagMap(t *testing.T) {
 	assert.Contains(t, changes, Change{Path: "tags[rack]", Before: "<unset>", After: `"A1"`})
 }
 
-func TestDiff_NetDevField(t *testing.T) {
+func TestDiff_NetDevMap(t *testing.T) {
 	a := NewNode("n01")
 	a.NetDevs = map[string]*NetDev{
 		"default": {Ipaddr: net.ParseIP("10.0.0.1"), Device: "eth0"},
 	}
 	b := a.Clone()
 	b.NetDevs["default"].Ipaddr = net.ParseIP("10.0.0.2")
+	b.NetDevs["secondary"] = &NetDev{Device: "eth1"}
 
 	changes := Diff(&a.Profile, &b.Profile)
 	assert.Contains(t, changes, Change{Path: "netdevs[default].ipaddr", Before: "10.0.0.1", After: "10.0.0.2"})
+	assert.Contains(t, changes, Change{Path: "netdevs[secondary].netdev", Before: "<unset>", After: `"eth1"`})
 }
 
 func TestFormatChanges_Collapse(t *testing.T) {
@@ -138,14 +131,3 @@ func TestDiff_NodeOnlyFields(t *testing.T) {
 	assert.True(t, sawDiscoverable, "discoverable change must be reported")
 }
 
-func TestDiff_NetDevAdded(t *testing.T) {
-	a := NewNode("n01")
-	a.NetDevs = map[string]*NetDev{
-		"default": {Device: "eth0"},
-	}
-	b := a.Clone()
-	b.NetDevs["secondary"] = &NetDev{Device: "eth1"}
-
-	changes := Diff(&a.Profile, &b.Profile)
-	assert.Contains(t, changes, Change{Path: "netdevs[secondary].netdev", Before: "<unset>", After: `"eth1"`})
-}

--- a/internal/pkg/node/diff_test.go
+++ b/internal/pkg/node/diff_test.go
@@ -99,7 +99,7 @@ func TestFormatChanges_Collapse(t *testing.T) {
 		"n03": uniq,
 	})
 
-	assert.Equal(t, "n01, n02:\n  system-overlays: [wwinit] → [wwinit, foo]\n\nn03:\n  comment: <unset> → \"x\"\n", out)
+	assert.Equal(t, "n[01-02]:\n  system-overlays: [wwinit] → [wwinit, foo]\n\nn03:\n  comment: <unset> → \"x\"\n", out)
 }
 
 func TestFormatChanges_Empty(t *testing.T) {
@@ -130,4 +130,3 @@ func TestDiff_NodeOnlyFields(t *testing.T) {
 	}
 	assert.True(t, sawDiscoverable, "discoverable change must be reported")
 }
-


### PR DESCRIPTION
## Description of the Pull Request (PR):

Displays the changes about to be performed when doing `wwctl [node/profile] set` by fetching the yaml structure and diffing the before/after for affected fields. Skipped when using `set [-y/--yes] `.

Nodes/profiles with identical changes are grouped and compressed to hostlist strings.

Example:

```
[root@wwtest01 ~]# wwctl node set head01,n0[1-8] --profile default,somenewprofile
head01:
  profile: [headnodes] → [default, somenewprofile]

n[01-04]:
  profile: [default, lab-course] → [default, somenewprofile]

n[05-08]:
  profile: [default] → [default, somenewprofile]
? Apply these changes to 9 node(s)?? [y/N]
```

A "Compress" function was added to internal/pkg/hostlist/hostlist.go to go along with the existing Expand, to convert e.g. `n01,n02,n04` to `n0[1-2],n04`

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
