### PR TITLE
wwctl node import: reload warewulfd after persist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `wwctl node status` now works on IPv6-only servers: it falls back to
   `ipaddr6` when `ipaddr` is unset, brackets IPv6 literals in the status URL,
   and bounds the request with a timeout. #2214
+- `wwctl node import` now reloads `warewulfd` after persisting `nodes.conf`,
+  matching every other mutating `wwctl node ...` command (`add`, `delete`,
+  `set`, `unset`, `edit`). Previously imported nodes were invisible to
+  `wwctl node status` (and to the daemon's in-memory registry that serves
+  PXE and wwclient) until `warewulfd` was reloaded or restarted; `wwctl
+  node list` was unaffected because it reads `nodes.conf` from disk.
 
 ## v4.7.0, 2026-05-12
 

--- a/internal/app/wwctl/node/imprt/main.go
+++ b/internal/app/wwctl/node/imprt/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/warewulf/warewulf/internal/pkg/node"
 	"github.com/warewulf/warewulf/internal/pkg/util"
+	"github.com/warewulf/warewulf/internal/pkg/warewulfd"
 	"gopkg.in/yaml.v3"
 )
 
@@ -47,6 +48,7 @@ func CobraRunE(cmd *cobra.Command, args []string) error {
 		if err := nodeDB.Persist(); err != nil {
 			return fmt.Errorf("failed to persist nodedb: %w", err)
 		}
+		return warewulfd.DaemonReload()
 	}
 
 	return nil


### PR DESCRIPTION
## Description of the Pull Request (PR):

`wwctl node import` was the only mutating `wwctl node ...` command that did not call `warewulfd.DaemonReload()` after persisting `nodes.conf`. Every other node mutator -- add, delete, set, unset, edit -- ends its CobraRunE with `return warewulfd.DaemonReload()` (see e.g. internal/app/wwctl/node/add/main.go:102). Since `warewulfd` keeps the status registry and hwaddr map only in memory and refreshes them on SIGHUP (`service warewulfd reload`, which is what DaemonReload triggers), nodes added or modified via `wwctl node import` remained invisible to `wwctl node status`, PXE handlers, and wwclient status updates until the daemon was reloaded or restarted.

Curiously `wwctl node list` was unaffected, because it reads `nodes.conf` directly from disk rather than querying the daemon -- a useful diagnostic when triaging: nodes visible via `list` but not via `status` are a strong signal that the daemon's in-memory state is stale.

Reproducer (on 4.6.5 and current main before this patch):

    wwctl node add --profile compute --netname production         --hwaddr E8:EB:D3:10:05:62 --ipaddr 10.220.80.30 test-01
    wwctl node status                # test-01 present
    wwctl node delete -y test-01
    wwctl node import test-01.yaml   # same node, YAML form
    wwctl node status                # test-01 MISSING
    systemctl reload warewulfd       # or: service warewulfd reload
    wwctl node status                # test-01 present again

Fix mirrors the exact pattern used by every sibling command: import the warewulfd package and return DaemonReload() as the final statement of the confirmed-branch. The existing table-driven test in internal/app/wwctl/node/imprt/main_test.go already calls warewulfd.SetNoDaemon() (line 63) which makes DaemonReload() a no-op under test, matching how every sibling command's test is structured; no test changes needed.


## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [x] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [x] The test suite has been updated, if necessary
