### PR TITLE
Fix IPMI address handling in power commands to skip nodes without an IP Address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `wwctl power` (`cycle`, `off`, `on`, `reset`, `soft`, `status`) no longer runs
+  `ipmitool` without `-H` for a node that has no `ipmi: ipaddr:`, which fell back
+  to the local BMC and acted on the Warewulf server itself. Such nodes are now
+  skipped and the command exits non-zero.
 - `wwctl profile set --nettagadd` no longer silently ignores the given tags
   when the network device already exists.
 - The two-stage dracut boot now completes on IPv6-only nodes. The `:dracut` entry

--- a/internal/app/wwctl/power/cycle/main.go
+++ b/internal/app/wwctl/power/cycle/main.go
@@ -44,8 +44,9 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 
 		for _, node := range nodes {
 
-			if node.Ipmi.Ipaddr.IsUnspecified() {
+			if node.Ipmi == nil || node.Ipmi.Ipaddr == nil || node.Ipmi.Ipaddr.IsUnspecified() {
 				wwlog.Error("%s: No IPMI IP address", node.Id())
+				returnErr = fmt.Errorf("one or more nodes have no IPMI IP address")
 				continue
 			}
 			ipmiCmd := bmc.TemplateStruct{

--- a/internal/app/wwctl/power/cycle/root_test.go
+++ b/internal/app/wwctl/power/cycle/root_test.go
@@ -54,3 +54,61 @@ nodes:
 		})
 	}
 }
+
+// Test_PowerCycle_NoIpmiAddress checks that a node with no ipmi ipaddr, such as a
+// virtual machine with no BMC, is skipped rather than acted on locally
+func Test_PowerCycle_NoIpmiAddress(t *testing.T) {
+	warewulfd.SetNoDaemon()
+	env := testenv.New(t)
+	defer env.RemoveAll()
+	env.WriteFile("etc/warewulf/nodes.conf", `
+nodeprofiles:
+  default:
+    ipmi:
+      template: ipmitool.tmpl
+      username: admin
+      password: admin
+nodes:
+  n01:
+    profiles:
+    - default
+    ipmi:
+      ipaddr: 10.10.10.10
+  n02:
+    profiles:
+    - default
+    ipmi: {}`)
+	env.ImportFile("usr/share/warewulf/bmc/ipmitool.tmpl", "../../../../../lib/warewulf/bmc/ipmitool.tmpl")
+
+	tests := map[string]struct {
+		args     []string
+		expected string
+	}{
+		"only a node without an address": {
+			args: []string{"--show", "n02"},
+		},
+		"a node with an address and one without": {
+			args:     []string{"--show", "n01,n02"},
+			expected: `10.10.10.10: ipmitool -H 10.10.10.10 -U "admin" -P "admin" chassis power cycle`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			baseCmd := GetCommand()
+			buf := new(bytes.Buffer)
+			baseCmd.SetOut(buf)
+			baseCmd.SetErr(buf)
+			wwlog.SetLogWriter(buf)
+			baseCmd.SetArgs(tt.args)
+			err := baseCmd.Execute()
+
+			assert.Error(t, err)
+			assert.Contains(t, buf.String(), "n02: No IPMI IP address")
+			assert.NotContains(t, buf.String(), `ipmitool -U "admin" -P "admin" chassis power cycle`)
+			if tt.expected != "" {
+				assert.Contains(t, buf.String(), tt.expected)
+			}
+		})
+	}
+}

--- a/internal/app/wwctl/power/off/main.go
+++ b/internal/app/wwctl/power/off/main.go
@@ -44,8 +44,9 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 
 		for _, node := range nodes {
 
-			if node.Ipmi.Ipaddr.IsUnspecified() {
+			if node.Ipmi == nil || node.Ipmi.Ipaddr == nil || node.Ipmi.Ipaddr.IsUnspecified() {
 				wwlog.Error("%s: No IPMI IP address", node.Id())
+				returnErr = fmt.Errorf("one or more nodes have no IPMI IP address")
 				continue
 			}
 			ipmiCmd := bmc.TemplateStruct{

--- a/internal/app/wwctl/power/off/root_test.go
+++ b/internal/app/wwctl/power/off/root_test.go
@@ -54,3 +54,61 @@ nodes:
 		})
 	}
 }
+
+// Test_PowerOff_NoIpmiAddress checks that a node with no ipmi ipaddr, such as a
+// virtual machine with no BMC, is skipped rather than acted on locally
+func Test_PowerOff_NoIpmiAddress(t *testing.T) {
+	warewulfd.SetNoDaemon()
+	env := testenv.New(t)
+	defer env.RemoveAll()
+	env.WriteFile("etc/warewulf/nodes.conf", `
+nodeprofiles:
+  default:
+    ipmi:
+      template: ipmitool.tmpl
+      username: admin
+      password: admin
+nodes:
+  n01:
+    profiles:
+    - default
+    ipmi:
+      ipaddr: 10.10.10.10
+  n02:
+    profiles:
+    - default
+    ipmi: {}`)
+	env.ImportFile("usr/share/warewulf/bmc/ipmitool.tmpl", "../../../../../lib/warewulf/bmc/ipmitool.tmpl")
+
+	tests := map[string]struct {
+		args     []string
+		expected string
+	}{
+		"only a node without an address": {
+			args: []string{"--show", "n02"},
+		},
+		"a node with an address and one without": {
+			args:     []string{"--show", "n01,n02"},
+			expected: `10.10.10.10: ipmitool -H 10.10.10.10 -U "admin" -P "admin" chassis power off`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			baseCmd := GetCommand()
+			buf := new(bytes.Buffer)
+			baseCmd.SetOut(buf)
+			baseCmd.SetErr(buf)
+			wwlog.SetLogWriter(buf)
+			baseCmd.SetArgs(tt.args)
+			err := baseCmd.Execute()
+
+			assert.Error(t, err)
+			assert.Contains(t, buf.String(), "n02: No IPMI IP address")
+			assert.NotContains(t, buf.String(), `ipmitool -U "admin" -P "admin" chassis power off`)
+			if tt.expected != "" {
+				assert.Contains(t, buf.String(), tt.expected)
+			}
+		})
+	}
+}

--- a/internal/app/wwctl/power/on/main.go
+++ b/internal/app/wwctl/power/on/main.go
@@ -45,8 +45,9 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 
 		for _, node := range nodes {
 
-			if node.Ipmi.Ipaddr.IsUnspecified() {
+			if node.Ipmi == nil || node.Ipmi.Ipaddr == nil || node.Ipmi.Ipaddr.IsUnspecified() {
 				wwlog.Error("%s: No IPMI IP address", node.Id())
+				returnErr = fmt.Errorf("one or more nodes have no IPMI IP address")
 				continue
 			}
 			ipmiCmd := bmc.TemplateStruct{

--- a/internal/app/wwctl/power/on/root_test.go
+++ b/internal/app/wwctl/power/on/root_test.go
@@ -53,3 +53,61 @@ nodes:
 		})
 	}
 }
+
+// Test_PowerOn_NoIpmiAddress checks that a node with no ipmi ipaddr, such as a
+// virtual machine with no BMC, is skipped rather than acted on locally
+func Test_PowerOn_NoIpmiAddress(t *testing.T) {
+	warewulfd.SetNoDaemon()
+	env := testenv.New(t)
+	defer env.RemoveAll()
+	env.WriteFile("etc/warewulf/nodes.conf", `
+nodeprofiles:
+  default:
+    ipmi:
+      template: ipmitool.tmpl
+      username: admin
+      password: admin
+nodes:
+  n01:
+    profiles:
+    - default
+    ipmi:
+      ipaddr: 10.10.10.10
+  n02:
+    profiles:
+    - default
+    ipmi: {}`)
+	env.ImportFile("usr/share/warewulf/bmc/ipmitool.tmpl", "../../../../../lib/warewulf/bmc/ipmitool.tmpl")
+
+	tests := map[string]struct {
+		args     []string
+		expected string
+	}{
+		"only a node without an address": {
+			args: []string{"--show", "n02"},
+		},
+		"a node with an address and one without": {
+			args:     []string{"--show", "n01,n02"},
+			expected: `10.10.10.10: ipmitool -H 10.10.10.10 -U "admin" -P "admin" chassis power on`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			baseCmd := GetCommand()
+			buf := new(bytes.Buffer)
+			baseCmd.SetOut(buf)
+			baseCmd.SetErr(buf)
+			wwlog.SetLogWriter(buf)
+			baseCmd.SetArgs(tt.args)
+			err := baseCmd.Execute()
+
+			assert.Error(t, err)
+			assert.Contains(t, buf.String(), "n02: No IPMI IP address")
+			assert.NotContains(t, buf.String(), `ipmitool -U "admin" -P "admin" chassis power on`)
+			if tt.expected != "" {
+				assert.Contains(t, buf.String(), tt.expected)
+			}
+		})
+	}
+}

--- a/internal/app/wwctl/power/reset/main.go
+++ b/internal/app/wwctl/power/reset/main.go
@@ -45,8 +45,9 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 
 		for _, node := range nodes {
 
-			if node.Ipmi.Ipaddr.IsUnspecified() {
+			if node.Ipmi == nil || node.Ipmi.Ipaddr == nil || node.Ipmi.Ipaddr.IsUnspecified() {
 				wwlog.Error("%s: No IPMI IP address", node.Id())
+				returnErr = fmt.Errorf("one or more nodes have no IPMI IP address")
 				continue
 			}
 			ipmiCmd := bmc.TemplateStruct{

--- a/internal/app/wwctl/power/reset/root_test.go
+++ b/internal/app/wwctl/power/reset/root_test.go
@@ -139,3 +139,61 @@ nodes:
 		})
 	}
 }
+
+// Test_PowerReset_NoIpmiAddress checks that a node with no ipmi ipaddr, such as a
+// virtual machine with no BMC, is skipped rather than acted on locally
+func Test_PowerReset_NoIpmiAddress(t *testing.T) {
+	warewulfd.SetNoDaemon()
+	env := testenv.New(t)
+	defer env.RemoveAll()
+	env.WriteFile("etc/warewulf/nodes.conf", `
+nodeprofiles:
+  default:
+    ipmi:
+      template: ipmitool.tmpl
+      username: admin
+      password: admin
+nodes:
+  n01:
+    profiles:
+    - default
+    ipmi:
+      ipaddr: 10.10.10.10
+  n02:
+    profiles:
+    - default
+    ipmi: {}`)
+	env.ImportFile("usr/share/warewulf/bmc/ipmitool.tmpl", "../../../../../lib/warewulf/bmc/ipmitool.tmpl")
+
+	tests := map[string]struct {
+		args     []string
+		expected string
+	}{
+		"only a node without an address": {
+			args: []string{"--show", "n02"},
+		},
+		"a node with an address and one without": {
+			args:     []string{"--show", "n01,n02"},
+			expected: `10.10.10.10: ipmitool -H 10.10.10.10 -U "admin" -P "admin" chassis power reset`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			baseCmd := GetCommand()
+			buf := new(bytes.Buffer)
+			baseCmd.SetOut(buf)
+			baseCmd.SetErr(buf)
+			wwlog.SetLogWriter(buf)
+			baseCmd.SetArgs(tt.args)
+			err := baseCmd.Execute()
+
+			assert.Error(t, err)
+			assert.Contains(t, buf.String(), "n02: No IPMI IP address")
+			assert.NotContains(t, buf.String(), `ipmitool -U "admin" -P "admin" chassis power reset`)
+			if tt.expected != "" {
+				assert.Contains(t, buf.String(), tt.expected)
+			}
+		})
+	}
+}

--- a/internal/app/wwctl/power/soft/main.go
+++ b/internal/app/wwctl/power/soft/main.go
@@ -45,8 +45,9 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 
 		for _, node := range nodes {
 
-			if node.Ipmi.Ipaddr.IsUnspecified() {
+			if node.Ipmi == nil || node.Ipmi.Ipaddr == nil || node.Ipmi.Ipaddr.IsUnspecified() {
 				wwlog.Error("%s: No IPMI IP address", node.Id())
+				returnErr = fmt.Errorf("one or more nodes have no IPMI IP address")
 				continue
 			}
 			ipmiCmd := bmc.TemplateStruct{

--- a/internal/app/wwctl/power/soft/root_test.go
+++ b/internal/app/wwctl/power/soft/root_test.go
@@ -54,3 +54,61 @@ nodes:
 		})
 	}
 }
+
+// Test_PowerSoft_NoIpmiAddress checks that a node with no ipmi ipaddr, such as a
+// virtual machine with no BMC, is skipped rather than acted on locally
+func Test_PowerSoft_NoIpmiAddress(t *testing.T) {
+	warewulfd.SetNoDaemon()
+	env := testenv.New(t)
+	defer env.RemoveAll()
+	env.WriteFile("etc/warewulf/nodes.conf", `
+nodeprofiles:
+  default:
+    ipmi:
+      template: ipmitool.tmpl
+      username: admin
+      password: admin
+nodes:
+  n01:
+    profiles:
+    - default
+    ipmi:
+      ipaddr: 10.10.10.10
+  n02:
+    profiles:
+    - default
+    ipmi: {}`)
+	env.ImportFile("usr/share/warewulf/bmc/ipmitool.tmpl", "../../../../../lib/warewulf/bmc/ipmitool.tmpl")
+
+	tests := map[string]struct {
+		args     []string
+		expected string
+	}{
+		"only a node without an address": {
+			args: []string{"--show", "n02"},
+		},
+		"a node with an address and one without": {
+			args:     []string{"--show", "n01,n02"},
+			expected: `10.10.10.10: ipmitool -H 10.10.10.10 -U "admin" -P "admin" chassis power soft`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			baseCmd := GetCommand()
+			buf := new(bytes.Buffer)
+			baseCmd.SetOut(buf)
+			baseCmd.SetErr(buf)
+			wwlog.SetLogWriter(buf)
+			baseCmd.SetArgs(tt.args)
+			err := baseCmd.Execute()
+
+			assert.Error(t, err)
+			assert.Contains(t, buf.String(), "n02: No IPMI IP address")
+			assert.NotContains(t, buf.String(), `ipmitool -U "admin" -P "admin" chassis power soft`)
+			if tt.expected != "" {
+				assert.Contains(t, buf.String(), tt.expected)
+			}
+		})
+	}
+}

--- a/internal/app/wwctl/power/status/main.go
+++ b/internal/app/wwctl/power/status/main.go
@@ -44,8 +44,9 @@ func CobraRunE(vars *variables) func(cmd *cobra.Command, args []string) (err err
 
 		for _, node := range nodes {
 
-			if node.Ipmi.Ipaddr.IsUnspecified() {
+			if node.Ipmi == nil || node.Ipmi.Ipaddr == nil || node.Ipmi.Ipaddr.IsUnspecified() {
 				wwlog.Error("%s: No IPMI IP address", node.Id())
+				returnErr = fmt.Errorf("one or more nodes have no IPMI IP address")
 				continue
 			}
 			ipmiCmd := bmc.TemplateStruct{

--- a/internal/app/wwctl/power/status/root_test.go
+++ b/internal/app/wwctl/power/status/root_test.go
@@ -54,3 +54,61 @@ nodes:
 		})
 	}
 }
+
+// Test_PowerStatus_NoIpmiAddress checks that a node with no ipmi ipaddr, such as a
+// virtual machine with no BMC, is skipped rather than acted on locally
+func Test_PowerStatus_NoIpmiAddress(t *testing.T) {
+	warewulfd.SetNoDaemon()
+	env := testenv.New(t)
+	defer env.RemoveAll()
+	env.WriteFile("etc/warewulf/nodes.conf", `
+nodeprofiles:
+  default:
+    ipmi:
+      template: ipmitool.tmpl
+      username: admin
+      password: admin
+nodes:
+  n01:
+    profiles:
+    - default
+    ipmi:
+      ipaddr: 10.10.10.10
+  n02:
+    profiles:
+    - default
+    ipmi: {}`)
+	env.ImportFile("usr/share/warewulf/bmc/ipmitool.tmpl", "../../../../../lib/warewulf/bmc/ipmitool.tmpl")
+
+	tests := map[string]struct {
+		args     []string
+		expected string
+	}{
+		"only a node without an address": {
+			args: []string{"--show", "n02"},
+		},
+		"a node with an address and one without": {
+			args:     []string{"--show", "n01,n02"},
+			expected: `10.10.10.10: ipmitool -H 10.10.10.10 -U "admin" -P "admin" chassis power status`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			baseCmd := GetCommand()
+			buf := new(bytes.Buffer)
+			baseCmd.SetOut(buf)
+			baseCmd.SetErr(buf)
+			wwlog.SetLogWriter(buf)
+			baseCmd.SetArgs(tt.args)
+			err := baseCmd.Execute()
+
+			assert.Error(t, err)
+			assert.Contains(t, buf.String(), "n02: No IPMI IP address")
+			assert.NotContains(t, buf.String(), `ipmitool -U "admin" -P "admin" chassis power status`)
+			if tt.expected != "" {
+				assert.Contains(t, buf.String(), tt.expected)
+			}
+		})
+	}
+}

--- a/internal/pkg/bmc/bmc.go
+++ b/internal/pkg/bmc/bmc.go
@@ -55,6 +55,12 @@ func (tstruct *TemplateStruct) getCommand() (cmdStr string, err error) {
 	}
 	cmdStr = strings.TrimSpace(tbuffer.String())
 	wwlog.Debug("bmc command: %s", cmdStr)
+	// ipmitool uses the local bmc, that of the warewulf server itself, when given
+	// neither a target host (-H) nor an explicit interface (-I)
+	if fields := strings.Fields(cmdStr); len(fields) > 0 && fields[0] == "ipmitool" &&
+		!strings.Contains(cmdStr, "-H ") && !strings.Contains(cmdStr, "-I ") {
+		return "", fmt.Errorf("no bmc target specified: refusing to run ipmitool against the local bmc")
+	}
 	return cmdStr, nil
 
 }

--- a/internal/pkg/bmc/bmc_test.go
+++ b/internal/pkg/bmc/bmc_test.go
@@ -19,6 +19,7 @@ func Test_Ipmitool(t *testing.T) {
 			bmc: TemplateStruct{},
 			err: true,
 		},
+		// with no ipaddr the command has no -H and would target the local bmc
 		"ipmitool PowerStatus empty": {
 			bmc: TemplateStruct{
 				Cmd: "PowerStatus",
@@ -26,7 +27,32 @@ func Test_Ipmitool(t *testing.T) {
 					Template: "ipmitool.tmpl",
 				},
 			},
-			cmdStr: `ipmitool chassis power status`,
+			err: true,
+		},
+		// IsUnspecified is true for 0.0.0.0 but false for nil, so cover both
+		"ipmitool PowerStatus unspecified ipaddr": {
+			bmc: TemplateStruct{
+				Cmd: "PowerStatus",
+				IpmiConf: node.IpmiConf{
+					Template: "ipmitool.tmpl",
+					Ipaddr:   net.IPv4zero,
+					UserName: "root",
+					Password: "calvin",
+				},
+			},
+			cmdStr: `ipmitool -H 0.0.0.0 -U "root" -P "calvin" chassis power status`,
+		},
+		// an explicit interface is an intentional choice of transport, so it is
+		// honoured even without an address
+		"ipmitool PowerStatus explicit interface": {
+			bmc: TemplateStruct{
+				Cmd: "PowerStatus",
+				IpmiConf: node.IpmiConf{
+					Template:  "ipmitool.tmpl",
+					Interface: "open",
+				},
+			},
+			cmdStr: `ipmitool -I open chassis power status`,
 		},
 		"ipmitool PowerStatus full": {
 			bmc: TemplateStruct{


### PR DESCRIPTION
## Description of the Pull Request (PR):

`wwctl power` acted on the BMC of the Warewulf server itself when run against a node with no IPMI address. A node with no BMC correctly has no `ipmi: ipaddr:` and therefor is unaffected.

### Changes

- **Guard** (all six `power/*/main.go`): use the nil-safe idiom already in `wwctl node console` / `sensors`, `node.Ipmi == nil || node.Ipmi.Ipaddr == nil || node.Ipmi.Ipaddr.IsUnspecified()`. The node is skipped, and `returnErr` is now set so a run that skips nodes exits non-zero. Nodes with an address are processed as before.
- **Backstop** (`internal/pkg/bmc/bmc.go`): refuse any rendered `ipmitool` command with neither `-H` nor `-I`, so the safety property holds even for a site-edited template.

Reproduced end to end on a VM with a working local BMC (QEMU `ipmi-bmc-sim`): before, `wwctl power reset` against an address-less node reset the head node itself; after, it is refused and the host is untouched.

The code and tests were written with AI but validated manually

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
