### PR TITLE
Allow version strings to capture more information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add an `ipv6_method` node tag to set the NetworkManager `[ipv6]` method, e.g.
   `auto` for SLAAC.
 - Don't silence curl when downloading with dracut. #2200
+- Extend kernel version string matching. #2267
 
 ### Fixed
 

--- a/internal/app/wwctl/image/kernels/main_test.go
+++ b/internal/app/wwctl/image/kernels/main_test.go
@@ -42,16 +42,16 @@ Image  Kernel  Version  Default  Nodes
 			},
 			args: []string{},
 			stdout: `
-Image   Kernel                                                   Version          Default  Nodes
------   ------                                                   -------          -------  -----
-image1  /boot/vmlinuz-4.14.0-427.18.1.el8_4.x86_64               4.14.0-427.18.1  false    0
-image1  /boot/vmlinuz-5.14.0-427.18.1.el9_4.x86_64               5.14.0-427.18.1  false    0
-image1  /boot/vmlinuz-5.14.0-427.24.1.el9_4.x86_64               5.14.0-427.24.1  true     0
-image2  /boot/vmlinuz-0-rescue-eb46964329b146e39518c625feab3ea0  --               false    0
-image2  /boot/vmlinuz-5.14.0-284.30.1.el9_2.aarch64              5.14.0-284.30.1  false    0
-image2  /boot/vmlinuz-5.14.0-362.24.1.el9_3.aarch64              5.14.0-362.24.1  false    0
-image2  /boot/vmlinuz-5.14.0-427.31.1.el9_4.aarch64              5.14.0-427.31.1  true     0
-image2  /boot/vmlinuz-5.14.0-427.31.1.el9_4.aarch64+debug        5.14.0-427.31.1  false    0
+Image   Kernel                                                   Version                              Default  Nodes
+-----   ------                                                   -------                              -------  -----
+image1  /boot/vmlinuz-4.14.0-427.18.1.el8_4.x86_64               4.14.0-427.18.1.el8-4.x86-64         false    0
+image1  /boot/vmlinuz-5.14.0-427.18.1.el9_4.x86_64               5.14.0-427.18.1.el9-4.x86-64         false    0
+image1  /boot/vmlinuz-5.14.0-427.24.1.el9_4.x86_64               5.14.0-427.24.1.el9-4.x86-64         true     0
+image2  /boot/vmlinuz-0-rescue-eb46964329b146e39518c625feab3ea0  --                                   false    0
+image2  /boot/vmlinuz-5.14.0-284.30.1.el9_2.aarch64              5.14.0-284.30.1.el9-2.aarch64        false    0
+image2  /boot/vmlinuz-5.14.0-362.24.1.el9_3.aarch64              5.14.0-362.24.1.el9-3.aarch64        false    0
+image2  /boot/vmlinuz-5.14.0-427.31.1.el9_4.aarch64              5.14.0-427.31.1.el9-4.aarch64        true     0
+image2  /boot/vmlinuz-5.14.0-427.31.1.el9_4.aarch64+debug        5.14.0-427.31.1.el9-4.aarch64+debug  false    0
 `,
 		},
 		"single image": {
@@ -71,13 +71,13 @@ image2  /boot/vmlinuz-5.14.0-427.31.1.el9_4.aarch64+debug        5.14.0-427.31.1
 			},
 			args: []string{"image2"},
 			stdout: `
-Image   Kernel                                                   Version          Default  Nodes
------   ------                                                   -------          -------  -----
-image2  /boot/vmlinuz-0-rescue-eb46964329b146e39518c625feab3ea0  --               false    0
-image2  /boot/vmlinuz-5.14.0-284.30.1.el9_2.aarch64              5.14.0-284.30.1  false    0
-image2  /boot/vmlinuz-5.14.0-362.24.1.el9_3.aarch64              5.14.0-362.24.1  false    0
-image2  /boot/vmlinuz-5.14.0-427.31.1.el9_4.aarch64              5.14.0-427.31.1  true     0
-image2  /boot/vmlinuz-5.14.0-427.31.1.el9_4.aarch64+debug        5.14.0-427.31.1  false    0
+Image   Kernel                                                   Version                              Default  Nodes
+-----   ------                                                   -------                              -------  -----
+image2  /boot/vmlinuz-0-rescue-eb46964329b146e39518c625feab3ea0  --                                   false    0
+image2  /boot/vmlinuz-5.14.0-284.30.1.el9_2.aarch64              5.14.0-284.30.1.el9-2.aarch64        false    0
+image2  /boot/vmlinuz-5.14.0-362.24.1.el9_3.aarch64              5.14.0-362.24.1.el9-3.aarch64        false    0
+image2  /boot/vmlinuz-5.14.0-427.31.1.el9_4.aarch64              5.14.0-427.31.1.el9-4.aarch64        true     0
+image2  /boot/vmlinuz-5.14.0-427.31.1.el9_4.aarch64+debug        5.14.0-427.31.1.el9-4.aarch64+debug  false    0
 `,
 		},
 	}

--- a/internal/pkg/image/initramfs.go
+++ b/internal/pkg/image/initramfs.go
@@ -4,8 +4,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 	"github.com/warewulf/warewulf/internal/pkg/util"
+	"github.com/warewulf/warewulf/internal/pkg/wwlog"
 )
 
 var (
@@ -14,9 +14,7 @@ var (
 		"/boot/initrd-*",
 		"/boot/initrd.img-*",
 	}
-
 )
-
 
 type Initramfs struct {
 	Path      string

--- a/internal/pkg/image/initramfs.go
+++ b/internal/pkg/image/initramfs.go
@@ -2,12 +2,10 @@ package image
 
 import (
 	"path/filepath"
-	"regexp"
 	"strings"
 
-	"github.com/hashicorp/go-version"
-
 	"github.com/warewulf/warewulf/internal/pkg/wwlog"
+	"github.com/warewulf/warewulf/internal/pkg/util"
 )
 
 var (
@@ -17,30 +15,16 @@ var (
 		"/boot/initrd.img-*",
 	}
 
-	versionPattern *regexp.Regexp
 )
 
-func init() {
-	versionPattern = regexp.MustCompile(`\d+\.\d+\.\d+(-[\d\.]+|)`)
-}
 
 type Initramfs struct {
 	Path      string
 	imageName string
 }
 
-func (initrd *Initramfs) version() *version.Version {
-	matches := versionPattern.FindAllString(initrd.Path, -1)
-	for i := len(matches) - 1; i >= 0; i-- {
-		if version_, err := version.NewVersion(strings.TrimSuffix(matches[i], ".")); err == nil {
-			return version_
-		}
-	}
-	return nil
-}
-
 func (initrd *Initramfs) Version() string {
-	version := initrd.version()
+	version := util.ParseVersion(initrd.Path)
 	if version == nil {
 		return ""
 	} else {

--- a/internal/pkg/kernel/kernel_test.go
+++ b/internal/pkg/kernel/kernel_test.go
@@ -22,7 +22,7 @@ func Test_FindKernel(t *testing.T) {
 				"/boot/vmlinuz-5.14.0-427.24.1.el9_4.x86_64",
 				"/boot/vmlinuz-4.14.0-427.18.1.el8_4.x86_64",
 			},
-			version: "5.14.0-427.24.1",
+			version: "5.14.0-427.24.1.el9-4.x86-64",
 			path:    "/boot/vmlinuz-5.14.0-427.24.1.el9_4.x86_64",
 		},
 		"/boot/vmlinuz-* (2)": {
@@ -31,7 +31,7 @@ func Test_FindKernel(t *testing.T) {
 				"/boot/vmlinuz-5.14.0-427.24.1.el9_4.x86_64",
 				"/boot/vmlinuz-6.15.0-119-generic",
 			},
-			version: "6.15.0-119",
+			version: "6.15.0-119-generic",
 			path:    "/boot/vmlinuz-6.15.0-119-generic",
 		},
 		"/boot/vmlinuz-* (3)": {
@@ -39,7 +39,7 @@ func Test_FindKernel(t *testing.T) {
 				"/boot/vmlinuz-5.15.0-0-vanilla",
 				"/boot/vmlinuz-5.14.0-427.24.1.el9_4.x86_64",
 			},
-			version: "5.15.0-0",
+			version: "5.15.0-0-vanilla",
 			path:    "/boot/vmlinuz-5.15.0-0-vanilla",
 		},
 		"/boot/vmlinuz-* (4)": {
@@ -48,7 +48,7 @@ func Test_FindKernel(t *testing.T) {
 				"/boot/vmlinuz-5.14.0-427.24.1.el9_4.x86_64",
 				"/boot/vmlinuz-5.13.0-427.24.1.el9_4.x86_64",
 			},
-			version: "5.15.0",
+			version: "5.15.0-generic",
 			path:    "/boot/vmlinuz-5.15.0-generic",
 		},
 		"/lib/modules/*/vmlinuz": {
@@ -56,7 +56,7 @@ func Test_FindKernel(t *testing.T) {
 				"/lib/modules/5.14.0-427.18.1.el9_4.x86_64/vmlinuz",
 				"/lib/modules/5.14.0-427.24.1.el9_4.x86_64/vmlinuz",
 			},
-			version: "5.14.0-427.24.1",
+			version: "5.14.0-427.24.1.el9-4.x86-64",
 			path:    "/lib/modules/5.14.0-427.24.1.el9_4.x86_64/vmlinuz",
 		},
 		"/boot/vmlinuz-*.gz": {
@@ -64,7 +64,7 @@ func Test_FindKernel(t *testing.T) {
 				"/boot/vmlinuz-5.14.0-427.18.1.el9_4.x86_64.gz",
 				"/boot/vmlinuz-5.14.0-427.24.1.el9_4.x86_64.gz",
 			},
-			version: "5.14.0-427.24.1",
+			version: "5.14.0-427.24.1.el9-4.x86-64",
 			path:    "/boot/vmlinuz-5.14.0-427.24.1.el9_4.x86_64.gz",
 		},
 		"ignore rescue and debug kernels": {
@@ -75,7 +75,7 @@ func Test_FindKernel(t *testing.T) {
 				"/boot/vmlinuz-5.14.0-284.30.1.el9_2.aarch64",
 				"/boot/vmlinuz-5.14.0-427.31.1.el9_4.aarch64",
 			},
-			version: "5.14.0-427.31.1",
+			version: "5.14.0-427.31.1.el9-4.aarch64",
 			path:    "/boot/vmlinuz-5.14.0-427.31.1.el9_4.aarch64",
 		},
 		"no kernels": {
@@ -139,7 +139,7 @@ func Test_FromNode(t *testing.T) {
 				"/boot/vmlinuz-5.14.0-427.24.1.el9_4.x86_64",
 				"/boot/vmlinuz-4.14.0-427.18.1.el8_4.x86_64",
 			},
-			version: "4.14.0-427.18.1",
+			version: "4.14.0-427.18.1.el8-4.x86-64",
 			path:    "/boot/vmlinuz-4.14.0-427.18.1.el8_4.x86_64",
 		},
 		"none": {

--- a/internal/pkg/util/version.go
+++ b/internal/pkg/util/version.go
@@ -9,16 +9,19 @@ import (
 
 var (
 	versionPattern *regexp.Regexp
+	imageSuffixPattern *regexp.Regexp
 )
 
 func init() {
-	versionPattern = regexp.MustCompile(`\d+\.\d+\.\d+(-[\d\.]+|)`)
+	versionPattern = regexp.MustCompile(`\d+\.\d+\.\d+(-[\w+\.-]+)?`)
+	imageSuffixPattern = regexp.MustCompile(`\.gz|\.bz2|\.xz|\.lz4|\.zst|\.lzma|\.lzo`)
 }
 
 func ParseVersion(versionString string) *version.Version {
 	matches := versionPattern.FindAllString(versionString, -1)
 	for _, match := range matches {
-		if version_, err := version.NewVersion(strings.TrimSuffix(match, ".")); err == nil {
+		match = imageSuffixPattern.ReplaceAllString(match, "")
+		if version_, err := version.NewVersion(strings.ReplaceAll(strings.TrimSuffix(match, "."), "_", "-")); err == nil {
 			return version_
 		}
 	}

--- a/internal/pkg/util/version.go
+++ b/internal/pkg/util/version.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	versionPattern *regexp.Regexp
+	versionPattern     *regexp.Regexp
 	imageSuffixPattern *regexp.Regexp
 )
 

--- a/internal/pkg/util/version_test.go
+++ b/internal/pkg/util/version_test.go
@@ -7,14 +7,14 @@ func TestParseVersion(t *testing.T) {
 		path     string
 		expected string
 	}{
-		"el9_4 module path":             {"/lib/modules/5.14.0-427.37.1.el9_4.aarch64/vmlinuz", "5.14.0-427.37.1"},
-		"el8_6 boot path":               {"/boot/vmlinuz-4.18.0-372.13.1.el8_6.x86_64", "4.18.0-372.13.1"},
-		"el10_2 with suffix after dist": {"/lib/modules/6.12.0-211.16.1.el10_2.0.1.x86_64/vmlinuz", "6.12.0-211.16.1"},
-		"el9_8 with suffix after dist":  {"/lib/modules/5.14.0-687.10.1.el9_8.0.1.x86_64/vmlinuz", "5.14.0-687.10.1"},
-		"el9_8 plain dist tag":          {"/lib/modules/5.14.0-687.10.1.el9_8.x86_64/vmlinuz", "5.14.0-687.10.1"},
-		"el9_7 respin suffix (#2199)":   {"/boot/vmlinuz-5.14.0-611.55.1.el9_7.0.3.x86_64", "5.14.0-611.55.1"},
-		"boot path with .gz":            {"/boot/vmlinuz-5.14.0-427.24.1.el9_4.x86_64.gz", "5.14.0-427.24.1"},
-		"leap16":                        {"/lib/modules/6.12.0-160000.33-default/vmlinuz", "6.12.0-160000.33"},
+		"el9_4 module path":             {"/lib/modules/5.14.0-427.37.1.el9_4.aarch64/vmlinuz", "5.14.0-427.37.1.el9-4.aarch64"},
+		"el8_6 boot path":               {"/boot/vmlinuz-4.18.0-372.13.1.el8_6.x86_64", "4.18.0-372.13.1.el8-6.x86-64"},
+		"el10_2 with suffix after dist": {"/lib/modules/6.12.0-211.16.1.el10_2.0.1.x86_64/vmlinuz", "6.12.0-211.16.1.el10-2.0.1.x86-64"},
+		"el9_8 with suffix after dist":  {"/lib/modules/5.14.0-687.10.1.el9_8.0.1.x86_64/vmlinuz", "5.14.0-687.10.1.el9-8.0.1.x86-64"},
+		"el9_8 plain dist tag":          {"/lib/modules/5.14.0-687.10.1.el9_8.x86_64/vmlinuz", "5.14.0-687.10.1.el9-8.x86-64"},
+		"el9_7 respin suffix (#2199)":   {"/boot/vmlinuz-5.14.0-611.55.1.el9_7.0.3.x86_64", "5.14.0-611.55.1.el9-7.0.3.x86-64"},
+		"boot path with .gz":            {"/boot/vmlinuz-5.14.0-427.24.1.el9_4.x86_64.gz", "5.14.0-427.24.1.el9-4.x86-64"},
+		"leap16":                        {"/lib/modules/6.12.0-160000.33-default/vmlinuz", "6.12.0-160000.33-default"},
 		"no version in path":            {"/boot/vmlinuz-linux", ""},
 	}
 	for name, tt := range tests {


### PR DESCRIPTION
## Description of the Pull Request (PR):

We're running some kernels now where the version string of two installed kernels would be identical to each other with how warewulf currently parses versions. This lead to me being slightly confused as to why the older kernel was being chosen as the default kernel for an image instead of the newer one. The differentiating detail is further down the kernel version string (eg past the el9_6 in the string). This is a quick first pass at attempting to allow warewulf to understand more of the kernel version string as the version.

Since we're using go-version to do some version validation this currently replaces `_` with `-` since the former is not valid in semver.

This also updates tests that were broken by this change to expect the now potentially expanded results.

We don't have to do this if there's strong objections. It's easy enough to work around by removing the older kernel when updating an image so the only kernel in the image is the one that should be booted.

## Reviewer  checklist

The reviewer checks the following items before merging the PR.

- [ ] The PR is based on the appropriate branch (typically [main](https://github.com/warewulf/warewulf/tree/main/userdocs))
- [ ] All commits are "Signed off" (e.g., using `git commit --signoff`) in agreement to the [DCO](DCO.txt)
- [ ] The [CHANGELOG](https://github.com/warewulf/warewulf/blob/main/CHANGELOG.md) has been updated, if necessary, and under the correct release heading
- [ ] The [userdocs](https://github.com/warewulf/warewulf/tree/main/userdocs) have been updated, if necessary
- [ ] The submitter is listed in the [contributors file](https://github.com/warewulf/warewulf/blob/main/CONTRIBUTORS.md)
- [ x] The test suite has been updated, if necessary
