### PR TITLE
wwctl node status: fall back to ipaddr6 on IPv6-only servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed generation of invalid `[ipv4]` sections in NetworkManager keyfiles
   for IPv6-only interfaces. `gateway=`, `dns=`, `dns-search=`, and route lines
   were being emitted even when `method=disabled`.
+- `wwctl node status` now works on IPv6-only servers: it falls back to
+  `ipaddr6` when `ipaddr` is unset, brackets IPv6 literals in the status URL,
+  and bounds the request with a timeout. #2214
 
 ## v4.7.0, 2026-05-12
 

--- a/internal/app/wwctl/node/status/main.go
+++ b/internal/app/wwctl/node/status/main.go
@@ -3,8 +3,10 @@ package nodestatus
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -47,14 +49,49 @@ func displayStage(stage string) string {
 	}
 }
 
-func CobraRunE(cmd *cobra.Command, args []string) (err error) {
+// statusHTTPTimeout bounds how long "wwctl node status" waits on the
+// warewulfd /status endpoint. The request would otherwise use
+// http.DefaultClient, which has no timeout, so an unreachable or
+// firewalled server would hang the command indefinitely.
+const statusHTTPTimeout = 30 * time.Second
 
+// statusURL builds the warewulfd /status endpoint URL from the server
+// configuration. It prefers the IPv4 server address (ipaddr) and falls
+// back to the IPv6 address (ipaddr6), so that node status works on
+// IPv6-only servers where ipaddr is left unset. net.JoinHostPort
+// brackets IPv6 literals correctly (e.g. [2001:db8::1]:9873).
+//
+// The IPv4-first order preserves the previous node status behavior,
+// which only ever used ipaddr. Address selection is currently duplicated
+// across the tree (wwclient prefers ipaddr6; warewulfd is request-driven);
+// consolidating it behind a shared config method is left as a follow-up.
+func statusURL(controller *warewulfconf.WarewulfYaml) (string, error) {
+	serverAddr := controller.Ipaddr
+	if serverAddr == "" {
+		serverAddr = controller.Ipaddr6
+	}
+
+	if serverAddr == "" {
+		confFile := controller.GetWarewulfConf()
+		if confFile == "" {
+			confFile = "warewulf.conf"
+		}
+		return "", fmt.Errorf("warewulf server address is not configured: set ipaddr or ipaddr6 in %s", confFile)
+	}
+
+	hostPort := net.JoinHostPort(serverAddr, strconv.Itoa(controller.Warewulf.Port))
+	return fmt.Sprintf("http://%s/status", hostPort), nil
+}
+
+func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 	controller := warewulfconf.Get()
 
-	if controller.Ipaddr == "" {
-		return fmt.Errorf("warewulf Server IP Address is not properly configured")
-
+	endpoint, err := statusURL(controller)
+	if err != nil {
+		return err
 	}
+
+	client := &http.Client{Timeout: statusHTTPTimeout}
 
 	for {
 		var elipsis bool
@@ -62,10 +99,9 @@ func CobraRunE(cmd *cobra.Command, args []string) (err error) {
 		var count int
 		rightnow := time.Now().Unix()
 
-		statusURL := fmt.Sprintf("http://%s:%d/status", controller.Ipaddr, controller.Warewulf.Port)
-		wwlog.Verbose("Connecting to: %s", statusURL)
+		wwlog.Verbose("Connecting to: %s", endpoint)
 
-		resp, err := http.Get(statusURL)
+		resp, err := client.Get(endpoint)
 		if err != nil {
 			return fmt.Errorf("could not connect to Warewulf server: %w", err)
 		}

--- a/internal/app/wwctl/node/status/main_test.go
+++ b/internal/app/wwctl/node/status/main_test.go
@@ -1,0 +1,61 @@
+package nodestatus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	warewulfconf "github.com/warewulf/warewulf/internal/pkg/config"
+)
+
+func TestStatusURL(t *testing.T) {
+	tests := map[string]struct {
+		ipaddr  string
+		ipaddr6 string
+		port    int
+		want    string
+		wantErr bool
+	}{
+		"ipv4": {
+			ipaddr: "10.0.0.1",
+			port:   9873,
+			want:   "http://10.0.0.1:9873/status",
+		},
+		"ipv6 only": {
+			ipaddr6: "2001:db8::1",
+			port:    9873,
+			want:    "http://[2001:db8::1]:9873/status",
+		},
+		"ipv4 preferred over ipv6": {
+			ipaddr:  "10.0.0.1",
+			ipaddr6: "2001:db8::1",
+			port:    9873,
+			want:    "http://10.0.0.1:9873/status",
+		},
+		"ipv6 loopback": {
+			ipaddr6: "::1",
+			port:    9873,
+			want:    "http://[::1]:9873/status",
+		},
+		"neither configured": {
+			port:    9873,
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			controller := warewulfconf.New()
+			controller.Ipaddr = tt.ipaddr
+			controller.Ipaddr6 = tt.ipaddr6
+			controller.Warewulf.Port = tt.port
+
+			got, err := statusURL(controller)
+			if tt.wantErr {
+				assert.ErrorContains(t, err, "ipaddr6")
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

On a Warewulf server whose `warewulf.conf` configures only IPv6 networking (`ipaddr6` / `prefixlen6`, with no `ipaddr`), `wwctl node status` fails with:

```
ERROR: warewulf Server IP Address is not properly configured
```

`warewulfd` already serves `/status` over IPv6, and I believe this is purely a client-side limitation in `node status`.

## Root cause

There are two issues in `internal/app/wwctl/node/status/main.go`.

1. The command guards on the IPv4 `controller.Ipaddr` and never falls back to `controller.Ipaddr6`. On an IPv6-only host the IPv4 autodetect in `config.Read()` (`GetOutboundIP()`, which dials `192.0.2.1:80`) also finds nothing, so `Ipaddr` stays empty and the command aborts.

2. Even past the guard, the status URL was built with `fmt.Sprintf("http://%s:%d/status", ...)`. That does not bracket an IPv6 literal, so it would produce an invalid URL such as `http://::1:9873/status`.

## Fix

Prefer `Ipaddr`, fall back to `Ipaddr6`, and build the URL with `net.JoinHostPort` so IPv6 literals are bracketed. The URL is now computed once, above the `--watch` loop.

The client also sets an explicit request timeout. The previous code used `http.Get` with `http.DefaultClient`, which has no timeout, so an unreachable or firewalled server would hang the command forever.

The guard error now names both fields and the config file, so the user can fix it without reading the source.

A table test covers the new `statusURL` helper: `ipaddr`, `ipaddr6`-only, `ipaddr` preferred over `ipaddr6`, `::1` loopback bracketing, and the neither-configured error. The CHANGELOG gets an entry under `Unreleased` -> `Fixed`.

## Testing

I built `wwctl` from the `v4.7.0` tag with the patch and ran it against a running `warewulfd` (serving `/status` over IPv6).

An IPv6-only host has to be simulated on a dual-stack test box, because `config.Read()` autodetects an IPv4 via `GetOutboundIP()` (a UDP dial to `192.0.2.1:80`) and that would otherwise mask the bug. Make the probe unreachable first:

```sh
ip route replace unreachable 192.0.2.1/32   # RFC 5737 TEST-NET-1
```

| Case | Config | Binary | Result |
|---|---|---|---|
| Reproduce | `ipaddr6` only | unpatched v4.7.0 | Fails, exit 255: `ERROR: warewulf Server IP Address is not properly configured` |
| Fix (loopback) | `ipaddr6: ::1` | patched | Exit 0, `Connecting to: http://[::1]:9873/status`, node table printed |
| Fix (ULA) | `ipaddr6: fd00:10::1` | patched | Exit 0, `Connecting to: http://[fd00:10::1]:9873/status`, node table printed |
| No regression | `ipaddr` set | patched | Exit 0, `Connecting to: http://<ipv4>:9873/status`, node table printed |
| Stopgap | `ipaddr: 127.0.0.1` | unpatched | Exit 0, node table printed |
| Unit test | n/a | patched tree | `go test ./internal/app/wwctl/node/status/` PASS (5 cases incl. `neither configured` error) |

## Follow-ups (out of scope for this PR)

- No IPv6 autodetect. An IPv6-only host with no explicit `ipaddr6` still trips the guard, because `config.Read()` autodetects only IPv4 (`GetOutboundIP`); there is no IPv6 analog. This change makes an explicitly configured `ipaddr6` usable, which is the reported case.

- Address selection is duplicated. `node status` (IPv4-first, here), `wwclient` (IPv6-first), and `warewulfd` (request-driven) each pick the server address differently. A shared `WarewulfYaml` method (as an example `ServerURL()`) would consolidate them; deferred to keep this fix focused.

- Zone-scoped / link-local `ipaddr6` (e.g. `fe80::1%eth0`) is not handled. It fails safe (URL parse error, no panic) but the message is opaque.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary

Thank you kindly for taking a look at this and please let me know if any further changes are required!