### PR TITLE
Fix two-stage dracut boot on IPv6-only fabrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The two-stage dracut boot now completes on IPv6-only nodes. The `:dracut` entry
+  rendered `ip=<device>:dhcp` for every device, which NetworkManager's initrd
+  generator turns into a mandatory DHCPv4 lease, so the connection never
+  activated and the initramfs never fetched the image. A device with `ipaddr6`
+  and no `ipaddr` now renders `ip=<device>:auto6`. Part of #910
 - Prevent cpio hardlink corruption caused by 64-bit inode numbers truncating to
   colliding 32-bit values when building node images and overlays: pass
   `--renumber-inodes` to cpio when the installed version supports it (GNU cpio

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -54,3 +54,4 @@
 - Jason Scott <jsco2t@outlook.com> @jsco2t
 - Sujeev Uthayakumar <sujeev.uthayakumar@gmail.com> [@Sujeev-Uthayakumar](https://github.com/Sujeev-Uthayakumar)
 - Jacob Sommerville <jsommerville@dow.com>
+- Howard Van Der Wal <howard.a.vanderwal@protonmail.com> [@metalllinux](https://github.com/metalllinux)

--- a/etc/ipxe/default.ipxe
+++ b/etc/ipxe/default.ipxe
@@ -95,7 +95,7 @@ goto metadata
 echo
 echo Downloading dracut initramfs...
 initrd --name initramfs ${base}/initramfs/${hwaddr}?${params} || goto error_reboot
-set dracut_net rd.neednet=1 {{range $devname, $netdev := .NetDevs}}{{if and $netdev.Hwaddr $netdev.Device}} ifname={{$netdev.Device}}:{{$netdev.Hwaddr}} ip={{$netdev.Device}}:dhcp {{end}}{{end}}
+set dracut_net rd.neednet=1 {{range $devname, $netdev := .NetDevs}}{{if and $netdev.Hwaddr $netdev.Device}} ifname={{$netdev.Device}}:{{$netdev.Hwaddr}}{{if and $netdev.Ipaddr6 (not $netdev.Ipaddr)}} ip={{$netdev.Device}}:auto6{{else}} ip={{$netdev.Device}}:dhcp{{end}} {{end}}{{end}}
 set dracut_wwinit root=wwinit:{{default "tmpfs" .Root}} wwinit.server=${base} wwinit.uri=${base}/provision/${hwaddr} init=/warewulf/run-init
 goto boot_two_stage_dracut
 

--- a/internal/pkg/warewulfd/ipxe_test.go
+++ b/internal/pkg/warewulfd/ipxe_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,6 +34,131 @@ var ipxeHandlerTests = []struct {
 		200,
 		"[fd00:10::10:12]:9873",
 	},
+}
+
+var ipxeDracutNetTests = []struct {
+	description string
+	url         string
+	expected    string
+	unexpected  string
+}{
+	{
+		"IPv6-only node gets IPv6 autoconfiguration",
+		"/ipxe/00:00:00:00:00:06",
+		"ip=net:auto6",
+		"ip=net:dhcp",
+	},
+	{
+		"IPv4-only node keeps DHCPv4",
+		"/ipxe/00:00:00:00:00:04",
+		"ip=net:dhcp",
+		"ip=net:auto6",
+	},
+	{
+		"dual-stack node keeps DHCPv4",
+		"/ipxe/00:00:00:00:00:46",
+		"ip=net:dhcp",
+		"ip=net:auto6",
+	},
+	{
+		"node with no address configured keeps DHCPv4",
+		"/ipxe/00:00:00:00:00:00",
+		"ip=net:dhcp",
+		"ip=net:auto6",
+	},
+}
+
+// dracutNetLine returns the "set dracut_net" line from the given iPXE entry.
+// default.ipxe defines dracut_net twice, once under :dracut_continue and once
+// under :dracut_static_continue, and only the former is under test: the latter
+// builds its ip= argument from the IPv4 fields. Anchoring on the label keeps the
+// assertions on the intended entry even if the entries are reordered.
+func dracutNetLine(script string, label string) string {
+	inEntry := false
+	for _, line := range strings.Split(script, "\n") {
+		if strings.HasPrefix(line, ":") {
+			inEntry = line == label
+			continue
+		}
+		if inEntry && strings.HasPrefix(line, "set dracut_net ") {
+			return line
+		}
+	}
+	return ""
+}
+
+// The :dracut entry must not request DHCPv4 for a device that only has an IPv6
+// address: NetworkManager's initrd generator turns ip=<device>:dhcp into
+// ipv4.method=auto with ipv4.may-fail=no, which can never activate on a fabric
+// with no DHCPv4 server, so the initramfs never fetches the image.
+func Test_HandleIpxeDracutNet(t *testing.T) {
+	env := testenv.New(t)
+	defer env.RemoveAll()
+
+	env.WriteFile("/etc/warewulf/nodes.conf", `nodes:
+  n6:
+    image name: rockylinux-9
+    network devices:
+      default:
+        hwaddr: 00:00:00:00:00:06
+        device: net
+        ipaddr6: fd00:10::6
+        prefixlen6: "64"
+  n4:
+    image name: rockylinux-9
+    network devices:
+      default:
+        hwaddr: 00:00:00:00:00:04
+        device: net
+        ipaddr: 10.10.0.4
+        netmask: 255.255.255.0
+  n46:
+    image name: rockylinux-9
+    network devices:
+      default:
+        hwaddr: 00:00:00:00:00:46
+        device: net
+        ipaddr: 10.10.0.46
+        netmask: 255.255.255.0
+        ipaddr6: fd00:10::46
+        prefixlen6: "64"
+  n0:
+    image name: rockylinux-9
+    network devices:
+      default:
+        hwaddr: 00:00:00:00:00:00
+        device: net`)
+	env.ImportFile("etc/warewulf/ipxe/default.ipxe", "../../../etc/ipxe/default.ipxe")
+
+	dbErr := LoadNodeDB()
+	assert.NoError(t, dbErr)
+
+	// an IPv6-only server, as deployed on the fabric where this was found
+	conf := warewulfconf.Get()
+	secureFalse := false
+	conf.Warewulf.SecureP = &secureFalse
+	conf.Ipaddr = ""
+	conf.Ipaddr6 = "fd00:10::1"
+
+	for _, tt := range ipxeDracutNetTests {
+		t.Run(tt.description, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			req.RemoteAddr = "[fd00:10::10:12]:9873"
+			w := httptest.NewRecorder()
+			HandleIpxe(w, req)
+			res := w.Result()
+			defer func() { _ = res.Body.Close() }()
+
+			data, readErr := io.ReadAll(res.Body)
+			assert.NoError(t, readErr)
+			assert.Equal(t, 200, res.StatusCode)
+
+			dracutNet := dracutNetLine(string(data), ":dracut_continue")
+			assert.NotEmpty(t, dracutNet, "template did not render a dracut_net line")
+			assert.Contains(t, dracutNet, tt.expected)
+			assert.NotContains(t, dracutNet, tt.unexpected)
+		})
+	}
 }
 
 func Test_HandleIpxe(t *testing.T) {

--- a/userdocs/server/bootloaders.rst
+++ b/userdocs/server/bootloaders.rst
@@ -396,3 +396,42 @@ The wwinit module provisions to tmpfs. By default, tmpfs is permitted to use up
 to 50% of physical memory. This size limit may be adjusted using the kernel
 argument ``wwinit.tmpfs.size``. (This parameter is passed to the ``size`` option
 during tmpfs mount. See ``tmpfs(5)`` for more details.)
+
+Network configuration in the dracut initramfs
+---------------------------------------------
+
+The ``:dracut`` entry passes ``rd.neednet=1`` and an ``ip=`` argument for each of
+the node's network devices, so that the initramfs can fetch the image from the
+Warewulf server. The autoconfiguration method is chosen per device from the
+node's configuration:
+
+- a device with an ``ipaddr6`` and no ``ipaddr`` gets ``ip=<device>:auto6``, so
+  that the initramfs configures IPv6 (SLAAC, and DHCPv6 if the router
+  advertisement asks for it) and does not wait for a DHCPv4 lease;
+- every other device, including dual-stack devices, gets ``ip=<device>:dhcp``.
+
+This matters because on an IPv6-only fabric a request for DHCPv4 is not merely
+redundant. NetworkManager's initrd generator translates ``ip=<device>:dhcp`` into
+``ipv4.method=auto`` with ``ipv4.may-fail=no``, which makes a DHCPv4 lease a
+requirement for the connection to activate. Where no DHCPv4 server exists the
+connection never activates, nothing that waits on the network proceeds, and the
+boot ends in the dracut emergency shell with ``FATAL: Unable to load stage:
+system``.
+
+The value a node will be served can be read without booting it.
+
+.. code-block:: shell
+
+   curl -s "http://<server>:<port>/ipxe/<hwaddr>" | grep 'set dracut_net'
+
+That prints one line for the ``:dracut`` entry and one for ``:dracut_static``.
+The latter builds its ``ip=`` argument from ``ipaddr``, ``gateway`` and
+``netmask``, so it does not support a node that has only an ``ipaddr6``.
+
+.. note::
+
+   When adjusting the method by hand in a copy of the template, prefer ``auto6``
+   over dracut's ``either6``. NetworkManager's initrd generator does not
+   recognise ``either6``: it falls back to interpreting the argument
+   positionally, fails to read the device name as an address, and discards the
+   whole ``ip=`` argument.


### PR DESCRIPTION
## Issue I observed

On an IPv6-only provisioning network, a node configured for the two-stage dracut boot, that being `IPXEMenuEntry=dracut`, fetches the iPXE script, the kernel and the initramfs, and then goes silent.

`warewulfd` never receives a request for the image, system or runtime stages, and the node ends up in the dracut emergency shell:

```
dracut: FATAL: Unable to load stage: system
dracut: Refusing to continue
```

Single-stage boots - `imgextract` and `initrd` on the same node and the same fabric work, which is why this only shows up when a site moves to provision-to-disk.

## Root cause

The `:dracut` entry in `etc/ipxe/default.ipxe` renders the initramfs network arguments without looking at the address family:

```
set dracut_net rd.neednet=1 {{range $devname, $netdev := .NetDevs}}{{if and $netdev.Hwaddr $netdev.Device}} ifname={{$netdev.Device}}:{{$netdev.Hwaddr}} ip={{$netdev.Device}}:dhcp {{end}}{{end}}
```

`ip=<device>:dhcp` is IPv4 DHCP.

On EL9 the `wwinit` dracut module's `network` dependency resolves to `network-manager`, so this argument is parsed by NetworkManager's initrd generator, which treats an explicitly requested family as **mandatory** (`src/nm-initrd-generator/nmi-cmdline-reader.c`):

```c
} else if (nm_streq(kind, "dhcp")) {
    g_object_set(s_ip4,
                 NM_SETTING_IP_CONFIG_METHOD,
                 NM_SETTING_IP4_CONFIG_METHOD_AUTO,
                 NM_SETTING_IP_CONFIG_MAY_FAIL,
                 FALSE,
                 NULL);
    if (nm_setting_ip_config_get_num_addresses(s_ip6) == 0) {
        g_object_set(s_ip6,
                     NM_SETTING_IP_CONFIG_METHOD,
                     NM_SETTING_IP6_CONFIG_METHOD_AUTO,
                     NULL);
    }
}
```

The generated connection carries `ipv4.method=auto` with `ipv4.may-fail=no`, and `ipv6.method=auto` as optional.

Where there is no DHCPv4 server, IPv6 autoconfiguration completes but the connection as a whole never activates, and NetworkManager tears the device back down.

From the initramfs console of a node reproducing this:

```
device (eth0): ip4: check-state: state pending => fail, is_failed=1, ... may-fail-4=0, may-fail-6=1;;
    manualip4=done dhcp4=fail; manualip6=done ll6=done ac6=done dhcp6=pending
device (eth0): state change: ip-config -> failed (reason 'ip-config-unavailable')
device (eth0): Activation: failed for connection 'eth0'
```

Observe that `ac6=done`: IPv6 SLAAC had succeeded. The boot fails anyway because IPv4 was marked required.

`nm-wait-online-initrd.service` then burns its full timeout, the `pre-mount` hook runs with no usable address, and `load-wwinit.sh` dies on the first fetch.

## Suggested change

Choose the autoconfiguration method per device from the node's own configuration. A device that has `ipaddr6` and no `ipaddr` gets `auto6`and everything else keeps today's behaviour.

```
{{if and $netdev.Ipaddr6 (not $netdev.Ipaddr)}} ip={{$netdev.Device}}:auto6{{else}} ip={{$netdev.Device}}:dhcp{{end}}
```

### Why this change

Warewulf already draws exactly this conclusion from exactly these two fields, in a shipped template.

`overlays/NetworkManager/rootfs/etc/NetworkManager/system-connections/ww4-managed.ww` renders `[ipv4] method=disabled` when `$netdev.Ipaddr` is empty, and `[ipv6] method=manual` when `$netdev.Ipaddr6` is set.

As far as I understand, "`ipaddr6` set and `ipaddr` unset" already means "this node is IPv6-only" for the booted system, using the same `net.IP` truthiness and the same `not`.

Before this change, the initramfs contradicted the keyfile the very same node was about to be handed: `ip=<device>:dhcp` in the initramfs, `[ipv4] method=disabled` after `switch_root`.

That inconsistency is the bug. This makes the two agree.

Another worry I had, is a node carrying an `ipaddr6` on a fabric that has no router advertisement.

Such a node is already broken today after `switch_root`, for the same reason, because its keyfile disables IPv4.

The change surfaces the misconfiguration in the initramfs instead of after the pivot. It does not create a new failure class.

### Alternatives considered

The value has to be understood by whichever network module the image pulls in `network-manager` on EL9, `network-legacy` elsewhere, and it must not make an unobtainable address family mandatory.

Behaviour below is from `src/nm-initrd-generator/nmi-cmdline-reader.c`.

| value | NetworkManager initrd generator | dracut `network-legacy` | verdict |
|---|---|---|---|
| `dhcp` (today) | `ipv4.method=auto` with **`may-fail=no`**, `ipv6.method=auto` optional | IPv4 DHCP | fails on an IPv6-only fabric |
| `either6` | not in `_parse_ip_method()`'s accepted set, whole `ip=` **discarded** | valid | unusable |
| `any` / `on` | aliased to `auto`: both families optional, but `ip4`'s `required-timeout` is left in place | valid | tested, and it makes every boot wait out the DHCPv4 timeout first |
| `dhcp,auto6` | normalises to `dhcp4+auto6`: both tried, each with a required timeout | comma combinations are documented by NetworkManager, not by dracut | more surface, same wait |
| `auto6` | aliased to `dhcp6`: `ipv6.method=auto` with **`may-fail=no`**, and `ipv4.method=disabled` | valid | chosen |

## Validation testing

I built a Warewulf 4.7.0 server on an isolated bridge carrying an IPv6 ULA prefix and no IPv4 address at all, with `warewulf.conf` holding only `ipaddr6`, and a node whose disk and filesystem configuration matches a real provision-to-disk deployment.

This included two GPT partitions by partlabel, xfs, and root at `/dev/disk/by-partlabel/rootfs`.

The image carries `warewulf-dracut` and its initramfs was built with `dracut --force --no-hostonly --add wwinit --add ignition --regenerate-all`. `lsinitrd` confirms the `wwinit` and `network-manager` modules.

The node is started with the exact kernel, initramfs and kernel command line the `:dracut` entry hands it, with `console=ttyS0` added so dracut's output is readable.

All testing was done on the same server. The only variable is the rendered `ip=` value:

| | stock (`ip=eth0:dhcp`) | patched (`ip=eth0:auto6`) |
|---|---|---|
| NetworkManager | `may-fail-4=0`, `dhcp4=fail`, `Activation: failed` | activates, IPv4 disabled |
| `nm-wait-online-initrd` | fails after its timeout | succeeds |
| stages fetched from `warewulfd` | none | `image` x1, `system` x2, `runtime` x18 |
| dracut | `FATAL: Unable to load stage: system`, emergency shell | mounts the rootfs partition, `switch_root` |
| console | emergency shell | `n1 login:` |
| disk afterwards | untouched | `/dev/sda1` 12.5 GB xfs with a full root tree, `/dev/sda2` 8.3 GB xfs |

Serial console of the patched run:

```
[    9.212490] XFS (vda1): Mounting V5 Filesystem b1b45f42-4e93-45a2-8ea3-3b274b2f9be3
[    9.218262] XFS (vda1): Ending clean mount
[   23.984156] XFS (vda2): Mounting V5 Filesystem 23b94bca-3471-4dbd-98c0-7eca1553e452
```

Rendering, with the patched template, for three nodes on the same server:

```
n1   IPv6-only   -> rd.neednet=1 ifname=eth0:52:54:00:31:61:01 ip=eth0:auto6
n2   IPv4-only   -> rd.neednet=1 ifname=eth0:52:54:00:31:61:02 ip=eth0:dhcp
n3   dual-stack  -> rd.neednet=1 ifname=eth0:52:54:00:31:61:03 ip=eth0:dhcp
```

The IPv4-only and dual-stack renders are byte-identical to the stock template, so the IPv4 boot path is unchanged by construction.

### Confirmation testing on aarch64, on a fabric that uses DHCPv6

From a customer's environment, they use an NVIDIA GH200 (this uses aarch64 architecture) node on a global IPv6 prefix, behind a `dnsmasq` that answers router solicitations and stateless DHCPv6.

The node's own firmware console shows it taking the two-stage entry (`Booting dracut (first stage)...`), and the server log shows the initramfs coming back for the next stage, which it had never done before.

Addresses and hardware addresses redacted:

```
14:36:12  request from hwaddr:<hwaddr> ipaddr:[<node-slaac>]:24284 | stage:ipxe
14:36:12  request from hwaddr:<hwaddr> ipaddr:[<node-slaac>]:24284 | stage:kernel
14:36:14  request from hwaddr:<hwaddr> ipaddr:[<node-slaac>]:24284 | stage:initramfs
14:37:07  request from hwaddr:<hwaddr> ipaddr:[<node-slaac>]:57084 | stage:system
```

I observed two details that make this more than a coincidence of timing.

The `stage:system` request arrives from a different source port than the three iPXE requests, so it is `curl` inside the initramfs rather than iPXE reusing its connection.

And its source address is the node's own SLAAC address, formed EUI-64 from the interface's hardware address, so the initramfs had configured an address from the router advertisement and routed with it.

On the same hardware before the change, the same node stopped at `stage:initramfs` and its initramfs NetworkManager repeated a router solicitation and a stateless DHCPv6 information-request every 390 seconds, with a stable DUID, for hours on end, without ever completing activation.

After the change each boot performs that exchange exactly once and the HTTP fetch follows two seconds later.

That closes the first two bench caveats. The value is now exercised on aarch64, and on a global IPv6 prefix whose fabric answers DHCPv6, not only on x86_64 with a ULA and router advertisements alone.

## Tests

`Test_HandleIpxeDracutNet` in `internal/pkg/warewulfd/ipxe_test.go` renders the real `etc/ipxe/default.ipxe` (imported into the test environment, as the `wwctl power` tests do with the BMC template) against an IPv6-only server, for four nodes: IPv6-only, IPv4-only, dual-stack, and a device with no address configured at all.

Each case asserts both the expected `ip=` value and the absence of the other one, so a template edit that emitted both branches would fail rather than pass on the strength of a substring match.

The assertions are anchored on the `:dracut_continue` label rather than on the first `set dracut_net` line in the output, because `:dracut_static` renders a `dracut_net` of its own and reordering the entries should not silently move the test onto the wrong one.

These tests were ran on Rocky Linux 9.8 x86_64 with go1.26.5, at `4.7.0+80.g7d5a0b8`:

```
$ go test -run Test_HandleIpxeDracutNet -v ./internal/pkg/warewulfd/
=== RUN   Test_HandleIpxeDracutNet
=== RUN   Test_HandleIpxeDracutNet/IPv6-only_node_gets_IPv6_autoconfiguration
request from hwaddr:00:00:00:00:00:06 ipaddr:[fd00:10::10:12]:9873 | stage:ipxe
SERV   : stage_file '/tmp/ww4test-3407396276/etc/warewulf/ipxe/default.ipxe'
send /tmp/ww4test-3407396276/etc/warewulf/ipxe/default.ipxe -> n6
=== RUN   Test_HandleIpxeDracutNet/IPv4-only_node_keeps_DHCPv4
request from hwaddr:00:00:00:00:00:04 ipaddr:[fd00:10::10:12]:9873 | stage:ipxe
SERV   : stage_file '/tmp/ww4test-3407396276/etc/warewulf/ipxe/default.ipxe'
send /tmp/ww4test-3407396276/etc/warewulf/ipxe/default.ipxe -> n4
=== RUN   Test_HandleIpxeDracutNet/dual-stack_node_keeps_DHCPv4
request from hwaddr:00:00:00:00:00:46 ipaddr:[fd00:10::10:12]:9873 | stage:ipxe
SERV   : stage_file '/tmp/ww4test-3407396276/etc/warewulf/ipxe/default.ipxe'
send /tmp/ww4test-3407396276/etc/warewulf/ipxe/default.ipxe -> n46
=== RUN   Test_HandleIpxeDracutNet/node_with_no_address_configured_keeps_DHCPv4
request from hwaddr:00:00:00:00:00:00 ipaddr:[fd00:10::10:12]:9873 | stage:ipxe
SERV   : stage_file '/tmp/ww4test-3407396276/etc/warewulf/ipxe/default.ipxe'
send /tmp/ww4test-3407396276/etc/warewulf/ipxe/default.ipxe -> n0
--- PASS: Test_HandleIpxeDracutNet (0.02s)
    --- PASS: Test_HandleIpxeDracutNet/IPv6-only_node_gets_IPv6_autoconfiguration (0.00s)
    --- PASS: Test_HandleIpxeDracutNet/IPv4-only_node_keeps_DHCPv4 (0.00s)
    --- PASS: Test_HandleIpxeDracutNet/dual-stack_node_keeps_DHCPv4 (0.00s)
    --- PASS: Test_HandleIpxeDracutNet/node_with_no_address_configured_keeps_DHCPv4 (0.00s)
PASS
ok  	github.com/warewulf/warewulf/internal/pkg/warewulfd	0.036s
```

### The test actually fails without the change

Reverting the one changed line in `etc/ipxe/default.ipxe` to its pre-patch form, with the test left untouched, fails the IPv6-only case on both of its assertions and leaves the other three passing.

That is the shape this test is meant to have. It pins the new behaviour without loosening the old one, and the rendered line it prints on failure is the stock render that breaks the boot.

warewulfd's per-request log lines are elided below for length; nothing else is.

```
$ git show HEAD~1:etc/ipxe/default.ipxe > etc/ipxe/default.ipxe
$ go test -run Test_HandleIpxeDracutNet -v ./internal/pkg/warewulfd/
=== RUN   Test_HandleIpxeDracutNet
=== RUN   Test_HandleIpxeDracutNet/IPv6-only_node_gets_IPv6_autoconfiguration
    ipxe_test.go:158: 
        	Error Trace:	/root/warewulf/internal/pkg/warewulfd/ipxe_test.go:158
        	Error:      	"set dracut_net rd.neednet=1  ifname=net:00:00:00:00:00:06 ip=net:dhcp " does not contain "ip=net:auto6"
        	Test:       	Test_HandleIpxeDracutNet/IPv6-only_node_gets_IPv6_autoconfiguration
    ipxe_test.go:159: 
        	Error Trace:	/root/warewulf/internal/pkg/warewulfd/ipxe_test.go:159
        	Error:      	"set dracut_net rd.neednet=1  ifname=net:00:00:00:00:00:06 ip=net:dhcp " should not contain "ip=net:dhcp"
        	Test:       	Test_HandleIpxeDracutNet/IPv6-only_node_gets_IPv6_autoconfiguration
=== RUN   Test_HandleIpxeDracutNet/IPv4-only_node_keeps_DHCPv4
=== RUN   Test_HandleIpxeDracutNet/dual-stack_node_keeps_DHCPv4
=== RUN   Test_HandleIpxeDracutNet/node_with_no_address_configured_keeps_DHCPv4
--- FAIL: Test_HandleIpxeDracutNet (0.02s)
    --- FAIL: Test_HandleIpxeDracutNet/IPv6-only_node_gets_IPv6_autoconfiguration (0.00s)
    --- PASS: Test_HandleIpxeDracutNet/IPv4-only_node_keeps_DHCPv4 (0.00s)
    --- PASS: Test_HandleIpxeDracutNet/dual-stack_node_keeps_DHCPv4 (0.00s)
    --- PASS: Test_HandleIpxeDracutNet/node_with_no_address_configured_keeps_DHCPv4 (0.00s)
FAIL
FAIL	github.com/warewulf/warewulf/internal/pkg/warewulfd	0.035s
```

### Full suite, vet, lint and formatting

Template then restored and confirmed byte-identical to the committed file by `sha256sum`, with `git status` clean.

On the same tree and host, `make test` exits 0, with 46 packages reporting `ok`, none reporting `FAIL`, and `internal/pkg/warewulfd` itself at 0.489s.

```
$ make vet
go vet ./...

$ make lint
.tools/bin/golangci-lint run --build-tags "containers_image_openpgp containers_image_ostree" --timeout=5m ./...
0 issues.

$ make fmt
go fmt ./...
```

All three exit 0, and `make fmt` reformatted nothing.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary

This PR is part of the [support for IPv6-only environments #910](https://github.com/warewulf/warewulf/issues/910) Issue.
