### PR TITLE
userdocs: clarify the scope and limits of HTTP boot

### DIFF
--- a/userdocs/server/bootloaders.rst
+++ b/userdocs/server/bootloaders.rst
@@ -297,11 +297,19 @@ booted by GRUB.
 These packages must also be installed on the Warewulf server host to enable
 node discovery using GRUB.
 
+.. _HTTP boot:
+
 HTTP boot
 ---------
 
-Modern EFI systems have the possibility to directly boot per http. The flow
-diagram is the following:
+Modern EFI systems have the possibility to directly boot per http. HTTP boot is
+part of the GRUB boot chain described above, and is not a separate bootloader.
+The node firmware fetches ``shim.efi`` over HTTP instead of TFTP, and the rest
+of the chain proceeds as it does for a TFTP-booted GRUB node. Warewulf does not
+serve an iPXE binary over HTTP, so HTTP boot cannot be used to start the iPXE
+boot method.
+
+The flow diagram is the following:
 
 .. graphviz::
 
@@ -319,6 +327,28 @@ diagram is the following:
 Warewulf delivers the initial ``shim.efi`` and ``grub.efi`` via http as taken
 directly from the node's assigned image.
 
+.. note::
+
+   HTTP boot has the following limitations in the current implementation.
+
+   * The DHCP rule that hands out the HTTP boot URI is generated differently by
+     each DHCP backend. With ISC ``dhcpd`` (the default) the rule is written
+     only when ``grubboot`` is enabled, and it matches any ``HTTPClient`` vendor
+     class, so the rule matches clients of any architecture. With ``dnsmasq``
+     the rule is always written, but it matches only the vendor class
+     ``HTTPClient:Arch:00016``, which is the `IANA processor architecture type`_
+     for "x64 uefi boot from http". An aarch64 client booting over HTTP presents
+     architecture type 19, "arm uefi 64 boot from http", and is therefore not
+     matched.
+   * The HTTP boot URI is built from the server's IPv4 address, so HTTP boot
+     requires an IPv4 address on the provisioning interface and is not usable on
+     an IPv6-only Warewulf server.
+   * The ``/efiboot/`` route identifies the requesting node from the ``wwid``
+     query parameter or, when that is absent, from a lookup of the client's
+     address in the IPv4 ARP cache. See :ref:`server-routes` for details.
+
+.. _IANA processor architecture type: https://www.iana.org/assignments/dhcpv6-parameters/dhcpv6-parameters.xhtml#processor-architecture
+
 .. _booting with dracut:
 
 Two-stage boot: dracut
@@ -329,6 +359,11 @@ unable to load an image of a certain size directly with a traditional bootloader
 either iPXE or GRUB. As a workaround for such systems, Warewulf can be
 configured to load a dracut initramfs from the image and to use that initramfs
 to load the full image.
+
+The two-stage boot is independent of how the first-stage bootloader reaches the
+node. It runs over the normal network boot path, whether iPXE or GRUB was
+delivered over TFTP or over HTTP, and it does not require :ref:`HTTP boot` to be
+configured.
 
 Warewulf provides a dracut module to configure the dracut initramfs to load the
 image. This module is available in the ``warewulf-dracut`` subpackage, which


### PR DESCRIPTION
## Description

The `HTTP boot` section of `userdocs/server/bootloaders.rst` is a subsection of `Booting with GRUB`, but nothing in its body says so. Read on its own it looks like a bootloader-independent transport.

My understanding is that HTTP boot cannot deliver an iPXE first stage. `warewulfd` registers no route that serves an iPXE binary, and `/efiboot/{file}` serves only `shim.efi`, `grub*.efi` and `grub.cfg`.

In practice, one of my customers has had to stand up a separate web server to try to serve `snponly.efi` over HTTP.

### Undocumented limitations

The section also does not record the current limitations in the DHCP configuration.

**The rule that hands out the HTTP boot URI is generated differently by each DHCP backend.**

- With ISC `dhcpd` (`overlays/host/rootfs/etc/dhcp/dhcpd.conf.ww`) the `HTTPClient` branch is inside `{{- if $.Warewulf.GrubBoot }}`, so it is only emitted when `grubboot` is enabled. It compares `substring(option vendor-class-identifier, 0, 10)`, so the rule matches clients of any architecture.

- With `dnsmasq` (`overlays/host/rootfs/etc/dnsmasq.d/ww4-hosts.conf.ww`) lines 12-15 sit *outside* the `GrubBoot` conditional and *inside* `{{- if .Ipaddr }}`. They are emitted whenever the server has an IPv4 address regardless of `grubboot`, and they match only the exact vendor class `HTTPClient:Arch:00016`.

  As I understand from the IANA Processor Architecture Types registry, 16 (0x10) is "x64 uefi boot from http" and an aarch64 HTTP-boot client presents 19 (0x13), "arm uefi 64 boot from http". So an aarch64 client is never matched under dnsmasq.

**HTTP boot requires IPv4.**

- Both backends interpolate `{{$.Ipaddr}}` into the boot URI, so HTTP boot needs an IPv4 address on the provisioning interface and is not usable on an IPv6-only server.

- `/efiboot/` identifies the node from `?wwid=` or, failing that, from an ARP lookup against `/proc/net/arp`, which is IPv4 only.

### Two-stage boot reads as dependent on HTTP boot

`Two-stage boot: dracut` immediately follows `HTTP boot` on the same page, and `userdocs/nodes/disks.rst` ties provision-to-disk to the two-stage boot.

Chaining those two pages makes HTTP boot look like a prerequisite for provisioning to disk. It is not. Two-stage boot is enabled with an `IPXEMenuEntry` or `GrubMenuEntry` node tag and runs over the normal network boot path.

### What this changes

This change is for the documentation only. I made three edits:

1. `HTTP boot` now states that it is part of the GRUB boot chain, that the firmware fetches `shim.efi` over HTTP while the rest of the chain proceeds as seen in a TFTP-booted GRUB node, and that Warewulf does not serve an iPXE binary over HTTP.

2. A `.. note::` records the limitations above, per backend, cross-referencing `:ref:`server-routes``.

3. `Two-stage boot: dracut` gains one sentence stating that it is independent of how the first-stage bootloader is delivered and does not require HTTP boot.

### One open question, raised separately

While writing this I found that the dhcpd and dnsmasq backends configure HTTP boot inconsistently, in two independent ways. I have raised that as #2231 rather than answering it here.

This PR documents the behaviour as it currently stands, since that is what a reader will observe today. If the two backends are meant to agree, the fix belongs in the templates and I will trim the note in this PR to whatever survives.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary

## Verification performed

Built locally with Sphinx before submitting.

The warning set is byte-identical to a build of the unmodified tree at the same commit, so both new `:ref:` targets resolve and no directive or indentation error was introduced.

`graphviz` was unavailable locally so the diagrams did not render. No diagram was touched.
