### PR TITLE
fix: use NetTagsAdd instead of TagsAdd for --nettagadd in profile set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `wwctl profile set --nettagadd` no longer silently ignores the given tags
+  when the network device already exists.
 - The two-stage dracut boot now completes on IPv6-only nodes. The `:dracut` entry
   rendered `ip=<device>:dhcp` for every device, which NetworkManager's initrd
   generator turns into a mandatory DHCPv4 lease, so the connection never

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -55,3 +55,4 @@
 - Sujeev Uthayakumar <sujeev.uthayakumar@gmail.com> [@Sujeev-Uthayakumar](https://github.com/Sujeev-Uthayakumar)
 - Jacob Sommerville <jsommerville@dow.com>
 - Howard Van Der Wal <howard.a.vanderwal@protonmail.com> [@metalllinux](https://github.com/metalllinux)
+- Sergio Cabello Simón <sergio.scs388@gmail.com> [@SergioZ3R0](https://github.com/SergioZ3R0)

--- a/internal/app/wwctl/profile/set/main.go
+++ b/internal/app/wwctl/profile/set/main.go
@@ -141,12 +141,10 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 				for _, key := range vars.profileDel.NetTagsDel {
 					delete(netDev.Tags, key)
 				}
-				// Note: original API code used set.TagAdd here (likely a bug),
-				// preserving existing behavior by using TagsAdd
-				if len(vars.profileAdd.TagsAdd) > 0 && netDev.Tags == nil {
+				if len(vars.profileAdd.NetTagsAdd) > 0 && netDev.Tags == nil {
 					netDev.Tags = make(map[string]string)
 				}
-				for key, val := range vars.profileAdd.TagsAdd {
+				for key, val := range vars.profileAdd.NetTagsAdd {
 					netDev.Tags[key] = val
 				}
 			}

--- a/internal/app/wwctl/profile/set/main_test.go
+++ b/internal/app/wwctl/profile/set/main_test.go
@@ -353,6 +353,43 @@ nodeprofiles:
         path: /var
 nodes: {}`,
 		},
+		"--nettagadd with existing netdev": {
+			args:    []string{"--netname=eth0", "--nettagadd=DNS1=1.1.1.1", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default:
+    network devices:
+      eth0:
+        device: eth0
+nodes: {}`,
+			outDb: `
+nodeprofiles:
+  default:
+    network devices:
+      eth0:
+        device: eth0
+        tags:
+          DNS1: "1.1.1.1"
+nodes: {}`,
+		},
+		"--nettagadd adds tags to default profile": {
+			args:    []string{"--nettagadd=DNS1=1.1.1.1", "--nettagadd=DNS2=1.0.0.1", "default"},
+			wantErr: false,
+			inDB: `
+nodeprofiles:
+  default: {}
+nodes: {}`,
+			outDb: `
+nodeprofiles:
+  default:
+    network devices:
+      default:
+        tags:
+          DNS1: "1.1.1.1"
+          DNS2: "1.0.0.1"
+nodes: {}`,
+		},
 	}
 
 	for name, tt := range tests {
@@ -375,7 +412,6 @@ nodes: {}`,
 				content := env.ReadFile("etc/warewulf/nodes.conf")
 				assert.YAMLEq(t, tt.outDb, content)
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
# Description
This PR fixes an issue where the `--nettagadd` flag fails to apply changes when used at the profile level via the CLI.

### Steps to Reproduce
Running the following commands currently does not save the tags to the profile:

```bash
wwctl profile set compute --nettagadd DNS1=1.1.1.1
wwctl profile set compute --nettagadd DNS2=1.0.0.1
wwctl profile set compute --nettagadd DNSSEARCH=hpc.customerdomain.com

```

### Expected Behavior
The tags should be applied to the profile properly, consistent with how it currently works when using:

* Interactive mode: `wwctl profile edit`
* Node level: `wwctl node set cpu001 --nettagadd DNS1=1.1.1.1`

### Fix

The refactoring in commit `4cc6d03f2f216a1fe9da932b38de06a5e8f1964d` incorrectly changed `NetTagsAdd` to `TagsAdd` when applying network tags in `profile set`.

```diff
- if len(vars.profileAdd.TagsAdd) > 0 && netDev.Tags == nil {
+ if len(vars.profileAdd.NetTagsAdd) > 0 && netDev.Tags == nil {

- for key, val := range vars.profileAdd.TagsAdd {
+ for key, val := range vars.profileAdd.NetTagsAdd {

```

The `--nettagadd` flags were stored in `NetTagsAdd` but the code read from `TagsAdd` (which is for `--tagadd`), causing `--nettagadd` to silently have no effect on profiles.

The `node set` equivalent code already used `NetTagsAdd` correctly.