### PR TITLE
Add IPMI address of nodes to /etc/hosts of master node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `wwctl group list [NAME ...]` enumerates every group referenced anywhere
   in the configuration along with its members.
 - Tab completion for groups.
+- Add IPMI address of nodes to /etc/hosts of master node
  
 ### Changed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -56,3 +56,4 @@
 - Jacob Sommerville <jsommerville@dow.com>
 - Howard Van Der Wal <howard.a.vanderwal@protonmail.com> [@metalllinux](https://github.com/metalllinux)
 - Sergio Cabello Simón <sergio.scs388@gmail.com> [@SergioZ3R0](https://github.com/SergioZ3R0)
+- Jorge L Florit <jlflorit@gmail.com> [@conxuro](https://github.com/conxuro)

--- a/overlays/host/rootfs/etc/hosts.ww
+++ b/overlays/host/rootfs/etc/hosts.ww
@@ -7,6 +7,9 @@
 
 {{- range $node := $.AllNodes}}{{/* for each node */}}
 # Entry for {{$node.Id}}
+{{- if $node.Ipmi.Ipaddr}}{{/* if we have IPMI address on the node */}}
+{{$node.Ipmi.Ipaddr}} {{$node.Id}}-ipmi
+{{- end }}
 {{- range $devname, $netdev := $node.NetDevs}}{{/* for each network device on the node */}}
 {{- if $netdev.Ipaddr}}{{/* if we have an ip address on this network device */}}
 {{- /* emit the node name as hostname if this is the primary */}}


### PR DESCRIPTION
## Description of the Pull Request (PR):

Addition of the node's IPMI adddres to `/etc/hosts`  of the master node, widely used in HPC environments for administration tasks (e.g. upgrading/patching the firmware of multiple nodes in parallel).

In the future this can be improved to make the suffix customizable.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
