### PR TITLE
Overlay template softlinks overwrite existing links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   directories for the files if they don't yet exist
 - Overlay templates that create symbolic links remove an existing link if it
   already exists in the overlay. #2252
+- Fix overlay creation of symbolic links over an existing file. #2252
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix MTU configuration with wicked. #2248
 - Overlay templates that create multiple files will create the parent
   directories for the files if they don't yet exist
+- Overlay templates that create symbolic links remove an existing link if it
+  already exists in the overlay. #2252
 
 ### Dependencies
 

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -1027,6 +1027,12 @@ func BuildOverlayIndir(nodeData node.Node, allNodes []node.Node, overlayNames []
 
 					if f.IsSymlink {
 						wwlog.Debug("Creating soft link %s -> %s", filePath, f.Target)
+						if _, err := os.Lstat(filePath); err == nil {
+							wwlog.Debug("Link %s already exists, will try to remove", filePath)
+							if err := os.Remove(filePath); err != nil {
+								return fmt.Errorf("failed to remove existing link at %s: %w", filePath, err)
+							}
+						}
 						if err = os.Symlink(f.Target, filePath); err != nil {
 							return fmt.Errorf("could not create symlink from template: %w", err)
 						}

--- a/internal/pkg/overlay/overlay.go
+++ b/internal/pkg/overlay/overlay.go
@@ -1026,15 +1026,15 @@ func BuildOverlayIndir(nodeData node.Node, allNodes []node.Node, overlayNames []
 					}
 
 					if f.IsSymlink {
-						wwlog.Debug("Creating soft link %s -> %s", filePath, f.Target)
-						if _, err := os.Lstat(filePath); err == nil {
-							wwlog.Debug("Link %s already exists, will try to remove", filePath)
-							if err := os.Remove(filePath); err != nil {
-								return fmt.Errorf("failed to remove existing link at %s: %w", filePath, err)
-							}
+						skip, err := prepareSymlinkPath(filePath, f.Target, rendered.BackupFile)
+						if err != nil {
+							return err
 						}
-						if err = os.Symlink(f.Target, filePath); err != nil {
-							return fmt.Errorf("could not create symlink from template: %w", err)
+						if !skip {
+							wwlog.Debug("Creating soft link %s -> %s", filePath, f.Target)
+							if err := os.Symlink(f.Target, filePath); err != nil {
+								return fmt.Errorf("could not create symlink from template: %w", err)
+							}
 						}
 					} else {
 						wwlog.Debug("Writing file %s", f.Name)
@@ -1087,6 +1087,60 @@ func BuildOverlayIndir(nodeData node.Node, allNodes []node.Node, overlayNames []
 	}
 
 	return nil
+}
+
+// prepareSymlinkPath clears filePath so that a symlink to target may be created
+// there, following the same wwbackup convention as CarefulWriteBuffer. It
+// reports skip when the correct symlink is already in place and nothing needs
+// to be done.
+//
+// An existing symlink is replaced outright: a symlink holds no content of its
+// own, so there is nothing to preserve. A regular file is moved aside to
+// filePath+".wwbackup" instead, or removed when a backup already exists or the
+// template called nobackup. A directory is an error, because removing it would
+// discard whatever it contains.
+func prepareSymlinkPath(filePath string, target string, backupFile bool) (skip bool, err error) {
+	info, err := os.Lstat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to stat existing path at %s: %w", filePath, err)
+	}
+
+	if info.Mode()&os.ModeSymlink == os.ModeSymlink {
+		existing, err := os.Readlink(filePath)
+		if err != nil {
+			return false, fmt.Errorf("failed reading existing symlink at %s: %w", filePath, err)
+		}
+		if existing == target {
+			wwlog.Debug("Soft link %s -> %s already exists", filePath, target)
+			return true, nil
+		}
+		wwlog.Debug("Soft link %s points at %s: removing to re-link to %s", filePath, existing, target)
+		if err := os.Remove(filePath); err != nil {
+			return false, fmt.Errorf("failed to remove existing symlink at %s: %w", filePath, err)
+		}
+		return false, nil
+	}
+
+	if info.IsDir() {
+		return false, fmt.Errorf("refusing to replace directory %s with a symlink to %s", filePath, target)
+	}
+
+	backupPath := filePath + ".wwbackup"
+	if backupFile && !util.IsFile(backupPath) {
+		wwlog.Debug("Output file %s already exists: moving to backup file", filePath)
+		if err := os.Rename(filePath, backupPath); err != nil {
+			return false, fmt.Errorf("failed renaming %s to backup file: %w", filePath, err)
+		}
+		return false, nil
+	}
+	wwlog.Debug("Removing existing file %s in favor of a soft link", filePath)
+	if err := os.Remove(filePath); err != nil {
+		return false, fmt.Errorf("failed removing existing file at %s: %w", filePath, err)
+	}
+	return false, nil
 }
 
 /*

--- a/internal/pkg/overlay/overlay_test.go
+++ b/internal/pkg/overlay/overlay_test.go
@@ -427,6 +427,161 @@ func Test_BuildOverlayIndir_PathTraversal(t *testing.T) {
 	}
 }
 
+// Test_BuildOverlayIndir_SymlinkCollision covers softlink() rendering to a path
+// that is already occupied. Overlays are routinely rebuilt over an existing
+// tree -- most visibly the host overlay, which builds into "/" -- so a
+// collision is ordinary rather than exceptional, and what is already there must
+// not be destroyed silently.
+func Test_BuildOverlayIndir_SymlinkCollision(t *testing.T) {
+	const (
+		linkPath   = "/image/test-link"
+		backupPath = "/image/test-link.wwbackup"
+		target     = "/link-target"
+		other      = "/other-target"
+	)
+	const template = `{{- softlink "/link-target" -}}`
+
+	tests := map[string]struct {
+		template  string
+		setup     func(env *testenv.TestEnv)
+		expectErr string
+		verify    func(t *testing.T, env *testenv.TestEnv)
+	}{
+		"unoccupied path": {
+			template: template,
+			verify: func(t *testing.T, env *testenv.TestEnv) {
+				assertSymlinkTo(t, env, linkPath, target)
+				assertNotExist(t, env, backupPath)
+			},
+		},
+		"symlink already pointing at the target": {
+			// Nothing to do: rebuilding must be idempotent and must not
+			// leave a backup behind for a link it did not change.
+			template: template,
+			setup: func(env *testenv.TestEnv) {
+				env.Symlink(target, linkPath)
+			},
+			verify: func(t *testing.T, env *testenv.TestEnv) {
+				assertSymlinkTo(t, env, linkPath, target)
+				assertNotExist(t, env, backupPath)
+			},
+		},
+		"symlink pointing somewhere else": {
+			// A symlink holds no content of its own, so it is replaced
+			// outright rather than backed up.
+			template: template,
+			setup: func(env *testenv.TestEnv) {
+				env.Symlink(other, linkPath)
+			},
+			verify: func(t *testing.T, env *testenv.TestEnv) {
+				assertSymlinkTo(t, env, linkPath, target)
+				assertNotExist(t, env, backupPath)
+			},
+		},
+		"dangling symlink pointing somewhere else": {
+			// The existing link is inspected with Lstat/Readlink, so a
+			// target that does not exist is handled like any other link.
+			template: template,
+			setup: func(env *testenv.TestEnv) {
+				env.Symlink("/nonexistent", linkPath)
+			},
+			verify: func(t *testing.T, env *testenv.TestEnv) {
+				assertSymlinkTo(t, env, linkPath, target)
+				assertNotExist(t, env, backupPath)
+			},
+		},
+		"regular file": {
+			template: template,
+			setup: func(env *testenv.TestEnv) {
+				env.WriteFile(linkPath, "precious content")
+			},
+			verify: func(t *testing.T, env *testenv.TestEnv) {
+				assertSymlinkTo(t, env, linkPath, target)
+				assert.Equal(t, "precious content", env.ReadFile(backupPath))
+			},
+		},
+		"regular file with an existing backup": {
+			// The first backup is the pristine one, so it is kept and the
+			// current file is discarded, as CarefulWriteBuffer does.
+			template: template,
+			setup: func(env *testenv.TestEnv) {
+				env.WriteFile(linkPath, "second run")
+				env.WriteFile(backupPath, "first run")
+			},
+			verify: func(t *testing.T, env *testenv.TestEnv) {
+				assertSymlinkTo(t, env, linkPath, target)
+				assert.Equal(t, "first run", env.ReadFile(backupPath))
+			},
+		},
+		"regular file with nobackup": {
+			template: `{{- nobackup -}}{{- softlink "/link-target" -}}`,
+			setup: func(env *testenv.TestEnv) {
+				env.WriteFile(linkPath, "precious content")
+			},
+			verify: func(t *testing.T, env *testenv.TestEnv) {
+				assertSymlinkTo(t, env, linkPath, target)
+				assertNotExist(t, env, backupPath)
+			},
+		},
+		"directory": {
+			template: template,
+			setup: func(env *testenv.TestEnv) {
+				env.WriteFile(path.Join(linkPath, "keep.txt"), "kept")
+			},
+			expectErr: "refusing to replace directory",
+			verify: func(t *testing.T, env *testenv.TestEnv) {
+				assert.Equal(t, "kept", env.ReadFile(path.Join(linkPath, "keep.txt")))
+			},
+		},
+		"empty directory": {
+			// An empty directory is removable, so it must be rejected
+			// explicitly rather than by relying on os.Remove to fail.
+			template: template,
+			setup: func(env *testenv.TestEnv) {
+				env.MkdirAll(linkPath)
+			},
+			expectErr: "refusing to replace directory",
+			verify: func(t *testing.T, env *testenv.TestEnv) {
+				assert.True(t, util.IsDir(env.GetPath(linkPath)))
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			env := testenv.New(t)
+			defer env.RemoveAll()
+			env.WriteFile("/var/lib/warewulf/overlays/o1/rootfs/test-link.ww", tt.template)
+			env.MkdirAll("/image")
+			if tt.setup != nil {
+				tt.setup(env)
+			}
+
+			err := BuildOverlayIndir(node.Node{}, []node.Node{}, []string{"o1"}, env.GetPath("/image"))
+			if tt.expectErr != "" {
+				assert.ErrorContains(t, err, tt.expectErr)
+			} else {
+				assert.NoError(t, err)
+			}
+			tt.verify(t, env)
+		})
+	}
+}
+
+func assertSymlinkTo(t *testing.T, env *testenv.TestEnv, fileName string, expected string) {
+	t.Helper()
+	target, err := os.Readlink(env.GetPath(fileName))
+	if assert.NoError(t, err, "%s is not a symlink", fileName) {
+		assert.Equal(t, expected, target)
+	}
+}
+
+func assertNotExist(t *testing.T, env *testenv.TestEnv, fileName string) {
+	t.Helper()
+	_, err := os.Lstat(env.GetPath(fileName))
+	assert.True(t, os.IsNotExist(err), "%s exists, but should not", fileName)
+}
+
 func Test_BuildOverlay(t *testing.T) {
 	tests := []struct {
 		description string


### PR DESCRIPTION
## Description of the Pull Request (PR):

When using `{{ softlink }}` and `{{ file }}` to make symlinks based on node tags,
I noticed that if the target path for the symlink already existed, such as the symlink
already being created the last time the overlay was built, the new link would fail to
be created, thus making the entire overlay fail to build.

This PR adds a check in `BuildOverlayIndir` which, when a template outputs a
symlink, it will check if the target path already exists, and if it does then it will
be unlinked/removed before making the new symlink.

## This fixes or addresses the following GitHub issues:

*none*

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [x] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [x] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [x] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [x] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
  - My other PR #2247 has my name added to the contributors file, I did not add it in this PR as well
- [ ] The test suite has been updated, if necessary
