### PR TITLE
Create parent directories in CarefulWriteBuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Mount additional (non-root) filesystems before image extraction during
   provision-to-disk so files are written to the correct partitions. #2147
 - Fix MTU configuration with wicked. #2248
+- Overlay templates that create multiple files will create the parent
+  directories for the files if they don't yet exist
 
 ### Dependencies
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -57,3 +57,4 @@
 - Howard Van Der Wal <howard.a.vanderwal@protonmail.com> [@metalllinux](https://github.com/metalllinux)
 - Sergio Cabello Simón <sergio.scs388@gmail.com> [@SergioZ3R0](https://github.com/SergioZ3R0)
 - Jorge L Florit <jlflorit@gmail.com> [@conxuro](https://github.com/conxuro)
+- Travis Greene <trg244@msstate.edu> [@sn8to](https://github.com/sn8to)

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -1088,6 +1088,13 @@ Writes buffer to the destination file. If wwbackup is set a wwbackup will be cre
 */
 func CarefulWriteBuffer(destFile string, buffer bytes.Buffer, backupFile bool, perm fs.FileMode) (err error) {
 	wwlog.Debug("Trying to careful write file (%d bytes): %s", buffer.Len(), destFile)
+	parentDir := path.Dir(destFile)
+	if !util.IsDir(parentDir) {
+		wwlog.Debug("Creating parent directory: %s", parentDir)
+		if err := os.MkdirAll(parentDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create parent directories for %s: %w", destFile, err)
+		}
+	}
 	if backupFile {
 		if !util.IsFile(destFile+".wwbackup") && util.IsFile(destFile) {
 			err := util.CopyFile(destFile, destFile+".wwbackup")


### PR DESCRIPTION
## Description of the Pull Request (PR):

While using the `{{ file }}` feature of the overlay templates, I noticed that if you tried
to create a file in a directory that did not yet exist, it would output the following:

```
host overlay could not be built: failed to build overlay image directory: could not write file from template: could not open new file for template open /full/path/to/file.txt: no such file or directory
```

This PR adds a check in `CarefulWriteBuffer`, which is used to create each output file
from a rendered template, that creates the parent directory of the file if it doesn't
yet exist.

## This fixes or addresses the following GitHub issues:

*none*

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ ] The test suite has been updated, if necessary
